### PR TITLE
fix keyword arguments for `tf.cond`

### DIFF
--- a/keras_core/backend/jax/__init__.py
+++ b/keras_core/backend/jax/__init__.py
@@ -42,8 +42,8 @@ def cast(x, dtype):
     return convert_to_tensor(x, dtype=dtype)
 
 
-def cond(pred, true_fun, false_fun):
-    return jax.lax.cond(pred, true_fn=true_fun, false_fun=false_fun)
+def cond(pred, true_fn, false_fn):
+    return jax.lax.cond(pred, true_fn=true_fn, false_fun=false_fn)
 
 
 def name_scope(name):

--- a/keras_core/backend/tensorflow/__init__.py
+++ b/keras_core/backend/tensorflow/__init__.py
@@ -232,8 +232,8 @@ def cast(x, dtype):
     return tf.cast(x, dtype=dtype)
 
 
-def cond(pred, true_fun, false_fun):
-    return tf.cond(pred, true_fn=true_fun, false_fn=false_fun)
+def cond(pred, true_fn, false_fn):
+    return tf.cond(pred, true_fn=true_fn, false_fn=false_fn)
 
 
 def name_scope(name):


### PR DESCRIPTION
@fchollet should we also standardize the `cond` function for both `TF` and `JAX`. JAX accepts `operands` along with condition, true_fun, and false_fun. Should we do this instead?

```ptyhon
def cond(pred, true_fun, false_fn, operands):
      ...

```