### PR TITLE
Fix Test breakage on with context for dropout

### DIFF
--- a/keras_core/backend/tensorflow/random.py
+++ b/keras_core/backend/tensorflow/random.py
@@ -106,10 +106,9 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
 
 def dropout(inputs, rate, noise_shape=None, seed=None):
     seed = tf_draw_seed(seed)
-    with tf.init_scope():
-        return tf.nn.experimental.stateless_dropout(
-            inputs,
-            rate=rate,
-            noise_shape=noise_shape,
-            seed=seed,
-        )
+    return tf.nn.experimental.stateless_dropout(
+        inputs,
+        rate=rate,
+        noise_shape=noise_shape,
+        seed=seed,
+    )


### PR DESCRIPTION
Fixes Test breakage from f75aadf2

Test failure at head when running `pytest` -
```
keras_core/operations/operation.py:51: in compute_output_spec
    return backend.compute_output_spec(self.call, *args, **kwargs)
keras_core/backend/tensorflow/__init__.py:260: in compute_output_spec
    tf_out = fn(*args, **kwargs)
jax_integration_test.py:35: in call
    return backend.random.dropout(
keras_core/backend/tensorflow/random.py:110: in dropout
    return tf.nn.experimental.stateless_dropout(
/opt/miniconda3/envs/kerasx/lib/python3.9/site-packages/tensorflow/python/util/traceback_utils.py:153: in error_handler
    raise e.with_traceback(filtered_tb) from None
/opt/miniconda3/envs/kerasx/lib/python3.9/site-packages/tensorflow/python/eager/execute.py:52: in quick_execute
    tensors = pywrap_tfe.TFE_Py_Execute(ctx._handle, device_name, op_name,
E   TypeError: <tf.Tensor 'Placeholder:0' shape=(3, 5) dtype=float32> is out of scope and cannot be used here. Use return values, explicit Python locals or TensorFlow collections to access it.
```