### PR TITLE
Fix format line length that fails `shell/format.sh`

### DIFF
--- a/keras_core/initializers/random_initializers.py
+++ b/keras_core/initializers/random_initializers.py
@@ -22,10 +22,10 @@ class RandomNormal(Initializer):
     >>> layer = Dense(3, kernel_initializer=initializer)
 
     Args:
-        mean: A python scalar or a scalar keras tensor. Mean of the random values to
-            generate.
-        stddev: A python scalar or a scalar keras tensor. Standard deviation of the
-           random values to generate.
+        mean: A python scalar or a scalar keras tensor. Mean of the random
+            values to generate.
+        stddev: A python scalar or a scalar keras tensor. Standard deviation of
+           the random values to generate.
         seed: A Python integer or instance of
             `keras_core.backend.SeedGenerator`.
             Used to make the behavior of the initializer
@@ -75,10 +75,10 @@ class TruncatedNormal(Initializer):
     >>> layer = Dense(3, kernel_initializer=initializer)
 
     Args:
-        mean: A python scalar or a scalar keras tensor. Mean of the random values to
-            generate.
-        stddev: A python scalar or a scalar keras tensor. Standard deviation of the
-           random values to generate.
+        mean: A python scalar or a scalar keras tensor. Mean of the random
+            values to generate.
+        stddev: A python scalar or a scalar keras tensor. Standard deviation of
+           the random values to generate.
         seed: A Python integer or instance of
             `keras_core.backend.SeedGenerator`.
             Used to make the behavior of the initializer
@@ -125,10 +125,10 @@ class RandomUniform(Initializer):
     >>> layer = Dense(3, kernel_initializer=initializer)
 
     Args:
-        minval: A python scalar or a scalar keras tensor. Lower bound of the range of
-            random values to generate (inclusive).
-        maxval: A python scalar or a scalar keras tensor. Upper bound of the range of
-            random values to generate (exclusive).
+        minval: A python scalar or a scalar keras tensor. Lower bound of the
+            range of random values to generate (inclusive).
+        maxval: A python scalar or a scalar keras tensor. Upper bound of the
+            range of random values to generate (exclusive).
         seed: A Python integer or instance of
             `keras_core.backend.SeedGenerator`.
             Used to make the behavior of the initializer
@@ -177,11 +177,13 @@ class VarianceScaling(Initializer):
     Examples:
 
     >>> # Standalone usage:
-    >>> initializer = VarianceScaling(scale=0.1, mode='fan_in', distribution='uniform')
+    >>> initializer = VarianceScaling(
+        scale=0.1, mode='fan_in', distribution='uniform')
     >>> values = initializer(shape=(2, 2))
 
     >>> # Usage in a Keras layer:
-    >>> initializer = VarianceScaling(scale=0.1, mode='fan_in', distribution='uniform')
+    >>> initializer = VarianceScaling(
+        scale=0.1, mode='fan_in', distribution='uniform')
     >>> layer = Dense(3, kernel_initializer=initializer)
 
     Args:
@@ -241,9 +243,9 @@ class VarianceScaling(Initializer):
         Args:
             shape: Shape of the tensor.
             dtype: Optional dtype of the tensor. Only floating point types are
-                supported. If not specified, `tf.keras.backend.floatx()` is used,
-                which default to `float32` unless you configured it otherwise (via
-                `tf.keras.backend.set_floatx(float_dtype)`)
+                supported. If not specified, `tf.keras.backend.floatx()` is
+                used, which default to `float32` unless you configured it
+                otherwise (via `tf.keras.backend.set_floatx(float_dtype)`)
         """
         scale = self.scale
         fan_in, fan_out = compute_fans(shape)

--- a/keras_core/layers/layer.py
+++ b/keras_core/layers/layer.py
@@ -36,7 +36,8 @@ from keras_core.operations.operation import Operation
 from keras_core.utils import summary_utils
 from keras_core.utils.tracking import Tracker
 
-# TODO: cache all call signature processing. See layer_utils.CallFunctionSpec() in Keras.
+# TODO: cache all call signature processing.
+# See layer_utils.CallFunctionSpec() in Keras.
 
 
 @keras_core_export(["keras_core.Layer", "keras_core.layers.Layer"])
@@ -240,8 +241,8 @@ class Layer(Operation):
         if len(layer_weights) != len(weights):
             raise ValueError(
                 f"You called `set_weights(weights)` on layer '{self.name}' "
-                f"with a weight list of length {len(weights)}, but the layer was "
-                f"expecting {len(layer_weights)} weights."
+                f"with a weight list of length {len(weights)}, but the layer "
+                f"was expecting {len(layer_weights)} weights."
             )
         for variable, value in zip(layer_weights, weights):
             if variable.shape != value.shape:
@@ -320,9 +321,9 @@ class Layer(Operation):
 
         # Infer training value
         # Training phase for `Layer.call` is set via (in order of priority):
-        # (1) The `training` argument passed to this `Layer.call`, if it is not None
+        # (1) The `training` argument passed to this `Layer.call`, if not None
         # (2) The training argument of an outer `Layer.call`.
-        # (4) Any non-None default value for `training` specified in the call signature
+        # (4) Any non-None default value for `training` in the call signature
         # (5) False (treating the layer as if it's in inference)
         arguments_dict = get_arguments_dict(self.call, *args, **kwargs)
         training = arguments_dict.get("training", None)
@@ -366,23 +367,25 @@ class Layer(Operation):
 
         if not self.built:
             raise ValueError(
-                "To call stateless_call, {self.__class__.__name__} must be built "
-                "(i.e. its variables must have been already created). "
+                "To call stateless_call, {self.__class__.__name__} must be "
+                "built (i.e. its variables must have been already created). "
                 "You can build it by calling it on some data."
             )
         if len(trainable_variables) != len(self.trainable_variables):
             raise ValueError(
                 "Argument `trainable_variables` must be a list of tensors "
-                f"corresponding 1:1 to {self.__class__.__name__}().trainable_variables. "
-                f"Received list with length {len(trainable_variables)}, but expected "
-                f"{len(self.trainable_variables)} variables."
+                "corresponding 1:1 to "
+                f"{self.__class__.__name__}().trainable_variables. "
+                f"Received list with length {len(trainable_variables)}, "
+                f"but expected {len(self.trainable_variables)} variables."
             )
         if len(non_trainable_variables) != len(self.non_trainable_variables):
             raise ValueError(
                 "Argument `non_trainable_variables` must be a list of tensors "
-                f"corresponding 1:1 to {self.__class__.__name__}().non_trainable_variables. "
-                f"Received list with length {len(non_trainable_variables)}, but expected "
-                f"{len(self.non_trainable_variables)} variables."
+                "corresponding 1:1 to "
+                f"{self.__class__.__name__}().non_trainable_variables. "
+                f"Received list with length {len(non_trainable_variables)}, "
+                f"but expected {len(self.non_trainable_variables)} variables."
             )
 
         # Gather variable mapping
@@ -440,8 +443,8 @@ class Layer(Operation):
         for x in losses:
             if not backend.is_tensor(x):
                 raise ValueError(
-                    "`add_loss()` can only be called from inside `build()` or `call()`, "
-                    f"on a tensor input. Received invalid value: {x}"
+                    "`add_loss()` can only be called from inside `build()` or "
+                    f"`call()`, on a tensor input. Received invalid value: {x}"
                 )
         if backend.in_stateless_scope():
             scope = backend.get_stateless_scope()
@@ -760,7 +763,8 @@ def get_shapes_dict(arguments_dict):
     Example:
 
     ```
-    >>> get_shapes_dict({"input_a": KerasTensor(shape=(2, 3)), "training": False})
+    >>> get_shapes_dict(
+        {"input_a": KerasTensor(shape=(2, 3)), "training": False})
     {"input_a_shape": (2, 3)}
     ```
     """
@@ -778,8 +782,8 @@ def get_shapes_dict(arguments_dict):
                     for x in flat
                 ):
                     raise ValueError(
-                        "You cannot mix tensors and non-tensors in a nested argument. "
-                        f"Invalid argument: {k}={v}"
+                        "You cannot mix tensors and non-tensors in a nested "
+                        f"argument. Invalid argument: {k}={v}"
                     )
             shapes_dict[f"{k}_shape"] = nest.map_structure(
                 lambda x: backend.standardize_shape(x.shape), v
@@ -788,7 +792,7 @@ def get_shapes_dict(arguments_dict):
 
 
 def check_build_signature(build_fn, shapes_dict):
-    """Asserts that the argument names in build_fn match the entries in shapes_dict.
+    """Asserts that the argument names in build_fn match entries in shapes_dict.
 
     For instance if call() has the signature `def call(self, a, b)`
     then we'll see `shapes_dict == {"a_shape": (...), "b_shape": (...)}

--- a/keras_core/models/functional.py
+++ b/keras_core/models/functional.py
@@ -34,49 +34,55 @@ class Functional(Function, Model):
             for k, v in inputs.items():
                 if not isinstance(v, backend.KerasTensor):
                     raise ValueError(
-                        "When providing `inputs` as a dict, all values in the dict "
-                        f"must be KerasTensors. Received: inputs={inputs} including "
-                        f"invalid value {v} of type {type(v)}"
+                        "When providing `inputs` as a dict, all values in the "
+                        f"dict must be KerasTensors. Received: inputs={inputs} "
+                        f"including invalid value {v} of type {type(v)}"
                     )
                 if k != v.name:
                     # TODO: maybe make this a warning
                     raise ValueError(
-                        "When providing `inputs` as a dict, all keys in the dict "
-                        "must match the names of the corresponding tensors. "
-                        f"Received key '{k}' mapping to value {v} which has name '{v.name}'. "
-                        f"Change the tensor name to '{k}' (via `Input(..., name='{k}')`)"
+                        "When providing `inputs` as a dict, all keys in the "
+                        "dict must match the names of the corresponding "
+                        f"tensors. Received key '{k}' mapping to value {v} "
+                        f"which has name '{v.name}'. Change the tensor name to "
+                        f"'{k}' (via `Input(..., name='{k}')`)"
                     )
         elif isinstance(inputs, (list, tuple)):
             for x in inputs:
                 if not isinstance(x, backend.KerasTensor):
                     raise ValueError(
-                        "When providing `inputs` as a list/tuple, all values in the list/tuple "
-                        f"must be KerasTensors. Received: inputs={inputs} including "
-                        f"invalid value {x} of type {type(x)}"
+                        "When providing `inputs` as a list/tuple, all values "
+                        f"in the list/tuple must be KerasTensors. Received: "
+                        f"inputs={inputs} including invalid value {x} of type "
+                        f"{type(x)}"
                     )
         elif not isinstance(inputs, backend.KerasTensor):
             raise ValueError(
-                f"Unrecognized type for `inputs`: {inputs} (of type {type(inputs)})"
+                f"Unrecognized type for `inputs`: {inputs} "
+                f"(of type {type(inputs)})"
             )
         if isinstance(outputs, dict):
             for k, v in outputs.items():
                 if not isinstance(v, backend.KerasTensor):
                     raise ValueError(
-                        "When providing `outputs` as a dict, all values in the dict "
-                        f"must be KerasTensors. Received: outputs={outputs} including "
-                        f"invalid value {v} of type {type(v)}"
+                        "When providing `outputs` as a dict, all values in the "
+                        f"dict must be KerasTensors. Received: "
+                        f"outputs={outputs} including invalid value {v} of "
+                        f"type {type(v)}"
                     )
         elif isinstance(outputs, (list, tuple)):
             for x in outputs:
                 if not isinstance(x, backend.KerasTensor):
                     raise ValueError(
-                        "When providing `outputs` as a list/tuple, all values in the list/tuple "
-                        f"must be KerasTensors. Received: outputs={outputs} including "
-                        f"invalid value {x} of type {type(x)}"
+                        "When providing `outputs` as a list/tuple, all values "
+                        f"in the list/tuple must be KerasTensors. Received: "
+                        f"outputs={outputs} including invalid value {x} of "
+                        f"type {type(x)}"
                     )
         elif not isinstance(outputs, backend.KerasTensor):
             raise ValueError(
-                f"Unrecognized type for `outputs`: {outputs} (of type {type(outputs)})"
+                f"Unrecognized type for `outputs`: {outputs} "
+                f"(of type {type(outputs)})"
             )
 
         Function.__init__(self, inputs, outputs, name=name, **kwargs)
@@ -498,7 +504,8 @@ def deserialize_node(node_data, created_layers):
                 raise IndexError(
                     "Layer node index out of bounds.\n"
                     f"inbound_layer = {inbound_layer}\n"
-                    f"inbound_layer._inbound_nodes = {inbound_layer._inbound_nodes}\n"
+                    "inbound_layer._inbound_nodes = "
+                    f"{inbound_layer._inbound_nodes}\n"
                     f"inbound_node_index = {inbound_node_index}"
                 )
             inbound_node = inbound_layer._inbound_nodes[inbound_node_index]

--- a/keras_core/models/sequential.py
+++ b/keras_core/models/sequential.py
@@ -42,9 +42,9 @@ class Sequential(Model):
             and isinstance(self._layers[0], InputLayer)
         ):
             raise ValueError(
-                f"Sequential model '{self.name}' has already been configured to "
-                f"use input shape {self._layers[0].batch_shape}. You cannot add "
-                f"a different Input layer to it."
+                f"Sequential model '{self.name}' has already been configured "
+                f"to use input shape {self._layers[0].batch_shape}. You cannot "
+                f"add a different Input layer to it."
             )
 
         self._layers.append(layer)
@@ -73,23 +73,26 @@ class Sequential(Model):
 
     def build(self, input_shape=None):
         if not isinstance(input_shape, (tuple, list)):
-            # Do not attempt to build if the model does not have a single input tensor.
+            # Do not attempt to build if the model does not have a single
+            # input tensor.
             return
         if input_shape and not (
             isinstance(input_shape[0], int) or input_shape[0] is None
         ):
-            # Do not attempt to build if the model does not have a single input tensor.
+            # Do not attempt to build if the model does not have a single
+            # input tensor.
             return
         if not self._layers:
             raise ValueError(
-                f"Sequential model {self.name} cannot be built because it has no layers. "
-                "Call `model.add(layer)`."
+                f"Sequential model {self.name} cannot be built because it has "
+                "no layers. Call `model.add(layer)`."
             )
         if isinstance(self._layers[0], InputLayer):
             if self._layers[0].batch_shape != input_shape:
                 raise ValueError(
-                    f"Sequential model '{self.name}' has already been configured to "
-                    f"use input shape {self._layers[0].batch_shape}. You cannot build it "
+                    f"Sequential model '{self.name}' has already been "
+                    "configured to use input shape "
+                    f"{self._layers[0].batch_shape}. You cannot build it "
                     f"with input_shape {input_shape}"
                 )
         else:
@@ -103,7 +106,7 @@ class Sequential(Model):
                 x = layer(x)
             except NotImplementedError:
                 # Can happen if shape inference is not implemented.
-                # TODO: consider reverting inbound nodes on layers processed so far.
+                # TODO: consider reverting inbound nodes on layers processed.
                 return
         outputs = x
         self._functional = Functional(inputs=inputs, outputs=outputs)

--- a/keras_core/operations/function.py
+++ b/keras_core/operations/function.py
@@ -124,17 +124,19 @@ class Function(Operation):
         for x, x_ref in zip(nest.flatten(inputs), self._inputs):
             if len(x.shape) != len(x_ref.shape):
                 raise ValueError(
-                    f"{self.__class__.__name__} was passed incompatible inputs. "
-                    f"For input '{x_ref.name}', expected shape {x_ref.shape}, "
-                    f"but received instead a tensor with shape {x.shape}."
+                    f"{self.__class__.__name__} was passed "
+                    f"incompatible inputs. For input '{x_ref.name}', "
+                    f"expected shape {x_ref.shape}, but received "
+                    f"instead a tensor with shape {x.shape}."
                 )
             for dim, ref_dim in zip(x.shape, x_ref.shape):
                 if ref_dim is not None and dim is not None:
                     if dim != ref_dim:
                         raise ValueError(
-                            f"{self.__class__.__name__} was passed incompatible inputs. "
-                            f"For input '{x_ref.name}', expected shape {x_ref.shape}, "
-                            f"but received instead a tensor with shape {x.shape}."
+                            f"{self.__class__.__name__} was passed "
+                            f"incompatible inputs. For input '{x_ref.name}', "
+                            f"expected shape {x_ref.shape}, but received "
+                            f"instead a tensor with shape {x.shape}."
                         )
 
 
@@ -154,7 +156,8 @@ def map_graph(inputs, outputs):
         - nodes: list of Node instances.
         - nodes_by_depth: dict mapping ints (depth) to lists of node instances.
         - operations: list of Operation instances.
-        - operations_by_depth: dict mapping ints (depth) to lists of Operation instances.
+        - operations_by_depth: dict mapping ints (depth) to lists of Operation
+            instances.
     """
     # "depth" is number of operations between output Node and the Node.
     # Nodes are ordered from inputs -> outputs.
@@ -274,14 +277,15 @@ def _build_map(outputs):
 
     Returns:
         A tuple like (ordered_nodes, operation_to_first_traversal_index)
-        ordered_nodes: list of nodes appearing in the keras history, topologically
-            sorted from original inputs to the `outputs`.
-            (If outputs have different sets of ancestors, the inputs to one output
-            may appear after a different output).
+        ordered_nodes: list of nodes appearing in the keras history,
+            topologically sorted from original inputs to the `outputs`.
+            (If outputs have different sets of ancestors, the inputs to one
+            output may appear after a different output).
         operation_to_first_traversal_index:
-            A dict mapping operation to the traversal index in the DFS where it is
-            seen. Note: if a operation is shared by several nodes, the dict will only
-            store the index corresponding to the *first* time the operation seen.
+            A dict mapping operation to the traversal index in the DFS where it
+            is seen. Note: if a operation is shared by several nodes, the dict
+            will onlystore the index corresponding to the *first* time the
+            operation seen.
     """
     finished_nodes = set()
     nodes_in_progress = set()
@@ -323,7 +327,8 @@ def _build_map_helper(
     # Prevent cycles.
     if node in nodes_in_progress:
         raise ValueError(
-            f'Tensor {tensor} from operation "{operation.name}" is part of a cycle.'
+            f"Tensor {tensor} from operation '{operation.name}' is part of a "
+            "cycle."
         )
 
     # Store the traversal order for operation sorting.

--- a/keras_core/optimizers/optimizer.py
+++ b/keras_core/optimizers/optimizer.py
@@ -45,8 +45,8 @@ class Optimizer:
                 or ema_overwrite_frequency < 1
             ):
                 raise ValueError(
-                    "`ema_overwrite_frequency` must be an integer >= 1 or None. "
-                    "Received: ema_overwrite_frequency="
+                    "`ema_overwrite_frequency` must be an integer >= 1 or "
+                    "None. Received: ema_overwrite_frequency="
                     f"{ema_overwrite_frequency}"
                 )
         self.ema_momentum = ema_momentum
@@ -75,11 +75,11 @@ class Optimizer:
         else:
             if not isinstance(learning_rate, float):
                 raise ValueError(
-                    "Argument `learning_rate` should be float, or an instance of "
-                    "LearningRateSchedule, or a callable "
+                    "Argument `learning_rate` should be float, or an instance "
+                    "of LearningRateSchedule, or a callable "
                     "(that takes in the current iteration value "
-                    "and returns the corresponding learning rate value). Received instead: "
-                    f"learning_rate={learning_rate}"
+                    "and returns the corresponding learning rate value). "
+                    f"Received instead: learning_rate={learning_rate}"
                 )
             self._learning_rate = backend.Variable(
                 learning_rate,
@@ -134,7 +134,9 @@ class Optimizer:
         return variable
 
     def add_variable_from_reference(self, reference_variable, name=None):
-        """Add an all-zeros variable with the shape and dtype of a reference variable."""
+        """Add an all-zeros variable with the shape and dtype of a reference
+        variable.
+        """
         initializer = initializers.Zeros()
         name = name or auto_name(self.__class__.__name__)
         return self.add_variable(
@@ -150,8 +152,8 @@ class Optimizer:
                 raise ValueError(
                     f"Unknown variable: {v}. This optimizer can only "
                     "be called for the variables it was originally built with. "
-                    "When working with a new set of variables, you should recreate "
-                    "a new optimizer instance."
+                    "When working with a new set of variables, you should "
+                    "recreate a new optimizer instance."
                 )
 
     def update_step(self, gradient, variable, learning_rate):
@@ -178,13 +180,15 @@ class Optimizer:
             if not self.built:
                 raise ValueError(
                     "When passing `grads` without `variables`, the optimizer "
-                    "must already be built on a list of variables. Call `optimizer.build(trainable_variables)` first. "
+                    "must already be built on a list of variables. "
+                    "Call `optimizer.build(trainable_variables)` first. "
                 )
             if len(grads) != len(self._trainable_variables_indices):
                 raise ValueError(
-                    "When passing `grads` as a list of gradient tensors, the gradients must "
-                    f"match `optimizer.variables` one-to-on. Received a list of {len(grads)} "
-                    f"gradients, but the optimizer is tracking {len(self._trainable_variables)} "
+                    "When passing `grads` as a list of gradient tensors, the "
+                    f"gradients must match `optimizer.variables` one-to-on. "
+                    f"Received a list of {len(grads)} gradients, but the "
+                    f"optimizer is tracking {len(self._trainable_variables)} "
                     "trainable variables."
                 )
             trainable_variables = self._trainable_variables
@@ -227,22 +231,22 @@ class Optimizer:
         if not self.built:
             raise ValueError(
                 "To call stateless_apply_gradients, {self.__class__.__name__} "
-                "must be built (i.e. its variables must have been already created). "
+                "must be built (i.e. its variables must have been created). "
                 "You can build it via `optimizer.build(trainable_variables)`."
             )
         if len(optimizer_variables) != len(self.variables):
             raise ValueError(
                 "Argument `optimizer_variables` must be a list of tensors "
                 f"corresponding 1:1 to {self.__class__.__name__}().variables. "
-                f"Received list with length {len(optimizer_variables)}, but expected "
-                f"{len(self.variables)} variables."
+                f"Received list with length {len(optimizer_variables)}, but "
+                f"expected {len(self.variables)} variables."
             )
         if len(trainable_variables) != len(self._trainable_variables):
             raise ValueError(
                 "Argument `optimizer_variables` must be a list of tensors "
                 "corresponding 1:1 to the trainable variables list that "
-                "the optimizer was built with. "
-                f"Received len(trainable_variables) == {len(trainable_variables)} "
+                "the optimizer was built with. Received "
+                f"len(trainable_variables) == {len(trainable_variables)} "
                 "whereas the optimizer was built with "
                 f"{len(self._trainable_variables)} variables."
             )

--- a/keras_core/regularizers/regularizers.py
+++ b/keras_core/regularizers/regularizers.py
@@ -22,7 +22,8 @@ class Regularizer:
 
     - `kernel_regularizer`: Regularizer to apply a penalty on the layer's kernel
     - `bias_regularizer`: Regularizer to apply a penalty on the layer's bias
-    - `activity_regularizer`: Regularizer to apply a penalty on the layer's output
+    - `activity_regularizer`: Regularizer to apply a penalty on the layer's
+        output
 
     All layers (including custom layers) expose `activity_regularizer` as a
     settable property, whether or not it is in the constructor arguments.
@@ -278,15 +279,15 @@ class OrthogonalRegularizer(Regularizer):
     (i.e. the basis of the output space) orthogonal to each other.
 
     Arguments:
-        factor: Float. The regularization factor. The regularization penalty will
-            be proportional to `factor` times the mean of the dot products between
-            the L2-normalized rows (if `mode="rows"`, or columns if
+        factor: Float. The regularization factor. The regularization penalty
+            will be proportional to `factor` times the mean of the dot products
+            between the L2-normalized rows (if `mode="rows"`, or columns if
             `mode="columns"`) of the inputs, excluding the product of each
             row/column with itself.  Defaults to 0.01.
-        mode: String, one of `{"rows", "columns"}`. Defaults to `"rows"`. In rows
-            mode, the regularization effect seeks to make the rows of the input
-            orthogonal to each other. In columns mode, it seeks to make the columns
-            of the input orthogonal to each other.
+        mode: String, one of `{"rows", "columns"}`. Defaults to `"rows"`. In
+            rows mode, the regularization effect seeks to make the rows of the
+            input orthogonal to each other. In columns mode, it seeks to make
+            the columns of the input orthogonal to each other.
 
     Example:
 

--- a/keras_core/saving/object_registration.py
+++ b/keras_core/saving/object_registration.py
@@ -19,9 +19,9 @@ class CustomObjectScope:
     """Exposes custom classes/functions to Keras deserialization internals.
 
     Under a scope `with custom_object_scope(objects_dict)`, Keras methods such
-    as `keras_core.models.load_model()` or `keras_core.models.model_from_config()`
-    will be able to deserialize any custom object referenced by a
-    saved config (e.g. a custom layer or metric).
+    as `keras_core.models.load_model()` or
+    `keras_core.models.model_from_config()` will be able to deserialize any
+    custom object referenced by a saved config (e.g. a custom layer or metric).
 
     Example:
 
@@ -108,18 +108,20 @@ def register_keras_serializable(package="Custom", name=None):
     class MyDense(keras_core.layers.Dense):
         pass
 
-    assert keras_core.saving.get_registered_object('my_package>MyDense') == MyDense
-    assert keras_core.saving.get_registered_name(MyDense) == 'my_package>MyDense'
+    assert keras_core.saving.get_registered_object(
+        'my_package>MyDense') == MyDense
+    assert keras_core.saving.get_registered_name(
+        MyDense) == 'my_package>MyDense'
     ```
 
     Args:
         package: The package that this class belongs to. This is used for the
-            `key` (which is `"package>name"`) to idenfify the class. Note that this
-            is the first argument passed into the decorator.
+            `key` (which is `"package>name"`) to idenfify the class. Note that
+            this is the first argument passed into the decorator.
         name: The name to serialize this class under in this package. If not
-            provided or `None`, the class' name will be used (note that this is the
-            case when the decorator is used with only one argument, which becomes
-            the `package`).
+            provided or `None`, the class' name will be used (note that this is
+            the case when the decorator is used with only one argument, which
+            becomes the `package`).
 
     Returns:
         A decorator that registers the decorated class with the passed names.
@@ -187,7 +189,8 @@ def get_registered_object(name, custom_objects=None, module_objects=None):
         custom_objects: A dictionary of custom objects to look the name up in.
             Generally, custom_objects is provided by the user.
         module_objects: A dictionary of custom objects to look the name up in.
-            Generally, module_objects is provided by midlevel library implementers.
+            Generally, module_objects is provided by midlevel library
+            implementers.
 
     Returns:
         An instantiable class associated with `name`, or `None` if no such class

--- a/keras_core/saving/saving_lib_test.py
+++ b/keras_core/saving/saving_lib_test.py
@@ -377,7 +377,9 @@ class SavingTest(testing.TestCase):
     #         os.path.join(self.get_temp_dir(), "my_model.keras")
     #     )
     #     model = CompileOverridingModel()
-    #     with mock.patch("re.match", autospec=True) as mock_re_match, mock.patch(
+    #     with mock.patch(
+    #         "re.match", autospec=True
+    #     ) as mock_re_match, mock.patch(
     #         "tensorflow.compat.v2.io.gfile.copy", autospec=True
     #     ) as mock_copy:
     #         # Mock Remote Path check to true to test gfile copy logic
@@ -389,7 +391,9 @@ class SavingTest(testing.TestCase):
     #         self.assertIn(str(temp_filepath), mock_copy.call_args.args)
 
     # def test_load_model_api_endpoint(self):
-    #     temp_filepath = Path(os.path.join(self.get_temp_dir(), "mymodel.keras"))
+    #     temp_filepath = Path(
+    #         os.path.join(self.get_temp_dir(), "mymodel.keras")
+    #     )
     #     model = self._get_functional_model()
     #     ref_input = np.random.random((10, 32))
     #     ref_output = model.predict(ref_input)
@@ -448,7 +452,9 @@ class SavingTest(testing.TestCase):
     #     with self.assertRaises(EOFError):
     #         model.save(temp_filepath, overwrite=False)
 
-    #     temp_filepath = os.path.join(self.get_temp_dir(), "mymodel.weights.h5")
+    #     temp_filepath = os.path.join(
+    #         self.get_temp_dir(), "mymodel.weights.h5"
+    #     )
     #     model = self._get_basic_functional_model()
     #     model.save_weights(temp_filepath)
     #     model.save_weights(temp_filepath, overwrite=True)
@@ -550,7 +556,8 @@ class SavingTest(testing.TestCase):
 #             [
 #                 keras_core.Input(shape=(3,)),
 #                 keras_core.layers.Normalization(
-#                     mean=np.random.random((3,)), variance=np.random.random((3,))
+#                     mean=np.random.random((3,)),
+#                     variance=np.random.random((3,)),
 #                 ),
 #             ]
 #         )
@@ -566,8 +573,12 @@ class SavingTest(testing.TestCase):
 #     def __init__(self, units):
 #         super(CustomRNN, self).__init__()
 #         self.units = units
-#         self.projection_1 = keras_core.layers.Dense(units=units, activation="tanh")
-#         self.projection_2 = keras_core.layers.Dense(units=units, activation="tanh")
+#         self.projection_1 = keras_core.layers.Dense(
+#             units=units, activation="tanh"
+#         )
+#         self.projection_2 = keras_core.layers.Dense(
+#             units=units, activation="tanh"
+#         )
 #         self.classifier = keras_core.layers.Dense(1)
 
 #     def call(self, inputs):
@@ -647,7 +658,9 @@ class SavingTest(testing.TestCase):
 #         input_dim = 5
 #         batch_size = 16
 
-#         inputs = keras_core.Input(batch_shape=(batch_size, timesteps, input_dim))
+#         inputs = keras_core.Input(
+#             batch_shape=(batch_size, timesteps, input_dim)
+#         )
 #         x = keras_core.layers.Conv1D(32, 3)(inputs)
 #         outputs = CustomRNN(32)(x)
 
@@ -665,7 +678,9 @@ class SavingTest(testing.TestCase):
 #         )
 
 #         inputs = keras_core.Input(shape=(4, 4))
-#         outputs = keras_core.layers.Dense(1, activation=GrowthFactor(0.5))(inputs)
+#         outputs = keras_core.layers.Dense(
+#             1, activation=GrowthFactor(0.5)
+#         )(inputs)
 #         model = keras_core.Model(inputs, outputs)
 
 #         model.save(temp_filepath)
@@ -676,7 +691,9 @@ class SavingTest(testing.TestCase):
 #             _ = keras_core.models.load_model(temp_filepath)
 
 #     def test_complex_model_without_explicit_deserialization(self):
-#         temp_filepath = os.path.join(self.get_temp_dir(), "complex_model.keras")
+#         temp_filepath = os.path.join(
+#             self.get_temp_dir(), "complex_model.keras"
+#         )
 
 #         inputs = keras_core.Input((32,))
 #         outputs = ComplexModel(first_layer=FactorLayer(0.5))(inputs)

--- a/keras_core/trainers/compile_utils.py
+++ b/keras_core/trainers/compile_utils.py
@@ -124,8 +124,8 @@ class CompileMetrics(metrics_module.Metric):
             weighted_metrics, (list, tuple, dict)
         ):
             raise ValueError(
-                "Expected `weighted_metrics` argument to be a list, tuple, or dict. "
-                f"Received instead: weighted_metrics={weighted_metrics} "
+                "Expected `weighted_metrics` argument to be a list, tuple, or "
+                f"dict. Received instead: weighted_metrics={weighted_metrics} "
                 f"of type {type(weighted_metrics)}"
             )
         self._user_metrics = metrics
@@ -195,14 +195,16 @@ class CompileMetrics(metrics_module.Metric):
             else:
                 if not isinstance(metrics, list):
                     raise ValueError(
-                        f"When there is only a single output, the `{argument_name}` argument "
-                        "must be a list of metric objects. "
-                        f"Received instead:\n{argument_name}={metrics} of type {type(metrics)}"
+                        "When there is only a single output, the "
+                        f"`{argument_name}` argument must be a list of metric "
+                        f"objects. Received instead:\n"
+                        f"{argument_name}={metrics} of type {type(metrics)}"
                     )
                 if not all(is_function_like(m) for m in metrics):
                     raise ValueError(
-                        f"Expected all entries in the `{argument_name}` list to be "
-                        f"metric objects. Received instead:\n{argument_name}={metrics}"
+                        f"Expected all entries in the `{argument_name}` list "
+                        f"to be metric objects. Received instead:\n"
+                        f"{argument_name}={metrics}"
                     )
                 flat_metrics.append(
                     MetricsList(
@@ -218,24 +220,27 @@ class CompileMetrics(metrics_module.Metric):
                 if len(metrics) != len(y_pred):
                     raise ValueError(
                         "For a model with multiple outputs, "
-                        f"when providing the `{argument_name}` argument as a list, "
-                        "it should have as many entries as the model has outputs. "
-                        f"Received:\n{argument_name}={metrics}\nof length {len(metrics)} "
-                        f"whereas the model has {len(y_pred)} outputs."
+                        f"when providing the `{argument_name}` argument as a "
+                        "list, it should have as many entries as the model has "
+                        f"outputs. Received:\n{argument_name}={metrics}\nof "
+                        f"length {len(metrics)} whereas the model has "
+                        f"{len(y_pred)} outputs."
                     )
                 if not all(isinstance(mls, list) for mls in metrics):
                     raise ValueError(
                         "For a model with multiple outputs, "
-                        f"when providing the `{argument_name}` argument as a list, "
-                        "each list entry should itself be a list (the list of metrics "
-                        f"corresponding to that output). Received:\n{argument_name}={metrics}"
+                        f"when providing the `{argument_name}` argument as a "
+                        "list, each list entry should itself be a list "
+                        "(the list of metrics corresponding to that output). "
+                        f"Received:\n{argument_name}={metrics}"
                     )
                 for mls, yt, yp in zip(metrics, y_true, y_pred):
                     if not all(is_function_like(e) for e in mls):
                         raise ValueError(
-                            f"All entries in the sublists of the `{argument_name}` "
-                            "list should be metric objects. "
-                            f"Found the following sublist with unknown types: {mls}"
+                            f"All entries in the sublists of the "
+                            f"`{argument_name}` list should be metric objects. "
+                            f"Found the following sublist with unknown "
+                            f"types: {mls}"
                         )
                     flat_metrics.append(
                         MetricsList(
@@ -249,29 +254,30 @@ class CompileMetrics(metrics_module.Metric):
             elif isinstance(metrics, dict):
                 if output_names is None:
                     raise ValueError(
-                        f"Argument `{argument_name}` can only be provided as a dict "
-                        "when the model also returns a dict of outputs. Received "
-                        f"{argument_name}={metrics}"
+                        f"Argument `{argument_name}` can only be provided as a "
+                        "dict when the model also returns a dict of outputs. "
+                        f"Received {argument_name}={metrics}"
                     )
                 for name in metrics.keys():
                     if name not in output_names:
                         raise ValueError(
                             f"In the dict argument `{argument_name}`, key "
-                            f"'{name}' does not correspond to any model output. "
-                            f"Received:\n{argument_name}={metrics}"
+                            f"'{name}' does not correspond to any model "
+                            f"output. Received:\n{argument_name}={metrics}"
                         )
                     if not isinstance(metrics[name], list):
                         raise ValueError(
                             "For a model with multiple outputs, "
-                            f"when providing the `{argument_name}` argument as a dict, "
-                            "each dict entry should be a list (the list of metrics "
-                            "corresponding to that output). "
-                            f"At key '{name}', received invalid type:\n{metrics[name]}"
+                            f"when providing the `{argument_name}` argument as "
+                            "a dict, each dict entry should be a list (the "
+                            "list of metrics corresponding to that output). "
+                            f"At key '{name}', received invalid type:\n"
+                            f"{metrics[name]}"
                         )
                     if not all(is_function_like(e) for e in metrics[name]):
                         raise ValueError(
-                            f"All entries in the sublists of the `{argument_name}` "
-                            "dict should be metric objects. "
+                            f"All entries in the sublists of the "
+                            f"`{argument_name}` dict should be metric objects. "
                             f"At key '{name}', found the following sublist "
                             f"with unknown types: {metrics[name]}"
                         )
@@ -369,8 +375,8 @@ class CompileLoss(losses_module.Loss):
     ):
         if loss_weights and not isinstance(loss_weights, (list, tuple, dict)):
             raise ValueError(
-                "Expected `loss_weights` argument to be a list, tuple, or dict. "
-                f"Received instead: loss_weights={loss_weights} "
+                "Expected `loss_weights` argument to be a list, tuple, or "
+                f"dict. Received instead: loss_weights={loss_weights} "
                 f"of type {type(loss_weights)}"
             )
         self._user_loss = loss
@@ -400,7 +406,7 @@ class CompileLoss(losses_module.Loss):
         if num_outputs == 1:
             if not is_function_like(loss):
                 raise ValueError(
-                    f"When there is only a single output, the `loss` argument "
+                    "When there is only a single output, the `loss` argument "
                     "must be a callable. "
                     f"Received instead:\nloss={loss} of type {type(loss)}"
                 )
@@ -408,9 +414,11 @@ class CompileLoss(losses_module.Loss):
             if loss_weights:
                 if not isinstance(loss_weights, float):
                     raise ValueError(
-                        f"When there is only a single output, the `loss_weights` argument "
+                        "When there is only a single output, the "
+                        "`loss_weights` argument "
                         "must be a Python float. "
-                        f"Received instead: loss_weights={loss_weights} of type {type(loss_weights)}"
+                        f"Received instead: loss_weights={loss_weights} of "
+                        f"type {type(loss_weights)}"
                     )
                 flat_loss_weights.append(loss_weights)
             else:
@@ -419,7 +427,7 @@ class CompileLoss(losses_module.Loss):
             if len(loss) != len(y_pred):
                 raise ValueError(
                     "For a model with multiple outputs, "
-                    f"when providing the `loss` argument as a list, "
+                    "when providing the `loss` argument as a list, "
                     "it should have as many entries as the model has outputs. "
                     f"Received:\nloss={loss}\nof length {len(loss)} "
                     f"whereas the model has {len(y_pred)} outputs."
@@ -427,7 +435,7 @@ class CompileLoss(losses_module.Loss):
             if not all(is_function_like(e) for e in loss):
                 raise ValueError(
                     "For a model with multiple outputs, "
-                    f"when providing the `loss` argument as a list, "
+                    "when providing the `loss` argument as a list, "
                     "each list entry should be a callable (the loss function "
                     "corresponding to that output). "
                     f"Received: loss={loss}"
@@ -439,24 +447,26 @@ class CompileLoss(losses_module.Loss):
                 if not isinstance(loss_weights, (list, tuple)):
                     raise ValueError(
                         "If the `loss` argument is provided as a list/tuple, "
-                        "the `loss_weight` argument should also be provided as a list/tuple, "
-                        f"of equal length. Received: loss_weights={loss_weights}"
+                        "the `loss_weight` argument should also be provided as "
+                        "a list/tuple, of equal length. "
+                        f"Received: loss_weights={loss_weights}"
                     )
                 if len(loss_weights) != len(y_pred):
                     raise ValueError(
                         "For a model with multiple outputs, "
-                        f"when providing the `loss_weights` argument as a list, "
-                        "it should have as many entries as the model has outputs. "
-                        f"Received: loss_weights={loss_weights} of length {len(loss_weights)} "
-                        f"whereas the model has {len(y_pred)} outputs."
+                        "when providing the `loss_weights` argument as a list, "
+                        "it should have as many entries as the model has "
+                        f"outputs. Received: loss_weights={loss_weights} of "
+                        f"length {len(loss_weights)} whereas the model has "
+                        f"{len(y_pred)} outputs."
                     )
                 if not all(isinstance(e, float) for e in loss_weights):
                     raise ValueError(
                         "For a model with multiple outputs, "
-                        f"when providing the `loss_weights` argument as a list, "
-                        "each list entry should be a Python float (the weighting coefficient "
-                        "corresponding to the loss for that output). "
-                        f"Received: loss_weights={loss_weights}"
+                        "when providing the `loss_weights` argument as a "
+                        "list, each list entry should be a Python float (the "
+                        "weighting coefficient corresponding to the loss for "
+                        f"that output). Received: loss_weights={loss_weights}"
                     )
                 flat_loss_weights = list(loss_weights)
             else:
@@ -464,21 +474,21 @@ class CompileLoss(losses_module.Loss):
         elif isinstance(loss, dict):
             if output_names is None:
                 raise ValueError(
-                    f"Argument `loss` can only be provided as a dict "
-                    "when the model also returns a dict of outputs. Received "
-                    f"loss={loss}"
+                    "Argument `loss` can only be provided as a dict "
+                    "when the model also returns a dict of outputs. "
+                    f"Received loss={loss}"
                 )
             for name in loss.keys():
                 if name not in output_names:
                     raise ValueError(
-                        f"In the dict argument `loss`, key "
+                        "In the dict argument `loss`, key "
                         f"'{name}' does not correspond to any model output. "
                         f"Received:\nloss={loss}"
                     )
                 if not is_function_like(loss[name]):
                     raise ValueError(
                         "For a model with multiple outputs, "
-                        f"when providing the `loss` argument as a dict, "
+                        "when providing the `loss` argument as a dict, "
                         "each dict entry should be a callable (the loss "
                         "function corresponding to that output). "
                         f"At key '{name}', received invalid type:\n{loss[name]}"
@@ -495,23 +505,24 @@ class CompileLoss(losses_module.Loss):
                 if not isinstance(loss_weights, dict):
                     raise ValueError(
                         "If the `loss` argument is provided as a dict, "
-                        "the `loss_weight` argument should also be provided as a dict. "
-                        f"Received: loss_weights={loss_weights}"
+                        "the `loss_weight` argument should also be provided as "
+                        f"a dict. Received: loss_weights={loss_weights}"
                     )
                 for name in loss_weights.keys():
                     if name not in output_names:
                         raise ValueError(
-                            f"In the dict argument `loss_weights`, key "
-                            f"'{name}' does not correspond to any model output. "
-                            f"Received: loss_weights={loss_weights}"
+                            "In the dict argument `loss_weights`, key "
+                            f"'{name}' does not correspond to any model "
+                            f"output. Received: loss_weights={loss_weights}"
                         )
                     if not isinstance(loss_weights[name], float):
                         raise ValueError(
                             "For a model with multiple outputs, "
-                            f"when providing the `loss_weights` argument as a dict, "
-                            "each dict entry should be a Python float (the weighting coefficient "
-                            "corresponding to the loss for that output). "
-                            f"At key '{name}', received invalid type:\n{loss_weights[name]}"
+                            "when providing the `loss_weights` argument as a "
+                            "dict, each dict entry should be a Python float "
+                            "(the weighting coefficient corresponding to the "
+                            f"loss for that output). At key '{name}', "
+                            f"received invalid type:\n{loss_weights[name]}"
                         )
                 for name in output_names:
                     if name in loss_weights:

--- a/keras_core/trainers/data_adapters/array_data_adapter.py
+++ b/keras_core/trainers/data_adapters/array_data_adapter.py
@@ -15,7 +15,9 @@ except ImportError:
 
 
 class ArrayDataAdapter(DataAdapter):
-    """Adapter that handles array-like objects, e.g. tf.Tensor and NumPy arrays."""
+    """Adapter that handles array-like objects,
+    e.g. tf.Tensor and NumPy arrays.
+    """
 
     def __init__(
         self,
@@ -33,15 +35,16 @@ class ArrayDataAdapter(DataAdapter):
             issubclass(c, data_adapter_utils.ARRAY_TYPES) for c in flat_types
         ):
             raise ValueError(
-                "Expected all elements of `x` to be array-like. Received invalid types: "
-                f"x={x}"
+                "Expected all elements of `x` to be array-like. "
+                f"Received invalid types: x={x}"
             )
 
         x, y, sample_weight = convert_to_arrays((x, y, sample_weight))
         if sample_weight is not None:
             if class_weight is not None:
                 raise ValueError(
-                    "You cannot `class_weight` and `sample_weight` at the same time."
+                    "You cannot `class_weight` and `sample_weight` "
+                    "at the same time."
                 )
             if tf.nest.is_nested(y):
                 if isinstance(sample_weight, np.ndarray):
@@ -51,10 +54,12 @@ class ArrayDataAdapter(DataAdapter):
                     )
                     if not is_samplewise:
                         raise ValueError(
-                            "For a model with multiple outputs, when providing a single `sample_weight` array, "
-                            "it should only have one scalar score per sample (i.e. shape `(num_samples,)`). "
-                            "If you want to use non-scalar sample weights, pass a `sample_weight` argument with one "
-                            "array per model output."
+                            "For a model with multiple outputs, when providing "
+                            "a single `sample_weight` array, it should only "
+                            "have one scalar score per sample "
+                            "(i.e. shape `(num_samples,)`). If you want to use "
+                            "non-scalar sample weights, pass a `sample_weight` "
+                            "argument with one array per model output."
                         )
                     # Replicate the same sample_weight array on all outputs.
                     sample_weight = tf.nest.map_structure(
@@ -65,8 +70,8 @@ class ArrayDataAdapter(DataAdapter):
                         tf.nest.assert_same_structure(y, sample_weight)
                     except ValueError:
                         raise ValueError(
-                            "You should provide one `sample_weight` array per output in `y`. "
-                            "The two structures did not match:\n"
+                            "You should provide one `sample_weight` array per "
+                            "output in `y`. The two structures did not match:\n"
                             f"- y: {y}\n"
                             f"- sample_weight: {sample_weight}\n"
                         )
@@ -161,8 +166,8 @@ def convert_to_arrays(arrays, dtype=None):
             x = x.numpy()
         if not isinstance(x, np.ndarray):
             raise ValueError(
-                "Expected a NumPy array, tf.Tensor, Pandas Dataframe or Pandas Series. "
-                f"Received invalid input: {x} (of type {type(x)})"
+                "Expected a NumPy array, tf.Tensor, Pandas Dataframe or Pandas "
+                f"Series. Received invalid input: {x} (of type {type(x)})"
             )
         if not str(x.dtype) == str(dtype):
             x = x.astype(dtype)

--- a/keras_core/trainers/epoch_iterator.py
+++ b/keras_core/trainers/epoch_iterator.py
@@ -78,19 +78,22 @@ class EpochIterator:
             # Unsupported args: y, sample_weight, shuffle
             if y is not None:
                 raise ValueError(
-                    "When providing `x` as a tf.data.Dataset, `y` should not be passed. "
-                    "Instead, the targets should be included as part of the Dataset `x`."
+                    "When providing `x` as a tf.data.Dataset, `y` should not "
+                    "be passed. Instead, the targets should be included as "
+                    "part of the Dataset `x`."
                 )
             if sample_weight is not None:
                 raise ValueError(
-                    "When providing `x` as a tf.data.Dataset, `sample_weight` should not be passed. "
-                    "Instead, the sample weights should be included as part of the Dataset `x`."
+                    "When providing `x` as a tf.data.Dataset, `sample_weight` "
+                    "should not be passed. Instead, the sample weights should "
+                    "be included as part of the Dataset `x`."
                 )
             # TODO: should we warn or not?
             # warnings.warn(
-            #     "`shuffle=True` was passed, but will be ignored since the data `x` was provided "
-            #     "as a tf.data.Dataset. The Dataset is expected to already "
-            #     "be shuffled (via `.shuffle(tf.data.AUTOTUNE)`)"
+            #     "`shuffle=True` was passed, but will be ignored since the "
+            #     "data `x` was provided as a tf.data.Dataset. The Dataset is "
+            #     "expected to already be shuffled "
+            #     "(via `.shuffle(tf.data.AUTOTUNE)`)"
             # )
         else:
             # TODO: add support for more types.

--- a/keras_core/trainers/trainer.py
+++ b/keras_core/trainers/trainer.py
@@ -39,8 +39,8 @@ class Trainer:
         if jit_compile and run_eagerly:
             jit_compile = False
             warnings.warn(
-                "If `run_eagerly` is True, then `jit_compile` cannot also be True. "
-                "Disabling `jit_compile`.",
+                "If `run_eagerly` is True, then `jit_compile` "
+                "cannot also be True. Disabling `jit_compile`.",
                 stacklevel=2,
             )
         self.jit_compile = jit_compile
@@ -174,7 +174,8 @@ class Trainer:
           def compute_metrics(self, x, y, y_pred, sample_weight):
             # This super call updates `self.compiled_metrics` and returns
             # results for all metrics listed in `self.metrics`.
-            metric_results = super().compute_metrics(x, y, y_pred, sample_weight)
+            metric_results = super().compute_metrics(
+                x, y, y_pred, sample_weight)
 
             # Note that `self.custom_metric` is not listed in `self.metrics`.
             self.custom_metric.update_state(x, y, y_pred, sample_weight)
@@ -185,14 +186,14 @@ class Trainer:
         Args:
             x: Input data.
             y: Target data.
-            y_pred: Predictions returned by the model (output of `model.call(x)`)
+            y_pred: Predictions returned by the model output of `model.call(x)`.
             sample_weight: Sample weights for weighting the loss function.
 
         Returns:
             A `dict` containing values that will be passed to
-            `tf.keras.callbacks.CallbackList.on_train_batch_end()`. Typically, the
-            values of the metrics listed in `self.metrics` are returned. Example:
-            `{'loss': 0.2, 'accuracy': 0.7}`.
+            `tf.keras.callbacks.CallbackList.on_train_batch_end()`. Typically,
+            the values of the metrics listed in `self.metrics` are returned.
+            Example: `{'loss': 0.2, 'accuracy': 0.7}`.
         """
         del x  # The default implementation does not use `x`.
         if self._compile_metrics is not None:
@@ -323,7 +324,7 @@ class Trainer:
         return result
 
     def _flatten_metrics_in_order(self, logs):
-        """Turns the `logs` dict into a list as per key order of `metrics_names`."""
+        """Turns `logs` dict into a list as per key order of `metrics_names`."""
         metric_names = [m.name for m in self.metrics]
         results = []
         for name in metric_names:


### PR DESCRIPTION
Fixes line length on comments, doc strings to < 80 chars to satisfy linter.