### PR TITLE
Set demo program backend for JAX and TF workflow example

### DIFF
--- a/demo_custom_jax_workflow.py
+++ b/demo_custom_jax_workflow.py
@@ -1,3 +1,9 @@
+# flake8: noqa
+import os
+
+# Set backend env to JAX
+os.environ["KERAS_BACKEND"] = "jax"
+
 import jax
 import numpy as np
 

--- a/demo_custom_tf_workflow.py
+++ b/demo_custom_tf_workflow.py
@@ -1,3 +1,9 @@
+# flake8: noqa
+import os
+
+# Set backend env to tensorflow
+os.environ["KERAS_BACKEND"] = "tensorflow"
+
 import numpy as np
 import tensorflow as tf
 


### PR DESCRIPTION
Sets the backend explicitly for JAX and TF Workflow demo examples.  Otherwise, if we run with default Tensorflow backend, the `demo_custom_jax_workflow.py` fails and vice versa.