### PR TITLE
Add MeanAbsoluteError, MeanAbsolutePercentageError, MeanSquaredLogarithmicError, CosineSimilarity, LogCoshError

### DIFF
--- a/keras_core/losses/losses.py
+++ b/keras_core/losses/losses.py
@@ -160,7 +160,7 @@ class CosineSimilarity(LossFunctionWrapper):
     Formula:
 
     ```python
-    loss = mean(square(log(y_true + 1) - log(y_pred + 1)))
+    loss = -sum(l2_norm(y_true) * l2_norm(y_pred))
     ```
 
     Args:
@@ -188,6 +188,7 @@ class Huber(LossFunctionWrapper):
     """Computes the Huber loss between `y_true` & `y_pred`.
 
     Formula:
+
     ```python
     for x in error:
         if abs(x) <= delta:
@@ -1380,7 +1381,7 @@ def log_cosh(y_true, y_pred):
     log2 = ops.convert_to_tensor(ops.log(2.0), dtype=y_pred.dtype)
 
     def _logcosh(x):
-        return x + ops.softplus(ops.multiply(x, -2.0)) - log2
+        return x + ops.softplus(x * -2.0) - log2
 
     return ops.mean(_logcosh(y_pred - y_true), axis=-1)
 

--- a/keras_core/metrics/regression_metrics.py
+++ b/keras_core/metrics/regression_metrics.py
@@ -14,13 +14,17 @@ from keras_core.utils.numerical_utils import normalize
 class MeanSquaredError(reduction_metrics.MeanMetricWrapper):
     """Computes the mean squared error between `y_true` and `y_pred`.
 
+    Formula:
+
+    ```python
+    loss = mean(square(y_true - y_pred))
+    ```
+
     Args:
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
     Example:
-
-    Standalone usage:
 
     >>> m = keras_core.metrics.MeanSquaredError()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])
@@ -39,6 +43,12 @@ class MeanSquaredError(reduction_metrics.MeanMetricWrapper):
 class MeanAbsoluteError(reduction_metrics.MeanMetricWrapper):
     """Computes the mean absolute error between the labels and predictions.
 
+    Formula:
+
+    ```python
+    loss = mean(abs(y_true - y_pred))
+    ```
+
     Args:
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
@@ -47,14 +57,14 @@ class MeanAbsoluteError(reduction_metrics.MeanMetricWrapper):
 
     Standalone usage:
 
-    >>> m = tf.keras.metrics.MeanAbsoluteError()
+    >>> m = keras_core.metrics.MeanAbsoluteError()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])
-    >>> m.result().numpy()
+    >>> m.result()
     0.25
     >>> m.reset_state()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]],
     ...                sample_weight=[1, 0])
-    >>> m.result().numpy()
+    >>> m.result()
     0.5
 
     Usage with `compile()` API:
@@ -63,7 +73,7 @@ class MeanAbsoluteError(reduction_metrics.MeanMetricWrapper):
     model.compile(
         optimizer='sgd',
         loss='mse',
-        metrics=[tf.keras.metrics.MeanAbsoluteError()])
+        metrics=[keras_core.metrics.MeanAbsoluteError()])
     ```
     """
 
@@ -76,8 +86,13 @@ class MeanAbsoluteError(reduction_metrics.MeanMetricWrapper):
 
 @keras_core_export("keras_core.metrics.MeanAbsolutePercentageError")
 class MeanAbsolutePercentageError(reduction_metrics.MeanMetricWrapper):
-    """Computes the mean absolute percentage error between `y_true` and
-    `y_pred`.
+    """Computes mean absolute percentage error between `y_true` and `y_pred`.
+
+    Formula:
+
+    ```python
+    loss = 100 * mean(abs((y_true - y_pred) / y_true))
+    ```
 
     Args:
         name: (Optional) string name of the metric instance.
@@ -87,14 +102,14 @@ class MeanAbsolutePercentageError(reduction_metrics.MeanMetricWrapper):
 
     Standalone usage:
 
-    >>> m = tf.keras.metrics.MeanAbsolutePercentageError()
+    >>> m = keras_core.metrics.MeanAbsolutePercentageError()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])
-    >>> m.result().numpy()
+    >>> m.result()
     250000000.0
     >>> m.reset_state()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]],
     ...                sample_weight=[1, 0])
-    >>> m.result().numpy()
+    >>> m.result()
     500000000.0
 
     Usage with `compile()` API:
@@ -103,7 +118,7 @@ class MeanAbsolutePercentageError(reduction_metrics.MeanMetricWrapper):
     model.compile(
         optimizer='sgd',
         loss='mse',
-        metrics=[tf.keras.metrics.MeanAbsolutePercentageError()])
+        metrics=[keras_core.metrics.MeanAbsolutePercentageError()])
     ```
     """
 
@@ -116,8 +131,13 @@ class MeanAbsolutePercentageError(reduction_metrics.MeanMetricWrapper):
 
 @keras_core_export("keras_core.metrics.MeanSquaredLogarithmicError")
 class MeanSquaredLogarithmicError(reduction_metrics.MeanMetricWrapper):
-    """Computes the mean squared logarithmic error between `y_true` and
-    `y_pred`.
+    """Computes mean squared logarithmic error between `y_true` and `y_pred`.
+
+    Formula:
+
+    ```python
+    loss = mean(square(log(y_true + 1) - log(y_pred + 1)))
+    ```
 
     Args:
         name: (Optional) string name of the metric instance.
@@ -127,14 +147,14 @@ class MeanSquaredLogarithmicError(reduction_metrics.MeanMetricWrapper):
 
     Standalone usage:
 
-    >>> m = tf.keras.metrics.MeanSquaredLogarithmicError()
+    >>> m = keras_core.metrics.MeanSquaredLogarithmicError()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])
-    >>> m.result().numpy()
+    >>> m.result()
     0.12011322
     >>> m.reset_state()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]],
     ...                sample_weight=[1, 0])
-    >>> m.result().numpy()
+    >>> m.result()
     0.24022643
 
     Usage with `compile()` API:
@@ -143,7 +163,7 @@ class MeanSquaredLogarithmicError(reduction_metrics.MeanMetricWrapper):
     model.compile(
         optimizer='sgd',
         loss='mse',
-        metrics=[tf.keras.metrics.MeanSquaredLogarithmicError()])
+        metrics=[keras_core.metrics.MeanSquaredLogarithmicError()])
     ```
     """
 
@@ -159,7 +179,10 @@ class CosineSimilarity(reduction_metrics.MeanMetricWrapper):
     """Computes the cosine similarity between the labels and predictions.
 
     Formula:
-    `cosine similarity = (a . b) / ||a|| ||b||`
+
+    ```python
+    loss = sum(l2_norm(y_true) * l2_norm(y_pred))
+    ```
     See: [Cosine Similarity](https://en.wikipedia.org/wiki/Cosine_similarity).
     This metric keeps the average cosine similarity between `predictions` and
     `labels` over a stream of data.
@@ -179,14 +202,14 @@ class CosineSimilarity(reduction_metrics.MeanMetricWrapper):
     >>> # l2_norm(y_true) . l2_norm(y_pred) = [[0., 0.], [0.5, 0.5]]
     >>> # result = mean(sum(l2_norm(y_true) . l2_norm(y_pred), axis=1))
     >>> #        = ((0. + 0.) +  (0.5 + 0.5)) / 2
-    >>> m = tf.keras.metrics.CosineSimilarity(axis=1)
+    >>> m = keras_core.metrics.CosineSimilarity(axis=1)
     >>> m.update_state([[0., 1.], [1., 1.]], [[1., 0.], [1., 1.]])
-    >>> m.result().numpy()
+    >>> m.result()
     0.49999997
     >>> m.reset_state()
     >>> m.update_state([[0., 1.], [1., 1.]], [[1., 0.], [1., 1.]],
     ...                sample_weight=[0.3, 0.7])
-    >>> m.result().numpy()
+    >>> m.result()
     0.6999999
 
     Usage with `compile()` API:
@@ -195,7 +218,7 @@ class CosineSimilarity(reduction_metrics.MeanMetricWrapper):
     model.compile(
         optimizer='sgd',
         loss='mse',
-        metrics=[tf.keras.metrics.CosineSimilarity(axis=1)])
+        metrics=[keras_core.metrics.CosineSimilarity(axis=1)])
     ```
     """
 
@@ -211,8 +234,11 @@ class LogCoshError(reduction_metrics.MeanMetricWrapper):
     """Computes the logarithm of the hyperbolic cosine of the prediction error.
 
     Formula:
-    `logcosh = log((exp(x) + exp(-x))/2)`, where x is the error (y_pred -
-    y_true)
+
+    ```python
+    error = y_pred - y_true
+    logcosh = mean(log((exp(error) + exp(-error))/2), axis=-1)
+    ```
 
     Args:
         name: (Optional) string name of the metric instance.
@@ -222,14 +248,14 @@ class LogCoshError(reduction_metrics.MeanMetricWrapper):
 
     Standalone usage:
 
-    >>> m = tf.keras.metrics.LogCoshError()
+    >>> m = keras_core.metrics.LogCoshError()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]])
-    >>> m.result().numpy()
+    >>> m.result()
     0.10844523
     >>> m.reset_state()
     >>> m.update_state([[0, 1], [0, 0]], [[1, 1], [0, 0]],
     ...                sample_weight=[1, 0])
-    >>> m.result().numpy()
+    >>> m.result()
     0.21689045
 
     Usage with `compile()` API:
@@ -237,7 +263,7 @@ class LogCoshError(reduction_metrics.MeanMetricWrapper):
     ```python
     model.compile(optimizer='sgd',
                   loss='mse',
-                  metrics=[tf.keras.metrics.LogCoshError()])
+                  metrics=[keras_core.metrics.LogCoshError()])
     ```
     """
 
@@ -252,6 +278,7 @@ def cosine_similarity(y_true, y_pred, axis=-1):
     """Computes the cosine similarity between labels and predictions.
 
     Formula:
+
     ```python
     loss = sum(l2_norm(y_true) * l2_norm(y_pred))
     ```

--- a/keras_core/metrics/regression_metrics_test.py
+++ b/keras_core/metrics/regression_metrics_test.py
@@ -112,7 +112,7 @@ class MeanAbsoluteErrorTest(testing.TestCase):
             [[0, 0, 1, 1, 0], [1, 1, 1, 1, 1], [0, 1, 0, 1, 0], [1, 1, 1, 1, 1]]
         )
 
-        update_op = mae_obj.update_state(y_true, y_pred)
+        mae_obj.update_state(y_true, y_pred)
         result = mae_obj.result()
         self.assertAllClose(0.5, result, atol=1e-5)
 


### PR DESCRIPTION
All regression metrics except for RootMeanSquaredError, which requires implementation outside of losses.