### PR TITLE
Add support for a -1 dimension in the `Reshape` operation.

### DIFF
--- a/keras_core/layers/reshaping/reshape.py
+++ b/keras_core/layers/reshaping/reshape.py
@@ -1,7 +1,6 @@
-import math
-
 from keras_core import operations as ops
 from keras_core.layers.layer import Layer
+from keras_core.operations import operation_utils
 
 
 class Reshape(Layer):
@@ -44,65 +43,13 @@ class Reshape(Layer):
         super().__init__(name=name, dtype=dtype)
         self.target_shape = tuple(target_shape)
 
-    def _fix_unknown_dimension(self, input_shape, output_shape):
-        """Find and replace a missing dimension in an output shape.
-
-        Args:
-            input_shape: Shape of tensor being reshaped as a tuple of ints.
-            output_shape: Desired shape of the tensor as a tuple of ints. It
-                contains at most a single `-1` which indicates a dimension that
-                should be derived from the input shape.
-
-        Returns:
-            The new output shape as a tuple of ints with a -1 replaced with its
-            computed value.
-
-        Raises:
-            ValueError: If the total tensor size of the output_shape is
-                different than the input_shape, or more than one unknown
-                dimension is specified.
-        """
-        msg = (
-            "total size of new tensor must be unchanged, "
-            f"input_shape={input_shape},output_shape={output_shape}"
-        )
-
-        known_output_size, unknown_dim_index = 1, None
-        for index, dim in enumerate(output_shape):
-            if dim == -1:
-                if unknown_dim_index is None:
-                    unknown_dim_index = index
-                else:
-                    raise ValueError(
-                        "There must be at most one unknown dimension in "
-                        f"output_shape. Received: output_shape={output_shape}."
-                    )
-            else:
-                known_output_size *= dim
-
-        input_size = math.prod(input_shape)
-        if unknown_dim_index is not None:
-            if known_output_size == 0 or input_size % known_output_size != 0:
-                raise ValueError(msg)
-            result = list(output_shape)
-            result[unknown_dim_index] = input_size // known_output_size
-            return tuple(result)
-        elif input_size != known_output_size:
-            raise ValueError(msg)
-        return output_shape
-
     def compute_output_shape(self, input_shape):
-        output_shape = (input_shape[0],)
-        if None in input_shape[1:]:
-            # input shape (partially) unknown? replace -1's with None's
-            output_shape += tuple(
-                s if s != -1 else None for s in self.target_shape
-            )
-        else:
-            output_shape += self._fix_unknown_dimension(
-                input_shape[1:], self.target_shape
-            )
-        return output_shape
+        return (
+            input_shape[0],
+            *operation_utils.compute_reshape_output_shape(
+                input_shape[1:], self.target_shape, "target_shape"
+            ),
+        )
 
     def call(self, inputs):
         return ops.reshape(inputs, (inputs.shape[0],) + self.target_shape)

--- a/keras_core/operations/numpy.py
+++ b/keras_core/operations/numpy.py
@@ -138,6 +138,7 @@ import numpy as np
 from keras_core import backend
 from keras_core.backend import KerasTensor
 from keras_core.backend import any_symbolic_tensors
+from keras_core.operations import operation_utils
 from keras_core.operations.operation import Operation
 
 
@@ -2346,7 +2347,10 @@ class Reshape(Operation):
         return backend.numpy.reshape(x, self.new_shape)
 
     def compute_output_spec(self, x):
-        return KerasTensor(self.new_shape, dtype=x.dtype)
+        output_shape = operation_utils.compute_reshape_output_shape(
+            x.shape, self.new_shape, "new_shape"
+        )
+        return KerasTensor(output_shape, dtype=x.dtype)
 
 
 def reshape(x, new_shape):

--- a/keras_core/operations/numpy_test.py
+++ b/keras_core/operations/numpy_test.py
@@ -1016,6 +1016,7 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
     def test_reshape(self):
         x = KerasTensor([None, 3])
         self.assertEqual(knp.reshape(x, (3, 2)).shape, (3, 2))
+        self.assertEqual(knp.reshape(x, (3, -1)).shape, (3, None))
 
     def test_roll(self):
         x = KerasTensor([None, 3])
@@ -1444,6 +1445,9 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
     def test_reshape(self):
         x = KerasTensor([2, 3])
         self.assertEqual(knp.reshape(x, (3, 2)).shape, (3, 2))
+        self.assertEqual(knp.reshape(x, (3, -1)).shape, (3, 2))
+        self.assertEqual(knp.reshape(x, (6,)).shape, (6,))
+        self.assertEqual(knp.reshape(x, (-1,)).shape, (6,))
 
     def test_roll(self):
         x = KerasTensor([2, 3])

--- a/keras_core/operations/operation_utils.py
+++ b/keras_core/operations/operation_utils.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 
 
@@ -111,3 +113,51 @@ def compute_conv_output_shape(
     else:
         output_shape = (input_shape[0], kernel_shape[-1]) + output_spatial_shape
     return output_shape
+
+
+def compute_reshape_output_shape(input_shape, new_shape, new_shape_arg_name):
+    """Converts `-1` in `new_shape` to either an actual dimension or `None`.
+
+    This utility does not special case the 0th dimension (batch size).
+    """
+    unknown_dim_count = new_shape.count(-1)
+    if unknown_dim_count > 1:
+        raise ValueError(
+            "There must be at most one unknown dimension (-1) in "
+            f"{new_shape_arg_name}. Received: {new_shape_arg_name}={new_shape}."
+        )
+
+    # If there is a None in input_shape, we can't infer what the -1 is
+    if None in input_shape:
+        return tuple(dim if dim != -1 else None for dim in new_shape)
+
+    input_size = math.prod(input_shape)
+    # If the new_shape fully defined, return it
+    if unknown_dim_count == 0:
+        if input_size != math.prod(new_shape):
+            raise ValueError(
+                "The total size of the tensor must be unchanged. Received: "
+                f"input_shape={input_shape}, {new_shape_arg_name}={new_shape}"
+            )
+        return new_shape
+
+    # We have one -1 in new_shape, compute the actual value
+    known_output_size = 1
+    unknown_dim_index = None
+    for index, dim in enumerate(new_shape):
+        if dim == -1:
+            unknown_dim_index = index
+        else:
+            known_output_size *= dim
+
+    if known_output_size == 0 or input_size % known_output_size != 0:
+        raise ValueError(
+            "The total size of the tensor must be unchanged, however, the "
+            "input size cannot by divided by the specified dimensions in "
+            f"{new_shape_arg_name}. Received: input_shape={input_shape}, "
+            f"{new_shape_arg_name}={new_shape}"
+        )
+
+    output_shape = list(new_shape)
+    output_shape[unknown_dim_index] = input_size // known_output_size
+    return tuple(output_shape)


### PR DESCRIPTION
The code to compute the output shape is now shared between the `Reshape` operation and the `Reshape` layer.