### PR TITLE
[Paused until Public Repo] Add CodeCov Report to `pytest` run

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,7 +38,7 @@ jobs:
           pip install -e "." --progress-bar off --upgrade
       - name: Test with pytest
         run: |
-          pytest keras_core --cov=keras_core --cov-report xml:coverage.xml
+          pytest keras_core --cov=keras_core
 
   format:
     name: Check the code format

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,7 +38,7 @@ jobs:
           pip install -e "." --progress-bar off --upgrade
       - name: Test with pytest
         run: |
-          pytest keras_core
+          pytest keras_core --cov=keras_core --cov-report xml:coverage.xml
 
   format:
     name: Check the code format

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # KerasCore
 
 [![](https://github.com/keras-team/keras-core/workflows/Tests/badge.svg?branch=main)](https://github.com/keras-team/keras-core/actions?query=workflow%3ATests+branch%3Amain)
-[![codecov](https://codecov.io/gh/keras-team/keras-core/branch/master/graph/badge.svg)](https://codecov.io/gh/keras-team/keras-core)
 
 KerasCore is an multi-backend implementation of the Keras API, with support for TensorFlow, JAX, and PyTorch.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# KerasCore
+
+[![](https://github.com/keras-team/keras-core/workflows/Tests/badge.svg?branch=main)](https://github.com/keras-team/keras-core/actions?query=workflow%3ATests+branch%3Amain)
+[![codecov](https://codecov.io/gh/keras-team/keras-core/branch/master/graph/badge.svg)](https://codecov.io/gh/keras-team/keras-core)
+
+KerasCore is an multi-backend implementation of the Keras API, with support for TensorFlow, JAX, and PyTorch.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,0 @@
-coverage:
-  status:
-    patch:
-      default:
-        target: 100%

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ black>=22
 flake8
 isort
 pytest
+pytest-cov
 pandas
 absl-py
 requests


### PR DESCRIPTION
Adds Code Coverage Report to `pytest` runs. Will integrate with `codecov.io` after the repo is made public.