### PR TITLE
[WIP] Add torch data adapter

### DIFF
--- a/keras_core/trainers/data_adapters/torch_data_adapter.py
+++ b/keras_core/trainers/data_adapters/torch_data_adapter.py
@@ -41,7 +41,7 @@ class TorchDataLoaderAdapter(DataAdapter):
             shape = x.shape
             if len(shape) < 1:
                 raise ValueError(
-                    "When passing a Python generator to a Keras model, "
+                    "When passing a Pytorch DataLoader to a Keras model, "
                     "the arrays returned by the generator "
                     "must be at least rank 1. Received: "
                     f"{x} of rank {len(x.shape)}"

--- a/keras_core/trainers/data_adapters/torch_data_adapter_test.py
+++ b/keras_core/trainers/data_adapters/torch_data_adapter_test.py
@@ -1,90 +1,26 @@
 import numpy as np
+import pytest
 import tensorflow as tf
-import torch
-from torch.utils.data import DataLoader
-from torch.utils.data import Dataset
-from torch.utils.data import TensorDataset
 
+from keras_core import backend
 from keras_core import testing
 from keras_core.trainers.data_adapters.torch_data_adapter import (
     TorchDataLoaderAdapter,
 )
 
 
-class SampleDataset(Dataset):
-    def __init__(self, x, y):
-        self.x = x
-        self.y = y
-
-    def __getitem__(self, item):
-        return self.x[item], self.y[item]
-
-    def __len__(self):
-        return len(self.x)
-
-
+@pytest.mark.skipif(
+    backend.backend() != "torch",
+    reason="Backend does not support TorchDataLoaderAdapter.",
+)
 class TestTorchDataLoaderAdapter(testing.TestCase):
     def test_basic_dataloader(self):
+        import torch
+        from torch.utils.data import DataLoader
+        from torch.utils.data import TensorDataset
+
         x = torch.normal(2, 3, size=(34, 4))
         y = torch.normal(1, 3, size=(34, 2))
-        base_ds = SampleDataset(x=x, y=y)
-        base_dataloader = DataLoader(base_ds, batch_size=16)
-        adapter = TorchDataLoaderAdapter(base_dataloader)
-
-        self.assertEqual(adapter.num_batches, 3)
-        self.assertEqual(adapter.batch_size, 16)
-        self.assertEqual(adapter.has_partial_batch, True)
-        self.assertEqual(adapter.partial_batch_size, 2)
-
-        gen = adapter.get_numpy_iterator()
-        for i, batch in enumerate(gen):
-            self.assertEqual(len(batch), 2)
-            bx, by = batch
-            self.assertTrue(isinstance(bx, np.ndarray))
-            self.assertTrue(isinstance(by, np.ndarray))
-            self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(bx.dtype, "float32")
-            if i < 2:
-                self.assertEqual(bx.shape, (16, 4))
-                self.assertEqual(by.shape, (16, 2))
-            else:
-                self.assertEqual(bx.shape, (2, 4))
-                self.assertEqual(by.shape, (2, 2))
-
-        ds = adapter.get_torch_dataloader()
-        for i, batch in enumerate(ds):
-            self.assertEqual(len(batch), 2)
-            bx, by = batch
-            self.assertTrue(isinstance(bx, torch.Tensor))
-            self.assertTrue(isinstance(by, torch.Tensor))
-            self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(bx.dtype, torch.float32)
-            if i < 2:
-                self.assertEqual(tuple(bx.shape), (16, 4))
-                self.assertEqual(tuple(by.shape), (16, 2))
-            else:
-                self.assertEqual(tuple(bx.shape), (2, 4))
-                self.assertEqual(tuple(by.shape), (2, 2))
-
-        ds = adapter.get_tf_dataset()
-        for i, batch in enumerate(ds):
-            self.assertEqual(len(batch), 2)
-            bx, by = batch
-            self.assertTrue(isinstance(bx, tf.Tensor))
-            self.assertTrue(isinstance(by, tf.Tensor))
-            self.assertEqual(bx.dtype, by.dtype)
-            self.assertEqual(bx.dtype, tf.float32)
-            if i < 2:
-                self.assertEqual(tuple(bx.shape), (16, 4))
-                self.assertEqual(tuple(by.shape), (16, 2))
-            else:
-                self.assertEqual(tuple(bx.shape), (2, 4))
-                self.assertEqual(tuple(by.shape), (2, 2))
-
-    def test_with_torchdataset(self):
-        x = torch.normal(2, 3, size=(34, 4))
-        y = torch.normal(1, 3, size=(34, 2))
-
         base_ds = TensorDataset(x, y)
         base_dataloader = DataLoader(base_ds, batch_size=16)
         adapter = TorchDataLoaderAdapter(base_dataloader)


### PR DESCRIPTION
@fchollet this is the first rough version of torch data adapter. A few points to note:

1. The right way to pass class weights in a `Dataloader` instance is to pass the weights via the `sampler` argument. 
2. We accept an instance of Dataloader in our data adapter. Hence class weights can't be added afterwards. One way to get rid of this is to accept all the arguments that the `Dataloader` class accepts within our data adapter, and then creating an instance with the data adapter. But I am open to any other suggestion you have for this one

I will add the corresponding tests once we agree on the right approach for handling the class weights 