### PR TITLE
Fix optimizer docstring

### DIFF
--- a/keras_core/optimizers/adadelta.py
+++ b/keras_core/optimizers/adadelta.py
@@ -21,9 +21,9 @@ class Adadelta(optimizer.Optimizer):
     learning rate can be set, as in most other Keras optimizers.
 
     Args:
-        learning_rate: A `Tensor`, float, or a schedule that is a
-            `keras_core.optimizers.schedules.LearningRateSchedule`, or a
-            callable that takes no arguments and returns the actual value to
+        learning_rate: A float, a
+            `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
             use. The learning rate. Defaults to 0.001. Note that `Adadelta`
             tends to benefit from higher initial learning rate values compared
             to other optimizers. To match the exact form in the original paper,

--- a/keras_core/optimizers/adafactor.py
+++ b/keras_core/optimizers/adafactor.py
@@ -17,9 +17,9 @@ class Adafactor(optimizer.Optimizer):
     last 2 dimensions separately in its accumulator variables.
 
     Args:
-        learning_rate: A `Tensor`, float, or a schedule that is a
-            `keras_core.optimizers.schedules.LearningRateSchedule`, or a
-            callable that takes no arguments and returns the actual value to
+        learning_rate: A float, a
+            `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
             use. The learning rate. Defaults to 0.001.
         beta_2_decay: float, defaults to -0.8. The decay rate of `beta_2`.
         epsilon_1: float, defaults to 1e-30. A small offset to keep demoninator

--- a/keras_core/optimizers/adagrad.py
+++ b/keras_core/optimizers/adagrad.py
@@ -14,9 +14,9 @@ class Adagrad(optimizer.Optimizer):
     the smaller the updates.
 
     Args:
-        learning_rate: A `Tensor`, float, or a schedule that is a
-            `keras_core.optimizers.schedules.LearningRateSchedule`, or a
-            callable that takes no arguments and returns the actual value to
+        learning_rate: A float, a
+            `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
             use. The learning rate. Defaults to 0.001. Note that `Adagrad` tends
             to benefit from higher initial learning rate values compared to
             other optimizers. To match the exact form in the original paper,

--- a/keras_core/optimizers/adam.py
+++ b/keras_core/optimizers/adam.py
@@ -18,9 +18,9 @@ class Adam(optimizer.Optimizer):
     data/parameters*".
 
     Args:
-        learning_rate: A `Tensor`, float, or a schedule that is a
-            `keras_core.optimizers.schedules.LearningRateSchedule`, or a
-            callable that takes no arguments and returns the actual value to
+        learning_rate: A float, a
+            `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
             use. The learning rate. Defaults to 0.001.
         beta_1: A float value or a constant float tensor, or a callable
             that takes no arguments and returns the actual value to use. The

--- a/keras_core/optimizers/adamax.py
+++ b/keras_core/optimizers/adamax.py
@@ -34,9 +34,9 @@ class Adamax(optimizer.Optimizer):
     ```
 
     Args:
-        learning_rate: A `Tensor`, float, or a schedule that is a
-            `keras_core.optimizers.schedules.LearningRateSchedule`, or a
-            callable that takes no arguments and returns the actual value to
+        learning_rate: A float, a
+            `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
             use. The learning rate. Defaults to 0.001.
         beta_1: A float value or a constant float tensor. The exponential decay
             rate for the 1st moment estimates.

--- a/keras_core/optimizers/adamw.py
+++ b/keras_core/optimizers/adamw.py
@@ -21,9 +21,9 @@ class AdamW(optimizer.Optimizer):
     data/parameters*".
 
     Args:
-        learning_rate: A `Tensor`, float, or a schedule that is a
-            `keras_core.optimizers.schedules.LearningRateSchedule`, or a
-            callable that takes no arguments and returns the actual value to
+        learning_rate: A float, a
+            `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
             use. The learning rate. Defaults to 0.001.
         beta_1: A float value or a constant float tensor, or a callable
             that takes no arguments and returns the actual value to use. The

--- a/keras_core/optimizers/ftrl.py
+++ b/keras_core/optimizers/ftrl.py
@@ -52,9 +52,9 @@ class Ftrl(optimizer.Optimizer):
     is replaced with a gradient with shrinkage.
 
     Args:
-        learning_rate: A `Tensor`, float, or a schedule that is a
-            `keras_core.optimizers.schedules.LearningRateSchedule`, or a
-            callable that takes no arguments and returns the actual value to
+        learning_rate: A float, a
+            `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
             use. The learning rate. Defaults to 0.001.
         learning_rate_power: A float value, must be less or equal to zero.
             Controls how the learning rate decreases during training. Use zero

--- a/keras_core/optimizers/nadam.py
+++ b/keras_core/optimizers/nadam.py
@@ -12,9 +12,9 @@ class Nadam(optimizer.Optimizer):
     Nesterov momentum.
 
     Args:
-        learning_rate: A `Tensor`, float, or a schedule that is a
-            `keras_core.optimizers.schedules.LearningRateSchedule`, or a
-            callable that takes no arguments and returns the actual value to
+        learning_rate: A float, a
+            `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
             use. The learning rate. Defaults to 0.001.
         beta_1: A float value or a constant float tensor, or a callable
             that takes no arguments and returns the actual value to use. The

--- a/keras_core/optimizers/rmsprop.py
+++ b/keras_core/optimizers/rmsprop.py
@@ -18,9 +18,9 @@ class RMSprop(optimizer.Optimizer):
     gradients, and uses that average to estimate the variance.
 
     Args:
-        learning_rate: A `Tensor`, float, or a schedule that is a
-            `keras_core.optimizers.schedules.LearningRateSchedule`, or a
-            callable that takes no arguments and returns the actual value to
+        learning_rate: A float, a
+            `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
             use. The learning rate. Defaults to 0.001.
         rho: float, defaults to 0.9. Discounting factor for the old gradients.
         momentum: float, defaults to 0.0. If not 0.0., the optimizer tracks the

--- a/keras_core/optimizers/sgd.py
+++ b/keras_core/optimizers/sgd.py
@@ -26,10 +26,10 @@ class SGD(optimizer.Optimizer):
     ```
 
     Args:
-        learning_rate: A `Tensor`, float, or a schedule that is a
-            `keras_core.optimizers.schedules.LearningRateSchedule`, or a
-            callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.001.
+        learning_rate: A float, a
+            `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
+            a callable that takes no arguments and returns the actual value to
+            use. The learning rate. Defaults to 0.01.
         momentum: float hyperparameter >= 0 that accelerates gradient descent in
             the relevant direction and dampens oscillations. Defaults to 0,
             i.e., vanilla gradient descent.


### PR DESCRIPTION
The main problem is `learning_rate` is documented as must be a float number.