### PR TITLE
Support compute_output_spec in torch

### DIFF
--- a/integration_tests/torch_backend_keras_workflow.py
+++ b/integration_tests/torch_backend_keras_workflow.py
@@ -2,22 +2,88 @@ import numpy as np
 
 import keras_core
 from keras_core import layers
+from keras_core import operations as ops
 
+keras_core.utils.set_random_seed(1337)
+x = np.random.rand(100, 32, 32, 3)
+y = np.random.randint(0, 2, size=(100, 1))
+
+# Test sequential model.
 model = keras_core.Sequential(
     [
+        layers.Conv2D(filters=10, kernel_size=3),
+        layers.GlobalAveragePooling2D(),
         layers.Dense(1, activation="sigmoid"),
     ]
 )
 model.compile(
     loss="binary_crossentropy", optimizer="adam", metrics=["mae", "accuracy"]
 )
-x = np.random.rand(100, 10)
-y = np.random.randint(0, 2, size=(100, 1))
 history = model.fit(
     x=x,
     y=y,
     epochs=10,
-    shuffle=False,
     validation_data=(x, y),
+    verbose=0,
 )
-model.predict(x)
+model.evaluate(x, y, verbose=0)
+model.predict(x, verbose=0)
+
+# Test functional model.
+inputs = keras_core.Input(shape=(32, 32, 3))
+outputs = layers.Conv2D(filters=10, kernel_size=3)(inputs)
+outputs = layers.GlobalAveragePooling2D()(outputs)
+outputs = layers.Dense(1)(outputs)
+model = keras_core.Model(inputs, outputs)
+model.compile(
+    loss="binary_crossentropy", optimizer="adam", metrics=["mae", "accuracy"]
+)
+history = model.fit(
+    x=x,
+    y=y,
+    epochs=10,
+    validation_data=(x, y),
+    verbose=0,
+)
+model.evaluate(x, y, verbose=0)
+model.predict(x, verbose=0)
+
+
+# Test custom layer
+class Linear(layers.Layer):
+    def __init__(self, units=32):
+        super().__init__()
+        self.units = units
+
+    def build(self, input_shape):
+        self.w = self.add_weight(
+            shape=(input_shape[-1], self.units),
+            initializer="random_normal",
+            trainable=True,
+        )
+        self.b = self.add_weight(
+            shape=(self.units,), initializer="random_normal", trainable=True
+        )
+
+    def call(self, inputs):
+        return ops.matmul(inputs, self.w) + self.b
+
+
+inputs = keras_core.Input(shape=(32, 32, 3))
+outputs = layers.Conv2D(filters=10, kernel_size=3)(inputs)
+outputs = layers.GlobalAveragePooling2D()(outputs)
+outputs = Linear(1)(outputs)
+outputs = layers.Activation("sigmoid")(outputs)
+model = keras_core.Model(inputs, outputs)
+model.compile(
+    loss="binary_crossentropy", optimizer="adam", metrics=["mae", "accuracy"]
+)
+history = model.fit(
+    x=x,
+    y=y,
+    epochs=10,
+    validation_data=(x, y),
+    verbose=0,
+)
+model.evaluate(x, y, verbose=0)
+model.predict(x, verbose=0)


### PR DESCRIPTION
Do we have to use symbolic tensors to infer the output shape and dtypes?
I do not find one yet.
Need a initial review before procceeding.