### PR TITLE
Fixes Torch Truncated Normal Random

### DIFF
--- a/keras_core/backend/torch/random.py
+++ b/keras_core/backend/torch/random.py
@@ -47,6 +47,10 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
 def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
     """Produce random number based on the uniform distribution.
 
+    The generated values follow a uniform distribution in the range
+    `[minval, maxval)`. The lower bound `minval` is included in the range,
+    while the upper bound `maxval` is excluded.
+
     Args:
         shape: The shape of the random values to generate.
         minval: Floats, defaults to 0. Lower bound of the range of
@@ -76,6 +80,10 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
 
 def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     """Produce random number based on the truncated normal distribution.
+
+    The values are drawn from a normal distribution with specified mean and
+    standard deviation, discarding and re-drawing any samples that are more
+    than two standard deviations from the mean.
 
     Args:
         shape: The shape of the random values to generate.


### PR DESCRIPTION
Ran `pytest keras_core/random/random_test.py` and fixed Truncated Normal that was failing test when Mean and stddev were not standard normal.

Also, used Normal Distribution to create Truncated Normal. 

Adopted code snippet from this discussion: https://discuss.pytorch.org/t/implementing-truncated-normal-initializer/4778/16

After this change only `dropout` doesn't use the seed generator and we have a TODO to come back and update it.
