### PR TITLE
Fix some problems in torch backend numpy

### DIFF
--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -341,8 +341,6 @@ def full(shape, fill_value, dtype=None):
     if len(fill_value.shape) > 0:
         # `torch.full` only supports scala `fill_value`.
         expand_size = len(shape) - len(fill_value.shape)
-        expand_index = [None] * expand_size + [...]
-        fill_value = fill_value[expand_index]
         tile_shape = tuple(shape[:expand_size]) + (1,) * len(fill_value.shape)
         return torch.tile(fill_value, tile_shape)
 
@@ -828,11 +826,8 @@ def eye(N, M=None, k=None, dtype="float32"):
     dtype = to_torch_dtype(dtype)
     M = N if M is None else M
     k = 0 if k is None else k
-    shorter_side = np.minimum(N, M)
-    if k > 0:
-        remaining = M - k
-    else:
-        remaining = N + k
-    diag_length = int(np.maximum(0, np.minimum(remaining, shorter_side)))
+    if k == 0:
+        return torch.eye(N, M, dtype=dtype)
+    diag_length = np.maximum(N, M)
     diag = torch.ones(diag_length, dtype=dtype)
     return torch.diag(diag, diagonal=k)[:N, :M]

--- a/keras_core/operations/numpy_test.py
+++ b/keras_core/operations/numpy_test.py
@@ -3032,14 +3032,7 @@ class NumpyArrayCreateOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(np.array(knp.zeros([2, 3])), np.zeros([2, 3]))
         self.assertAllClose(np.array(knp.Zeros()([2, 3])), np.zeros([2, 3]))
 
-    @pytest.mark.skipif(
-        backend.backend() == "torch",
-        reason="`torch.eye` does not support arg `k`.",
-    )
     def test_eye(self):
-        # TODO: implement support for `k` diagonal arg,
-        # does not exist in torch.eye()
-
         self.assertAllClose(np.array(knp.eye(3)), np.eye(3))
         self.assertAllClose(np.array(knp.eye(3, 4)), np.eye(3, 4))
         self.assertAllClose(np.array(knp.eye(3, 4, 1)), np.eye(3, 4, 1))


### PR DESCRIPTION
There a few minor issues:
- `cross` we should just throw valueError since we don't need to have those `axisa...` args.
- `full()` should not assume the value is either scalar or 1D vector.