### PR TITLE
Enable Keras layers in PyTorch workflow

### DIFF
--- a/integration_tests/layer_in_torch_workflow.py
+++ b/integration_tests/layer_in_torch_workflow.py
@@ -1,0 +1,20 @@
+import torch
+
+from keras_core import layers
+
+
+class Net(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = layers.Dense(1)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        return x
+
+
+net = Net()
+
+assert list(net(torch.empty(100, 10)).shape) == [100, 1]
+assert len(list(net.parameters())) == 2
+optimizer = torch.optim.SGD(net.parameters(), lr=1e-3)

--- a/keras_core/backend/common/variables.py
+++ b/keras_core/backend/common/variables.py
@@ -446,6 +446,10 @@ def standardize_shape(
 def is_float_dtype(dtype):
     if hasattr(dtype, "name"):
         dtype = dtype.name
+    # The is a torch.dtype when using torch backend.
+    # Need to convert it to a str.
+    if not isinstance(dtype, str):
+        dtype = str(dtype).split(".")[-1]
     return dtype.startswith("float") or dtype.startswith("bfloat")
 
 

--- a/keras_core/backend/jax/layer.py
+++ b/keras_core/backend/jax/layer.py
@@ -1,0 +1,2 @@
+class JaxLayer:
+    pass

--- a/keras_core/backend/tensorflow/layer.py
+++ b/keras_core/backend/tensorflow/layer.py
@@ -1,0 +1,2 @@
+class TFLayer:
+    pass

--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import torch
 
 from keras_core.backend.common import KerasVariable
@@ -70,7 +72,7 @@ def cast(x, dtype):
 
 
 def name_scope(name):
-    raise NotImplementedError
+    return contextlib.nullcontext()
 
 
 # Shape / dtype inference util

--- a/keras_core/backend/torch/layer.py
+++ b/keras_core/backend/torch/layer.py
@@ -1,0 +1,13 @@
+import torch
+
+from keras_core.operations.operation import Operation
+
+
+class TorchLayer(torch.nn.Module):
+    def forward(self, *args, **kwargs):
+        # TODO: find a good place to add the params. It should be added right
+        # after the variables are initialized.
+        self.params = torch.nn.ParameterList(
+            [variable.value for variable in self.variables]
+        )
+        return Operation.__call__(self, *args, **kwargs)


### PR DESCRIPTION
This a basic implementation of the idea of Layer mixin.
The `LayerMixin` in the torch backend ensures when a layer is called, the functions are called in the following order: `Layer.__call__`, `nn.Module.__call__`, `LayerMixin.forward`, `Operation.__call__`, `CustomLayer.call()`.

It triggers [this warning](https://github.com/pytorch/pytorch/blob/v2.0.1/torch/csrc/utils/python_arg_parser.cpp#L360-L368). The reason is unclear.

The `@torch.jit.script` and `@torch.jit.trace` still don't work because it would parse the `nn.Module` by calling all of its attributes, methods and properties.
The `@torch.jit.ignore` can prevent it from calling and parsing an method, but doesn't work with `@property`.
Therefore, it would fail in the following ways:
* It calls every property, many of which would raise an error, for example, `input()` and `output()`.
* It doesn't support some types, for example, `layer.variable_type` and `layer.dtype_policy.compute_dtype`.
* It doesn't support for loop with if in list, for example, `[v for v in self.variables if v.trainable]` in the `trainable_variables()`.

We may need to find other ways to support TorchScript instead of modifying the code in `Layer` to make it compatible.
