### PR TITLE
Remove useless property from mha layer

### DIFF
--- a/keras_core/layers/attention/multi_head_attention.py
+++ b/keras_core/layers/attention/multi_head_attention.py
@@ -134,7 +134,6 @@ class MultiHeadAttention(Layer):
                 f"Received: attention_axes={attention_axes}"
             )
         self._attention_axes = attention_axes
-        self._built_from_signature = False
 
     def get_config(self):
         base_config = super().get_config()


### PR DESCRIPTION
The _built_from_signature property is no longer used or useful.