### PR TITLE
Support the `trainable` keyword in Functional models

### DIFF
--- a/keras_core/models/functional.py
+++ b/keras_core/models/functional.py
@@ -143,7 +143,13 @@ class Functional(Function, Model):
                 f"(of type {type(outputs)})"
             )
 
+        trainable = kwargs.pop("trainable", None)
+
         Function.__init__(self, inputs, outputs, name=name, **kwargs)
+
+        if trainable is not None:
+            self.trainable = trainable
+
         self._layers = self.layers
         self.built = True
 
@@ -499,6 +505,7 @@ class Functional(Function, Model):
 
         # Create lits of input and output tensors and return new class
         name = config.get("name")
+        trainable = config.get("trainable")
         input_tensors = []
         output_tensors = []
         for layer_data in config["input_layers"]:
@@ -517,7 +524,12 @@ class Functional(Function, Model):
                 node_index
             ].output_tensors
             output_tensors.append(layer_output_tensors[tensor_index])
-        return cls(inputs=input_tensors, outputs=output_tensors, name=name)
+        return cls(
+            inputs=input_tensors,
+            outputs=output_tensors,
+            name=name,
+            trainable=trainable,
+        )
 
 
 def operation_fn(operation, training):

--- a/keras_core/models/functional_test.py
+++ b/keras_core/models/functional_test.py
@@ -164,7 +164,7 @@ class FunctionalTest(testing.TestCase):
         # Test basic model
         inputs = Input(shape=(3,), batch_size=2)
         outputs = layers.Dense(3)(inputs)
-        model = Functional(inputs, outputs)
+        model = Functional(inputs, outputs, trainable=False)
         self.run_class_serialization_test(model)
 
         # Test multi-io model


### PR DESCRIPTION
We discovered in https://github.com/ianstenbit/keras-cv/pull/2/files that initializing a `Functional` model in Keras Core with the `trainable` keyword arg throws an error.

I've re-run the affected test after installing `keras_core` with this change, and the error no longer shows up.

Original error:
```
>       Function.__init__(self, inputs, outputs, name=name, **kwargs)
E       TypeError: __init__() got an unexpected keyword argument 'trainable'
```