### PR TITLE
implement evaluate() for torch backend

### DIFF
--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -39,7 +39,8 @@ class Variable(KerasVariable):
         self._value.requires_grad_(self.trainable)
 
     def _direct_assign(self, value):
-        self._value.copy_(value)
+        with torch.no_grad():
+            self._value.copy_(value)
 
     def _convert_to_tensor(self, value, dtype=None):
         return convert_to_tensor(value, dtype=dtype)

--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -300,7 +300,7 @@ def empty(shape, dtype="float32"):
 
 def equal(x1, x2):
     x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
-    return torch.equal(x1, x2)
+    return torch.eq(x1, x2)
 
 
 def exp(x):


### PR DESCRIPTION
Other notable changes:
* It also includes one minor bug fix for torch numpy `equal()` function. `torch.equal()` is "all equal", which returns a single boolean, while `torch.eq()` return element-wise compare results.
* When assign new value to `KerasVariable`, use `torch.no_grad()`. Otherwise, `torch` would try to get gradients of the update value operation, which may throw an error.

I was able to run `numerical_test.py`.
It fails when the number of training sample >= 296, and succeeded while <= 295.
A larger gap in metrics appears at the increase of this single sample.
It looks like an accumulated error from small errors.
