### PR TITLE
add predict() to torch trainer

### DIFF
--- a/integration_tests/numerical_test.py
+++ b/integration_tests/numerical_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 from tensorflow import keras
 
 import keras_core
@@ -81,10 +82,13 @@ def numerical_test():
     keras_core_model = build_keras_model(keras_core, NUM_CLASSES)
 
     # Make sure both model have same weights before training
-    keras_core_model.set_weights(keras_model.weights)
+    weights = [weight.numpy() for weight in keras_model.weights]
+    keras_core_model.set_weights(weights)
 
     for kw, kcw in zip(keras_model.weights, keras_core_model.weights):
-        np.testing.assert_allclose(kw, kcw)
+        if torch.is_tensor(kcw.value):
+            kcw = kcw.value.detach().numpy()
+        np.testing.assert_allclose(kw.numpy(), kcw)
 
     keras_history = train_model(keras_model, x_train, y_train)
     keras_core_history = train_model(keras_core_model, x_train, y_train)

--- a/integration_tests/torch_backend_keras_workflow.py
+++ b/integration_tests/torch_backend_keras_workflow.py
@@ -5,13 +5,19 @@ from keras_core import layers
 
 model = keras_core.Sequential(
     [
-        layers.Dense(1),
+        layers.Dense(1, activation="sigmoid"),
     ]
 )
-model.compile(loss="mse", optimizer="adam", metrics=["mae"])
+model.compile(
+    loss="binary_crossentropy", optimizer="adam", metrics=["mae", "accuracy"]
+)
+x = np.random.rand(100, 10)
+y = np.random.randint(0, 2, size=(100, 1))
 history = model.fit(
-    x=np.random.rand(100, 10),
-    y=np.random.rand(100, 1),
+    x=x,
+    y=y,
     epochs=10,
     shuffle=False,
+    validation_data=(x, y),
 )
+model.predict(x)


### PR DESCRIPTION
Some other changes:
* The `integration_test/numerical_test.py` now run with torch backend, but the
  numerics are not the same.
