### PR TITLE
fix math.segment_sum for torch backend

### DIFF
--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -58,7 +58,7 @@ def max(x, axis=None, keepdims=False, initial=None):
         result = result.values
 
     if initial is not None:
-        return torch.maximum(result, initial)
+        return torch.maximum(result, torch.full(result.shape, initial))
     return result
 
 

--- a/keras_core/operations/math_test.py
+++ b/keras_core/operations/math_test.py
@@ -103,6 +103,15 @@ class MathOpsCorrectnessTest(testing.TestCase):
         )
         self.assertAllClose(outputs, expected)
 
+        # Test 1D with -1 case.
+        data = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.float32)
+        segment_ids = np.array([0, 0, 1, 1, -1, 2, 2, -1], dtype=np.int32)
+        outputs = kmath.segment_sum(data, segment_ids, num_segments=4)
+        expected = tf.math.unsorted_segment_sum(
+            data, segment_ids, num_segments=4
+        )
+        self.assertAllClose(outputs, expected)
+
         # Test N-D case.
         data = np.random.rand(9, 3, 3)
         segment_ids = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int32)


### PR DESCRIPTION
Fixed `math.segment_sum` to support negative values in indices, which means to ignore the value when calculating the sum.
also fixed torch numpy.max. The `torch.maximum()` only takes tensors of same shapes, not single value.
