### PR TITLE
Allow `RNN` layer's `state_size` argument to be a tuple of ints.

### DIFF
--- a/keras_core/layers/rnn/rnn.py
+++ b/keras_core/layers/rnn/rnn.py
@@ -26,7 +26,7 @@ class RNN(Layer):
             section "Note on passing external constants" below.
             - A `state_size` attribute. This can be a single integer
             (single state) in which case it is the size of the recurrent
-            state. This can also be a list of integers
+            state. This can also be a list/tuple of integers
             (one size per state).
             - A `output_size` attribute, a single integer.
             - A `get_initial_state(batch_size=None)`
@@ -227,16 +227,16 @@ class RNN(Layer):
             raise ValueError(
                 "state_size must be specified as property on the RNN cell."
             )
-        if not isinstance(state_size, (list, int)):
+        if not isinstance(state_size, (list, tuple, int)):
             raise ValueError(
-                "state_size must be an integer, or a list of integers "
+                "state_size must be an integer, or a list/tuple of integers "
                 "(one for each state tensor)."
             )
         if isinstance(state_size, int):
             self.state_size = [state_size]
             self.single_state = True
         else:
-            self.state_size = state_size
+            self.state_size = list(state_size)
             self.single_state = False
 
     def compute_output_shape(self, sequences_shape, initial_state_shape=None):

--- a/keras_core/layers/rnn/rnn_test.py
+++ b/keras_core/layers/rnn/rnn_test.py
@@ -8,10 +8,10 @@ from keras_core import testing
 
 
 class OneStateRNNCell(layers.Layer):
-    def __init__(self, units, **kwargs):
+    def __init__(self, units, state_size=None, **kwargs):
         super().__init__(**kwargs)
         self.units = units
-        self.state_size = units
+        self.state_size = state_size if state_size else units
 
     def build(self, input_shape):
         self.kernel = self.add_weight(
@@ -34,10 +34,10 @@ class OneStateRNNCell(layers.Layer):
 
 
 class TwoStatesRNNCell(layers.Layer):
-    def __init__(self, units, **kwargs):
+    def __init__(self, units, state_size=None, **kwargs):
         super().__init__(**kwargs)
         self.units = units
-        self.state_size = [units, units]
+        self.state_size = state_size if state_size else [units, units]
         self.output_size = units
 
     def build(self, input_shape):
@@ -72,7 +72,27 @@ class RNNTest(testing.TestCase):
     def test_basics(self):
         self.run_layer_test(
             layers.RNN,
-            init_kwargs={"cell": OneStateRNNCell(5)},
+            init_kwargs={"cell": OneStateRNNCell(5, state_size=5)},
+            input_shape=(3, 2, 4),
+            expected_output_shape=(3, 5),
+            expected_num_trainable_weights=2,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=0,
+            supports_masking=True,
+        )
+        self.run_layer_test(
+            layers.RNN,
+            init_kwargs={"cell": OneStateRNNCell(5, state_size=[5])},
+            input_shape=(3, 2, 4),
+            expected_output_shape=(3, 5),
+            expected_num_trainable_weights=2,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=0,
+            supports_masking=True,
+        )
+        self.run_layer_test(
+            layers.RNN,
+            init_kwargs={"cell": OneStateRNNCell(5, state_size=(5,))},
             input_shape=(3, 2, 4),
             expected_output_shape=(3, 5),
             expected_num_trainable_weights=2,
@@ -106,7 +126,17 @@ class RNNTest(testing.TestCase):
         )
         self.run_layer_test(
             layers.RNN,
-            init_kwargs={"cell": TwoStatesRNNCell(5)},
+            init_kwargs={"cell": TwoStatesRNNCell(5, state_size=[5, 5])},
+            input_shape=(3, 2, 4),
+            expected_output_shape=(3, 5),
+            expected_num_trainable_weights=3,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=0,
+            supports_masking=True,
+        )
+        self.run_layer_test(
+            layers.RNN,
+            init_kwargs={"cell": TwoStatesRNNCell(5, state_size=(5, 5))},
             input_shape=(3, 2, 4),
             expected_output_shape=(3, 5),
             expected_num_trainable_weights=3,


### PR DESCRIPTION
The `tf.keras` documentation and error message mention both list and tuple as options.