### PR TITLE
add comments to torch trainer

### DIFF
--- a/integration_tests/numerical_test.py
+++ b/integration_tests/numerical_test.py
@@ -1,7 +1,7 @@
+import keras_core  # isort: skip, keep it on top for torch test
+
 import numpy as np
 from tensorflow import keras
-
-import keras_core
 
 NUM_CLASSES = 10
 

--- a/keras_core/backend/torch/trainer.py
+++ b/keras_core/backend/torch/trainer.py
@@ -27,7 +27,11 @@ class TorchTrainer(base_trainer.Trainer):
             y_pred = self(x, training=True)
         else:
             y_pred = self(x)
+
+        # Call torch.nn.Module.zero_grad() to clear the leftover gradients for
+        # the weights from the previous train step.
         self.zero_grad()
+
         loss = self.compute_loss(
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
@@ -37,7 +41,11 @@ class TorchTrainer(base_trainer.Trainer):
         if self.trainable_weights:
             # Backpropagation
             trainable_weights = [v for v in self.trainable_weights]
+
+            # Call torch.Tensor.backward() on the loss to compute gradients for
+            # the weights.
             loss.backward()
+
             gradients = [v.value.grad for v in trainable_weights]
 
             # Update weights


### PR DESCRIPTION
As I tested, the two statements commented in this PR are inevitable.
The gradients are stored with the tensors. The `optimizer.zero_grad()`, which is common in a torch workflow, is just to clear all the gradients in all the tensors (variables) it tracks.