### PR TITLE
Fix ops.min dtype issue

### DIFF
--- a/keras_core/backend/tensorflow/numpy.py
+++ b/keras_core/backend/tensorflow/numpy.py
@@ -362,9 +362,10 @@ def min(x, axis=None, keepdims=False, initial=None):
 
     # TensorFlow returns inf by default for an empty list, but for consistency
     # with other backends and the numpy API we want to throw in this case.
+    size_x = size(x)
     tf.assert_greater(
-        size(x),
-        tf.constant(0, dtype=tf.int64),
+        size_x,
+        tf.constant(0, dtype=size_x.dtype),
         message="Cannot compute the min of an empty tensor.",
     )
 


### PR DESCRIPTION
The `min` op explicitly assumed the dtype of the input being `int64`. This PR fixes the issue.

cc @ianstenbit 