### PR TITLE
ensure all logs are python types before passing to callbacks

### DIFF
--- a/keras_core/backend/jax/trainer.py
+++ b/keras_core/backend/jax/trainer.py
@@ -391,7 +391,7 @@ class JAXTrainer(base_trainer.Trainer):
                 }
 
                 # Callbacks
-                callbacks.on_train_batch_end(step, logs)
+                callbacks.on_train_batch_end(step, self._pythonify_logs(logs))
                 if self.stop_training:
                     break
 
@@ -401,7 +401,7 @@ class JAXTrainer(base_trainer.Trainer):
             self.jax_state_sync()
 
             # Override with model metrics instead of last step logs
-            epoch_logs = self._pythonify_logs(self.get_metrics_result())
+            epoch_logs = self.get_metrics_result()
 
             # Run validation.
             if validation_data and self._should_eval(epoch, validation_freq):
@@ -427,7 +427,7 @@ class JAXTrainer(base_trainer.Trainer):
                 val_logs = {
                     "val_" + name: val for name, val in val_logs.items()
                 }
-                epoch_logs.update(self._pythonify_logs(val_logs))
+                epoch_logs.update(val_logs)
 
             callbacks.on_epoch_end(epoch, epoch_logs)
             training_logs = epoch_logs
@@ -528,12 +528,12 @@ class JAXTrainer(base_trainer.Trainer):
                 "non_trainable_variables": non_trainable_variables,
                 "metrics_variables": metrics_variables,
             }
-            callbacks.on_test_batch_end(step, logs)
+            callbacks.on_test_batch_end(step, self._pythonify_logs(logs))
 
         # Reattach state back to model.
         self.jax_state_sync()
 
-        logs = self._pythonify_logs(self.get_metrics_result())
+        logs = self.get_metrics_result()
         callbacks.on_test_end(logs)
         self._jax_state = None
         if return_dict:

--- a/keras_core/backend/tensorflow/trainer.py
+++ b/keras_core/backend/tensorflow/trainer.py
@@ -304,12 +304,14 @@ class TensorFlowTrainer(base_trainer.Trainer):
                 for step, iterator in epoch_iterator.enumerate_epoch():
                     callbacks.on_train_batch_begin(step)
                     logs = self.train_function(iterator)
-                    callbacks.on_train_batch_end(step, logs)
+                    callbacks.on_train_batch_end(
+                        step, self._pythonify_logs(logs)
+                    )
                     if self.stop_training:
                         break
 
             # Override with model metrics instead of last step logs
-            epoch_logs = self._pythonify_logs(self.get_metrics_result())
+            epoch_logs = self.get_metrics_result()
 
             # Run validation.
             if validation_data and self._should_eval(epoch, validation_freq):
@@ -335,7 +337,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
                 val_logs = {
                     "val_" + name: val for name, val in val_logs.items()
                 }
-                epoch_logs.update(self._pythonify_logs(val_logs))
+                epoch_logs.update(val_logs)
 
             callbacks.on_epoch_end(epoch, epoch_logs)
             training_logs = epoch_logs
@@ -407,8 +409,8 @@ class TensorFlowTrainer(base_trainer.Trainer):
             for step, iterator in epoch_iterator.enumerate_epoch():
                 callbacks.on_test_batch_begin(step)
                 logs = self.test_function(iterator)
-                callbacks.on_test_batch_end(step, logs)
-        logs = self._pythonify_logs(self.get_metrics_result())
+                callbacks.on_test_batch_end(step, self._pythonify_logs(logs))
+        logs = self.get_metrics_result()
         callbacks.on_test_end(logs)
 
         if return_dict:

--- a/keras_core/backend/torch/trainer.py
+++ b/keras_core/backend/torch/trainer.py
@@ -144,12 +144,12 @@ class TorchTrainer(base_trainer.Trainer):
                 logs = self.train_step(data)
 
                 # Callbacks
-                callbacks.on_train_batch_end(step, logs)
+                callbacks.on_train_batch_end(step, self._pythonify_logs(logs))
                 if self.stop_training:
                     break
 
             # Override with model metrics instead of last step logs
-            epoch_logs = self._pythonify_logs(self.get_metrics_result())
+            epoch_logs = self.get_metrics_result()
 
             # Switch the torch Module back to testing mode.
             self.eval()
@@ -178,7 +178,7 @@ class TorchTrainer(base_trainer.Trainer):
                 val_logs = {
                     "val_" + name: val for name, val in val_logs.items()
                 }
-                epoch_logs.update(self._pythonify_logs(val_logs))
+                epoch_logs.update(val_logs)
 
             callbacks.on_epoch_end(epoch, epoch_logs)
             training_logs = epoch_logs
@@ -263,8 +263,8 @@ class TorchTrainer(base_trainer.Trainer):
             callbacks.on_test_batch_begin(step)
             with torch.no_grad():
                 logs = self.test_step(data)
-            callbacks.on_test_batch_end(step, logs)
-        logs = self._pythonify_logs(self.get_metrics_result())
+            callbacks.on_test_batch_end(step, self._pythonify_logs(logs))
+        logs = self.get_metrics_result()
         callbacks.on_test_end(logs)
 
         if return_dict:

--- a/keras_core/trainers/trainer.py
+++ b/keras_core/trainers/trainer.py
@@ -230,7 +230,7 @@ class Trainer:
                 return_metrics.update(result)
             else:
                 return_metrics[metric.name] = result
-        return return_metrics
+        return self._pythonify_logs(return_metrics)
 
     def fit(
         self,


### PR DESCRIPTION
The torch backend doesn't work with progbar since progbar is using np operations instead of ops on the metrics values.
Now changing the values from torch tensors to python types in the logs.﻿
