### PR TITLE
Symbolic execution for torch backend

### DIFF
--- a/benchmarks/layer_benchmark/base_benchmark.py
+++ b/benchmarks/layer_benchmark/base_benchmark.py
@@ -239,9 +239,19 @@ class LayerBenchmark:
             # Generate default label if not provided.
             if self.flat_call_inputs:
                 # Scale by a small factor to avoid zero gradients.
-                label = np.array(self._keras_core_layer(*data)) * 1.001
+                label = (
+                    keras_core.backend.convert_to_numpy(
+                        self._keras_core_layer(*data)
+                    )
+                    * 1.001
+                )
             else:
-                label = np.array(self._keras_core_layer(data)) * 1.001
+                label = (
+                    keras_core.backend.convert_to_numpy(
+                        self._keras_core_layer(data)
+                    )
+                    * 1.001
+                )
 
         num_iterations = num_samples // batch_size - 1
         callback = KerasCoreBenchmarkMetricsCallback(stop_batch=num_iterations)

--- a/keras_core/backend/common/variables.py
+++ b/keras_core/backend/common/variables.py
@@ -62,7 +62,6 @@ class KerasVariable:
     def _deferred_initialize(self):
         if self._value is not None:
             raise ValueError(f"Variable {self.name} is already initialized.")
-        from keras_core.backend.common.stateless_scope import in_stateless_scope
 
         if in_stateless_scope():
             raise ValueError(
@@ -381,12 +380,6 @@ PYTHON_DTYPES_MAP = {
     int: "int",  # TBD by backend
     float: "float32",
     str: "string",
-}
-
-PYTHON_DTYPES_MAP = {
-    bool: "bool",
-    int: "int",  # TBD by backend
-    float: "float32",
 }
 
 

--- a/keras_core/backend/torch/layer.py
+++ b/keras_core/backend/torch/layer.py
@@ -1,10 +1,15 @@
 import torch
 
+from keras_core.backend.common.stateless_scope import in_stateless_scope
 from keras_core.operations.operation import Operation
 
 
 class TorchLayer(torch.nn.Module):
     def _post_build(self):
+        # Do not track variables when in a stateless scope.
+        # The variables are not initialized.
+        if in_stateless_scope():
+            return
         self._track_variables()
 
     def _track_variables(self):

--- a/keras_core/backend/torch/random.py
+++ b/keras_core/backend/torch/random.py
@@ -10,9 +10,9 @@ from keras_core.random.seed_generator import draw_seed
 from keras_core.random.seed_generator import make_default_seed
 
 
-def torch_seed_generator(seed, device="cpu"):
+def torch_seed_generator(seed):
     seed_val, _ = draw_seed(seed)
-    generator = torch.Generator(device=device)
+    generator = torch.Generator(device=get_device())
     generator.manual_seed(int(seed_val))
     return generator
 
@@ -20,17 +20,34 @@ def torch_seed_generator(seed, device="cpu"):
 def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     dtype = dtype or floatx()
     dtype = to_torch_dtype(dtype)
+    # Do not use generator during symbolic execution.
+    if get_device() == "meta":
+        return torch.normal(
+            mean, stddev, size=shape, dtype=dtype, device=get_device()
+        )
     generator = torch_seed_generator(seed)
     return torch.normal(
-        mean, stddev, size=shape, generator=generator, dtype=dtype
-    ).to(get_device())
+        mean,
+        stddev,
+        size=shape,
+        generator=generator,
+        dtype=dtype,
+        device=get_device(),
+    )
 
 
 def categorical(logits, num_samples, dtype="int32", seed=None):
     logits = convert_to_tensor(logits)
     dtype = to_torch_dtype(dtype)
-    generator = torch_seed_generator(seed, device=get_device())
     probs = torch.softmax(logits, dim=-1)
+    # Do not use generator during symbolic execution.
+    if get_device() == "meta":
+        return torch.multinomial(
+            probs,
+            num_samples,
+            replacement=True,
+        ).type(dtype)
+    generator = torch_seed_generator(seed)
     return torch.multinomial(
         probs,
         num_samples,
@@ -42,20 +59,40 @@ def categorical(logits, num_samples, dtype="int32", seed=None):
 def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
     dtype = dtype or floatx()
     dtype = to_torch_dtype(dtype)
-    generator = torch_seed_generator(seed)
     if len(shape) == 0:
         shape = (1,)
-    output = (maxval - minval) * torch.rand(
-        *shape, generator=generator, dtype=dtype
-    ) + minval
-    return output.to(get_device())
+    # Do not use generator during symbolic execution.
+    if get_device() == "meta":
+        rand_tensor = torch.rand(size=shape, dtype=dtype, device=get_device())
+    else:
+        generator = torch_seed_generator(seed)
+        rand_tensor = torch.rand(
+            size=shape, generator=generator, dtype=dtype, device=get_device()
+        )
+
+    output = (maxval - minval) * rand_tensor + minval
+    return output
 
 
 def randint(shape, minval, maxval, dtype="int32", seed=None):
     dtype = to_torch_dtype(dtype)
+    # Do not use generator during symbolic execution.
+    if get_device() == "meta":
+        return torch.randint(
+            low=minval,
+            high=maxval,
+            size=shape,
+            dtype=dtype,
+            device=get_device(),
+        )
     generator = torch_seed_generator(seed)
     return torch.randint(
-        low=minval, high=maxval, size=shape, generator=generator, dtype=dtype
+        low=minval,
+        high=maxval,
+        size=shape,
+        generator=generator,
+        dtype=dtype,
+        device=get_device(),
     )
 
 

--- a/keras_core/callbacks/tensorboard.py
+++ b/keras_core/callbacks/tensorboard.py
@@ -495,7 +495,9 @@ class TensorBoard(Callback):
         else:
             lr_schedule = getattr(self.model.optimizer, "lr", None)
         if isinstance(lr_schedule, learning_rate_schedule.LearningRateSchedule):
-            logs["learning_rate"] = lr_schedule(self.model.optimizer.iterations)
+            logs["learning_rate"] = float(
+                lr_schedule(self.model.optimizer.iterations)
+            )
         return logs
 
     def _compute_steps_per_second(self):
@@ -512,7 +514,7 @@ class TensorBoard(Callback):
         steps_per_second = (
             current_iteration - self._previous_epoch_iterations
         ) / time_since_epoch_begin
-        return steps_per_second
+        return float(steps_per_second)
 
     def _log_epoch_metrics(self, epoch, logs):
         """Writes epoch metrics out as scalar summaries.

--- a/keras_core/callbacks/tensorboard_test.py
+++ b/keras_core/callbacks/tensorboard_test.py
@@ -446,7 +446,8 @@ class TestTensorBoardV2(testing.TestCase):
                 tensor = backend.convert_to_tensor(data, dtype="float32")
                 if backend.backend() == "torch":
                     # TODO: Use device scope after the API is added.
-                    tensor = tensor.cpu()
+                    if tensor.is_cuda:
+                        tensor = tensor.cpu()
                 summary.write(
                     tag=tag,
                     tensor=tensor,

--- a/keras_core/layers/preprocessing/normalization.py
+++ b/keras_core/layers/preprocessing/normalization.py
@@ -296,12 +296,17 @@ class Normalization(Layer):
     def call(self, inputs):
         inputs = backend.convert_to_tensor(inputs, dtype=self.compute_dtype)
         if self.invert:
-            return self.mean + (
-                inputs * ops.maximum(ops.sqrt(self.variance), backend.epsilon())
+            return ops.add(
+                self.mean,
+                ops.multiply(
+                    inputs,
+                    ops.maximum(ops.sqrt(self.variance), backend.epsilon()),
+                ),
             )
         else:
-            return (inputs - self.mean) / ops.maximum(
-                ops.sqrt(self.variance), backend.epsilon()
+            return ops.divide(
+                ops.subtract(inputs, self.mean),
+                ops.maximum(ops.sqrt(self.variance), backend.epsilon()),
             )
 
     def compute_output_shape(self, input_shape):

--- a/keras_core/operations/function.py
+++ b/keras_core/operations/function.py
@@ -108,7 +108,7 @@ class Function(Operation):
         # Dictionary mapping reference tensors to computed tensors.
         tensor_dict = {}
         for x, y in zip(self.inputs, inputs):
-            tensor_dict[x] = y
+            tensor_dict[id(x)] = y
 
         nodes_by_depth = self._nodes_by_depth
         depth_keys = list(nodes_by_depth.keys())
@@ -120,7 +120,7 @@ class Function(Operation):
                 if not node.operation or node.is_input:
                     continue  # Input tensors already exist.
 
-                if any(x not in tensor_dict for x in node.input_tensors):
+                if any(id(x) not in tensor_dict for x in node.input_tensors):
                     continue  # Node is not computable, try skipping.
 
                 args, kwargs = node.arguments.fill_in(tensor_dict)
@@ -128,11 +128,11 @@ class Function(Operation):
 
                 # Update tensor_dict.
                 for x, y in zip(node.outputs, nest.flatten(outputs)):
-                    tensor_dict[x] = y
+                    tensor_dict[id(x)] = y
 
         output_tensors = []
         for x in self.outputs:
-            output_tensors.append(tensor_dict[x])
+            output_tensors.append(tensor_dict[id(x)])
 
         return nest.pack_sequence_as(self._outputs_struct, output_tensors)
 

--- a/keras_core/operations/symbolic_arguments.py
+++ b/keras_core/operations/symbolic_arguments.py
@@ -38,11 +38,11 @@ class SymbolicArguments:
         if self._single_positional_tensor is not None:
             # Performance optimization for most common case.
             # Approx. 70x faster.
-            return (tensor_dict[self._single_positional_tensor],), {}
+            return (tensor_dict[id(self._single_positional_tensor)],), {}
 
         def switch_fn(x):
             if isinstance(x, KerasTensor):
-                val = tensor_dict.get(x, None)
+                val = tensor_dict.get(id(x), None)
                 if val is not None:
                     return val
             return x

--- a/keras_core/regularizers/regularizers.py
+++ b/keras_core/regularizers/regularizers.py
@@ -197,8 +197,8 @@ class L1L2(Regularizer):
         validate_float_arg(l1, name="l1")
         validate_float_arg(l2, name="l2")
 
-        self.l1 = ops.convert_to_tensor(l1)
-        self.l2 = ops.convert_to_tensor(l2)
+        self.l1 = l1
+        self.l2 = l2
 
     def __call__(self, x):
         regularization = ops.convert_to_tensor(0.0, dtype=x.dtype)
@@ -261,7 +261,7 @@ class L2(Regularizer):
     def __init__(self, l2=0.01):
         l2 = 0.01 if l2 is None else l2
         validate_float_arg(l2, name="l2")
-        self.l2 = ops.convert_to_tensor(l2)
+        self.l2 = l2
 
     def __call__(self, x):
         return self.l2 * ops.sum(ops.square(x))


### PR DESCRIPTION
The `torch.compile()` still have some failed tests.
So not enabled right now.

This PR enables symbolic build for torch backend.
It places the tensors on the "meta" device to do symbolic execution.

For ops in torch that do not support tensors on the "meta" device,
we handle them on our own op abstractions with special cases, for example, in the op implementations in `torch/numpy.py`.

Next step:
To further reduce overhead,
change all torch tensor creation calls to place tensor on `get_device()` directly instead of creating on CPU and move to the designated device.