### PR TITLE
Export "backend.backend" to config module

### DIFF
--- a/keras_core/backend/config.py
+++ b/keras_core/backend/config.py
@@ -228,16 +228,22 @@ if "KERAS_BACKEND" in os.environ:
         _BACKEND = _backend
 
 
-@keras_core_export("keras_core.backend.backend")
+@keras_core_export(
+    [
+        "keras_core.config.backend",
+        "keras_core.backend.backend",
+    ]
+)
 def backend():
     """Publicly accessible method for determining the current backend.
 
     Returns:
-        String, the name of the backend Keras is currently using.
+        String, the name of the backend Keras is currently using. One of
+            `"tensorflow"`, `"torch"`, or `"jax"`.
 
     Example:
 
-    >>> keras.backend.backend()
+    >>> keras.config.backend()
     'tensorflow'
     """
     return _BACKEND


### PR DESCRIPTION
I think `keras_core.config.backend` is actually a little more readable then `keras_core.backend.backend` for what this function does. And all the other options (e.g. floatx) are exposed both in backend and config modules.