### PR TITLE
Add slice op, rename block_update -> slice_update

### DIFF
--- a/keras_core/backend/jax/core.py
+++ b/keras_core/backend/jax/core.py
@@ -202,14 +202,12 @@ def scatter_update(inputs, indices, updates):
     return inputs
 
 
-def block_update(inputs, start_indices, updates):
-    update_shape = updates.shape
-    slices = [
-        slice(start_index, start_index + update_length)
-        for start_index, update_length in zip(start_indices, update_shape)
-    ]
-    inputs[tuple(slices)] = updates
-    return inputs
+def slice(inputs, start_indices, shape):
+    return jax.lax.dynamic_slice(inputs, start_indices, shape)
+
+
+def slice_update(inputs, start_indices, updates):
+    return jax.lax.dynamic_update_slice(inputs, updates, start_indices)
 
 
 def while_loop(

--- a/keras_core/backend/tensorflow/core.py
+++ b/keras_core/backend/tensorflow/core.py
@@ -141,7 +141,11 @@ def scatter_update(inputs, indices, updates):
     return tf.tensor_scatter_nd_update(inputs, indices, updates)
 
 
-def block_update(inputs, start_indices, updates):
+def slice(inputs, start_indices, shape):
+    return tf.slice(inputs, start_indices, shape)
+
+
+def slice_update(inputs, start_indices, updates):
     return dynamic_update_slice(inputs, updates, start_indices)
 
 

--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -251,15 +251,30 @@ def scatter_update(inputs, indices, updates):
     return inputs
 
 
-def block_update(inputs, start_indices, updates):
+def slice(inputs, start_indices, shape):
+    shape_dtype = to_torch_dtype("int64")
     inputs = convert_to_tensor(inputs)
-    start_indices = convert_to_tensor(start_indices, dtype="int64")
+    start_indices = convert_to_tensor(start_indices).to(shape_dtype)
+    shape = convert_to_tensor(shape).to(shape_dtype)
+
+    python_slice = __builtins__["slice"]
+    slices = [
+        python_slice(start_index, start_index + length)
+        for start_index, length in zip(start_indices, shape)
+    ]
+    return inputs[slices]
+
+
+def slice_update(inputs, start_indices, updates):
+    shape_dtype = to_torch_dtype("int64")
+    inputs = convert_to_tensor(inputs)
+    start_indices = convert_to_tensor(start_indices).to(shape_dtype)
     updates = convert_to_tensor(updates)
 
-    update_shape = updates.shape
+    python_slice = __builtins__["slice"]
     slices = [
-        slice(start_index, start_index + update_length)
-        for start_index, update_length in zip(start_indices, update_shape)
+        python_slice(start_index, start_index + update_length)
+        for start_index, update_length in zip(start_indices, updates.shape)
     ]
     inputs[slices] = updates
     return inputs

--- a/keras_core/operations/core_test.py
+++ b/keras_core/operations/core_test.py
@@ -32,19 +32,19 @@ class CoreOpsStaticShapeTest(testing.TestCase):
             core.scatter_update(inputs, indices, updates).shape, (4, 4, 4)
         )
 
-    def test_block_update(self):
+    def test_slice_update(self):
         inputs = KerasTensor((4, 4))
         start_indices = KerasTensor((2,))
         updates = KerasTensor((2, 2))
         self.assertEqual(
-            core.block_update(inputs, start_indices, updates).shape, (4, 4)
+            core.slice_update(inputs, start_indices, updates).shape, (4, 4)
         )
 
         inputs = KerasTensor((4, 4, 4))
         start_indices = KerasTensor((3,))
         updates = KerasTensor((2, 2, 2))
         self.assertEqual(
-            core.block_update(inputs, start_indices, updates).shape, (4, 4, 4)
+            core.slice_update(inputs, start_indices, updates).shape, (4, 4, 4)
         )
 
 
@@ -119,13 +119,53 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(outputs[1, 1, :], [0, 1, 2, 3])
         self.assertAllClose(outputs[2, 2, :], [3, 2, 1, 0])
 
-    def test_block_update(self):
+    def test_slice(self):
+        # Test 1D.
+        inputs = np.arange(10)
+        start_indices = np.array([1])
+        shape = np.array([4])
+        self.assertAllClose(
+            core.slice(inputs, start_indices, shape),
+            [1, 2, 3, 4],
+        )
+
+        # Test 2D.
+        inputs = np.broadcast_to(np.arange(10), (4, 10))
+        start_indices = np.array([1, 1])
+        shape = np.array([2, 4])
+        self.assertAllClose(
+            core.slice(inputs, start_indices, shape),
+            [[1, 2, 3, 4], [1, 2, 3, 4]],
+        )
+
+        # Test N-D.
+        inputs = np.broadcast_to(np.arange(10), (4, 4, 4, 10))
+        start_indices = np.array([1, 1, 1, 1])
+        shape = np.array([1, 2, 3, 4])
+        outputs = core.slice(inputs, start_indices, shape)
+        expected = np.broadcast_to(np.arange(1, 5), (1, 2, 3, 4))
+        self.assertAllClose(outputs, expected)
+
+    def test_dynamic_slice(self):
+        def cond(index, inputs, sum):
+            return index < 10
+
+        def body(index, inputs, sum):
+            sum = sum + core.slice(inputs, [index], [1])
+            index = index + 1
+            return index, inputs, sum
+
+        index, inputs, sum = 0, np.arange(10), np.array([0])
+        index, inputs, sum = core.while_loop(cond, body, (index, inputs, sum))
+        self.assertAllClose(sum, [45])
+
+    def test_slice_update(self):
         # Test 1D.
         inputs = np.array([0, 0, 0, 0, 0, 0, 0, 0])
         start_indices = [1]
         updates = np.array([9, 10, 11, 12])
         self.assertAllClose(
-            core.block_update(inputs, start_indices, updates),
+            core.slice_update(inputs, start_indices, updates),
             [0, 9, 10, 11, 12, 0, 0, 0],
         )
 
@@ -134,7 +174,7 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         start_indices = [1, 0]
         updates = np.array([[2, 2], [2, 2]])
         self.assertAllClose(
-            core.block_update(inputs, start_indices, updates),
+            core.slice_update(inputs, start_indices, updates),
             [[1, 1], [2, 2], [2, 2]],
         )
 
@@ -142,7 +182,7 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         inputs = np.ones([4, 4, 4, 4])
         start_indices = [1, 1, 2, 2]
         updates = np.zeros([2, 2, 2, 2])
-        outputs = core.block_update(inputs, start_indices, updates)
+        outputs = core.slice_update(inputs, start_indices, updates)
         self.assertAllClose(outputs[1:3, 1:3, 2:4, 2:4], np.zeros([2, 2, 2, 2]))
 
     def test_while_loop(self):


### PR DESCRIPTION
For KerasNLP, we need to be able to slice into a tensor with dynamic tensor indices during generative decoding. This is not supported in a consistent way across frameworks, so we need to wrap a backend agnostic slice op.

While we are doing that, we can rename `block_update` to `slice_update`, to reflex the fact that they have similar signatures, and represent slice getters and setters.