### PR TITLE
Add keras_core.random.randint

### DIFF
--- a/keras_core/backend/__init__.py
+++ b/keras_core/backend/__init__.py
@@ -15,6 +15,7 @@ from keras_core.backend.common.stateless_scope import in_stateless_scope
 from keras_core.backend.common.variables import AutocastScope
 from keras_core.backend.common.variables import get_autocast_scope
 from keras_core.backend.common.variables import is_float_dtype
+from keras_core.backend.common.variables import is_int_dtype
 from keras_core.backend.common.variables import standardize_dtype
 from keras_core.backend.common.variables import standardize_shape
 from keras_core.backend.config import epsilon

--- a/keras_core/backend/common/__init__.py
+++ b/keras_core/backend/common/__init__.py
@@ -3,6 +3,7 @@ from keras_core.backend.common.variables import AutocastScope
 from keras_core.backend.common.variables import KerasVariable
 from keras_core.backend.common.variables import get_autocast_scope
 from keras_core.backend.common.variables import is_float_dtype
+from keras_core.backend.common.variables import is_int_dtype
 from keras_core.backend.common.variables import standardize_dtype
 from keras_core.backend.common.variables import standardize_shape
 from keras_core.random import random

--- a/keras_core/backend/common/variables.py
+++ b/keras_core/backend/common/variables.py
@@ -460,6 +460,11 @@ def is_float_dtype(dtype):
     return dtype.startswith("float") or dtype.startswith("bfloat")
 
 
+def is_int_dtype(dtype):
+    dtype = standardize_dtype(dtype)
+    return dtype.startswith("int") or dtype.startswith("uint")
+
+
 def get_autocast_scope():
     return global_state.get_global_attribute("autocast_scope")
 

--- a/keras_core/backend/jax/random.py
+++ b/keras_core/backend/jax/random.py
@@ -7,26 +7,6 @@ from keras_core.random.seed_generator import make_default_seed
 
 
 def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
-    """Draw random samples from a normal (Gaussian) distribution.
-
-    Args:
-        shape: The shape of the random values to generate.
-        mean: Floats, defaults to 0. Mean of the random values to generate.
-        stddev: Floats, defaults to 1. Standard deviation of the random values
-            to generate.
-        dtype: Optional dtype of the tensor. Only floating point types are
-            supported. If not specified, `keras.backend.floatx()` is used,
-            which defaults to `float32` unless you configured it otherwise (via
-            `keras.backend.set_floatx(float_dtype)`).
-        seed: A Python integer or instance of
-            `keras_core.backend.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras_core.backend.SeedGenerator`.
-    """
     dtype = dtype or floatx()
     seed = draw_seed(seed)
     sample = jax.random.normal(seed, shape=shape, dtype=dtype)
@@ -34,34 +14,6 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
 
 
 def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
-    """Draw samples from a uniform distribution.
-
-    The generated values follow a uniform distribution in the range
-    `[minval, maxval)`. The lower bound `minval` is included in the range,
-    while the upper bound `maxval` is excluded.
-
-    For floats, the default range is `[0, 1)`.  For ints, at least `maxval`
-    must be specified explicitly.
-
-    Args:
-        shape: The shape of the random values to generate.
-        minval: Floats, defaults to 0. Lower bound of the range of
-            random values to generate (inclusive).
-        maxval: Floats, defaults to 1. Upper bound of the range of
-            random values to generate (exclusive).
-        dtype: Optional dtype of the tensor. Only floating point types are
-            supported. If not specified, `keras.backend.floatx()` is used,
-            which defaults to `float32` unless you configured it otherwise (via
-            `keras.backend.set_floatx(float_dtype)`)
-        seed: A Python integer or instance of
-            `keras_core.backend.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras_core.backend.SeedGenerator`.
-    """
     dtype = dtype or floatx()
     seed = draw_seed(seed)
     return jax.random.uniform(
@@ -69,31 +21,14 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
     )
 
 
+def randint(shape, minval, maxval, dtype="int32", seed=None):
+    seed = draw_seed(seed)
+    return jax.random.randint(
+        seed, shape=shape, dtype=dtype, minval=minval, maxval=maxval
+    )
+
+
 def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
-    """Draw samples from a truncated normal distribution.
-
-    The values are drawn from a normal distribution with specified mean and
-    standard deviation, discarding and re-drawing any samples that are more
-    than two standard deviations from the mean.
-
-    Args:
-        shape: The shape of the random values to generate.
-        mean: Floats, defaults to 0. Mean of the random values to generate.
-        stddev: Floats, defaults to 1. Standard deviation of the random values
-            to generate.
-        dtype: Optional dtype of the tensor. Only floating point types are
-            supported. If not specified, `keras.backend.floatx()` is used,
-            which defaults to `float32` unless you configured it otherwise (via
-            `keras.backend.set_floatx(float_dtype)`)
-        seed: A Python integer or instance of
-            `keras_core.backend.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras_core.backend.SeedGenerator`.
-    """
     dtype = dtype or floatx()
     seed = draw_seed(seed)
     sample = jax.random.truncated_normal(

--- a/keras_core/backend/tensorflow/random.py
+++ b/keras_core/backend/tensorflow/random.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 
+from keras_core.backend.common import standardize_dtype
 from keras_core.backend.config import floatx
 from keras_core.random.seed_generator import SeedGenerator
 from keras_core.random.seed_generator import draw_seed
@@ -12,26 +13,6 @@ def tf_draw_seed(seed):
 
 
 def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
-    """Draw random samples from a normal (Gaussian) distribution.
-
-    Args:
-        shape: The shape of the random values to generate.
-        mean: Floats, defaults to 0. Mean of the random values to generate.
-        stddev: Floats, defaults to 1. Standard deviation of the random values
-            to generate.
-        dtype: Optional dtype of the tensor. Only floating point types are
-            supported. If not specified, `keras.backend.floatx()` is used,
-            which defaults to `float32` unless you configured it otherwise (via
-            `keras.backend.set_floatx(float_dtype)`).
-        seed: A Python integer or instance of
-            `keras_core.backend.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras_core.backend.SeedGenerator`.
-    """
     dtype = dtype or floatx()
     seed = tf_draw_seed(seed)
     return tf.random.stateless_normal(
@@ -40,34 +21,6 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
 
 
 def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
-    """Draw samples from a uniform distribution.
-
-    The generated values follow a uniform distribution in the range
-    `[minval, maxval)`. The lower bound `minval` is included in the range,
-    while the upper bound `maxval` is excluded.
-
-    For floats, the default range is `[0, 1)`.  For ints, at least `maxval`
-    must be specified explicitly.
-
-    Args:
-        shape: The shape of the random values to generate.
-        minval: Floats, defaults to 0. Lower bound of the range of
-            random values to generate (inclusive).
-        maxval: Floats, defaults to 1. Upper bound of the range of
-            random values to generate (exclusive).
-        dtype: Optional dtype of the tensor. Only floating point types are
-            supported. If not specified, `keras.backend.floatx()` is used,
-            which defaults to `float32` unless you configured it otherwise (via
-            `keras.backend.set_floatx(float_dtype)`)
-        seed: A Python integer or instance of
-            `keras_core.backend.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras_core.backend.SeedGenerator`.
-    """
     dtype = dtype or floatx()
     seed = tf_draw_seed(seed)
     return tf.random.stateless_uniform(
@@ -79,31 +32,22 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
     )
 
 
+def randint(shape, minval, maxval, dtype="int32", seed=None):
+    intemediate_dtype = dtype
+    if standardize_dtype(dtype) not in ["int32", "int64"]:
+        intemediate_dtype = "int64"
+    seed = tf_draw_seed(seed)
+    output = tf.random.stateless_uniform(
+        shape=shape,
+        minval=minval,
+        maxval=maxval,
+        dtype=intemediate_dtype,
+        seed=seed,
+    )
+    return tf.cast(output, dtype)
+
+
 def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
-    """Draw samples from a truncated normal distribution.
-
-    The values are drawn from a normal distribution with specified mean and
-    standard deviation, discarding and re-drawing any samples that are more
-    than two standard deviations from the mean.
-
-    Args:
-        shape: The shape of the random values to generate.
-        mean: Floats, defaults to 0. Mean of the random values to generate.
-        stddev: Floats, defaults to 1. Standard deviation of the random values
-            to generate.
-        dtype: Optional dtype of the tensor. Only floating point types are
-            supported. If not specified, `keras.backend.floatx()` is used,
-            which defaults to `float32` unless you configured it otherwise (via
-            `keras.backend.set_floatx(float_dtype)`)
-        seed: A Python integer or instance of
-            `keras_core.backend.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras_core.backend.SeedGenerator`.
-    """
     dtype = dtype or floatx()
     seed = tf_draw_seed(seed)
     return tf.random.stateless_truncated_normal(

--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -18,6 +18,7 @@ TORCH_DTYPES = {
     "float32": torch.float32,
     "float64": torch.float64,
     "uint8": torch.uint8,
+    "uint16": torch.int32,  # TODO: Torch doesn't have `uint16` dtype.
     "uint32": torch.int64,  # TODO: Torch doesn't have `uint32` dtype.
     "int8": torch.int8,
     "int16": torch.int16,

--- a/keras_core/backend/torch/random.py
+++ b/keras_core/backend/torch/random.py
@@ -16,26 +16,6 @@ def torch_seed_generator(seed):
 
 
 def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
-    """Produce random number based on the normal distribution.
-
-    Args:
-        shape: The shape of the random values to generate.
-        mean: Floats, defaults to 0. Mean of the random values to generate.
-        stddev: Floats, defaults to 1. Standard deviation of the random values
-            to generate.
-        dtype: Optional dtype of the tensor. Only floating point types are
-            supported. If not specified, `keras.backend.floatx()` is used,
-            which defaults to `float32` unless you configured it otherwise (via
-            `keras.backend.set_floatx(float_dtype)`).
-        seed: A Python integer or instance of
-            `keras_core.backend.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras_core.backend.SeedGenerator`.
-    """
     dtype = dtype or floatx()
     dtype = to_torch_dtype(dtype)
     generator = torch_seed_generator(seed)
@@ -45,31 +25,6 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
 
 
 def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
-    """Produce random number based on the uniform distribution.
-
-    The generated values follow a uniform distribution in the range
-    `[minval, maxval)`. The lower bound `minval` is included in the range,
-    while the upper bound `maxval` is excluded.
-
-    Args:
-        shape: The shape of the random values to generate.
-        minval: Floats, defaults to 0. Lower bound of the range of
-            random values to generate (inclusive).
-        maxval: Floats, defaults to 1. Upper bound of the range of
-            random values to generate (exclusive).
-        dtype: Optional dtype of the tensor. Only floating point types are
-            supported. If not specified, `keras.backend.floatx()` is used,
-            which defaults to `float32` unless you configured it otherwise (via
-            `keras.backend.set_floatx(float_dtype)`)
-        seed: A Python integer or instance of
-            `keras_core.backend.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras_core.backend.SeedGenerator`.
-    """
     dtype = dtype or floatx()
     dtype = to_torch_dtype(dtype)
     generator = torch_seed_generator(seed)
@@ -78,31 +33,15 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
     ) + minval
 
 
+def randint(shape, minval, maxval, dtype="int32", seed=None):
+    dtype = to_torch_dtype(dtype)
+    generator = torch_seed_generator(seed)
+    return torch.randint(
+        low=minval, high=maxval, size=shape, generator=generator, dtype=dtype
+    )
+
+
 def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
-    """Produce random number based on the truncated normal distribution.
-
-    The values are drawn from a normal distribution with specified mean and
-    standard deviation, discarding and re-drawing any samples that are more
-    than two standard deviations from the mean.
-
-    Args:
-        shape: The shape of the random values to generate.
-        mean: Floats, defaults to 0. Mean of the random values to generate.
-        stddev: Floats, defaults to 1. Standard deviation of the random values
-            to generate.
-        dtype: Optional dtype of the tensor. Only floating point types are
-            supported. If not specified, `keras.backend.floatx()` is used,
-            which defaults to `float32` unless you configured it otherwise (via
-            `keras.backend.set_floatx(float_dtype)`)
-        seed: A Python integer or instance of
-            `keras_core.backend.SeedGenerator`.
-            Used to make the behavior of the initializer
-            deterministic. Note that an initializer seeded with an integer
-            or None (unseeded) will produce the same random values
-            across multiple calls. To get different random values
-            across multiple calls, use as seed an instance
-            of `keras_core.backend.SeedGenerator`.
-    """
     # Take a larger standard normal dist, discard values outside 2 * stddev
     # Offset by mean and stddev
     x = normal(shape + (4,), mean=0, stddev=1, dtype=dtype, seed=seed)

--- a/keras_core/random/random.py
+++ b/keras_core/random/random.py
@@ -37,8 +37,7 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
     `[minval, maxval)`. The lower bound `minval` is included in the range,
     while the upper bound `maxval` is excluded.
 
-    For floats, the default range is `[0, 1)`.  For ints, at least `maxval`
-    must be specified explicitly.
+    `dtype` must be a floating point type, the default range is `[0, 1)`.
 
     Args:
         shape: The shape of the random values to generate.
@@ -59,7 +58,51 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
             across multiple calls, use as seed an instance
             of `keras_core.random.SeedGenerator`.
     """
+    if dtype and not backend.is_float_dtype(dtype):
+        raise ValueError(
+            "`keras_core.random.uniform` requires a floating point `dtype`. "
+            f"Received: dtype={dtype} "
+        )
     return backend.random.uniform(
+        shape, minval=minval, maxval=maxval, dtype=dtype, seed=seed
+    )
+
+
+@keras_core_export("keras_core.random.randint")
+def randint(shape, minval, maxval, dtype="int32", seed=None):
+    """Draw random integers from a uniform distribution.
+
+    The generated values follow a uniform distribution in the range
+    `[minval, maxval)`. The lower bound `minval` is included in the range,
+    while the upper bound `maxval` is excluded.
+
+    `dtype` must be an integer type.
+
+    Args:
+        shape: The shape of the random values to generate.
+        minval: Floats, defaults to 0. Lower bound of the range of
+            random values to generate (inclusive).
+        maxval: Floats, defaults to 1. Upper bound of the range of
+            random values to generate (exclusive).
+        dtype: Optional dtype of the tensor. Only integer types are
+            supported. If not specified, `keras_core.config.floatx()` is used,
+            which defaults to `float32` unless you configured it otherwise (via
+            `keras_core.config.set_floatx(float_dtype)`)
+        seed: A Python integer or instance of
+            `keras_core.random.SeedGenerator`.
+            Used to make the behavior of the initializer
+            deterministic. Note that an initializer seeded with an integer
+            or None (unseeded) will produce the same random values
+            across multiple calls. To get different random values
+            across multiple calls, use as seed an instance
+            of `keras_core.random.SeedGenerator`.
+    """
+    if dtype and not backend.is_int_dtype(dtype):
+        raise ValueError(
+            "`keras_core.random.randint` requires an integer `dtype`. "
+            f"Received: dtype={dtype} "
+        )
+    return backend.random.randint(
         shape, minval=minval, maxval=maxval, dtype=dtype, seed=seed
     )
 

--- a/keras_core/random/random_test.py
+++ b/keras_core/random/random_test.py
@@ -3,6 +3,7 @@ import pytest
 from absl.testing import parameterized
 
 import keras_core
+from keras_core import backend
 from keras_core import testing
 from keras_core.operations import numpy as knp
 from keras_core.random import random
@@ -38,6 +39,27 @@ class RandomTest(testing.TestCase, parameterized.TestCase):
         self.assertEqual(res.shape, np_res.shape)
         self.assertLessEqual(knp.max(res), maxval)
         self.assertGreaterEqual(knp.max(res), minval)
+
+    @parameterized.parameters(
+        {"seed": 10, "shape": (5,), "min": 0, "max": 10, "dtype": "uint16"},
+        {"seed": 10, "shape": (2, 3), "min": 0, "max": 10, "dtype": "uint32"},
+        {"seed": 10, "shape": (2, 3, 4), "min": 0, "max": 2, "dtype": "int8"},
+        {"seed": 10, "shape": (2, 3), "min": -1, "max": 1, "dtype": "int16"},
+        {"seed": 10, "shape": (2, 3), "min": 1, "max": 3, "dtype": "int32"},
+    )
+    def test_randint(self, seed, shape, min, max, dtype):
+        np.random.seed(seed)
+        np_res = np.random.randint(low=min, high=max, size=shape)
+        res = random.randint(
+            shape, minval=min, maxval=max, seed=seed, dtype=dtype
+        )
+        self.assertEqual(res.shape, shape)
+        self.assertEqual(res.shape, np_res.shape)
+        self.assertLessEqual(knp.max(res), max)
+        self.assertGreaterEqual(knp.max(res), min)
+        # Torch has incomplete dtype support for uints; will remap some dtypes.
+        if keras_core.backend.backend() != "torch":
+            self.assertEqual(backend.standardize_dtype(res.dtype), dtype)
 
     @parameterized.parameters(
         {"seed": 10, "shape": (5,), "mean": 0, "stddev": 1},


### PR DESCRIPTION
Drawing random integers is a big confusing across backends, jax and torch have separate randint ops, tf folds support into random.uniform with incomplete dtype support.

This gives us a unified surface for drawing random ints.