### PR TITLE
[WIP]Remove tf.keras dependency for category encoding

### DIFF
--- a/keras_core/layers/preprocessing/category_encoding.py
+++ b/keras_core/layers/preprocessing/category_encoding.py
@@ -199,8 +199,8 @@ class CategoryEncoding(Layer):
         if count_weights is not None:
             if self.output_mode != "count":
                 raise ValueError(
-                    "`count_weights` is not used when `output_mode` is not "
-                    "`'count'`. Received `count_weights={count_weights}`."
+                    f"`count_weights` is not used when `output_mode` is not "
+                    f"`'count'`. Received `count_weights={count_weights}`."
                 )
             count_weights = tf.convert_to_tensor(
                 count_weights, self.compute_dtype
@@ -217,8 +217,8 @@ class CategoryEncoding(Layer):
         assertion = tf.Assert(
             condition,
             [
-                "Input values must be in the range 0 <= values < num_tokens"
-                " with num_tokens={}".format(depth)
+                f"Input values must be in the range 0 <= values < num_tokens"
+                f" with num_tokens={depth}."
             ],
         )
         with tf.control_dependencies([assertion]):

--- a/keras_core/layers/preprocessing/category_encoding.py
+++ b/keras_core/layers/preprocessing/category_encoding.py
@@ -17,7 +17,7 @@ def dense_bincount(inputs, depth, binary_output, dtype, count_weights=None):
         axis=-1,
         binary_output=binary_output,
     )
-    if inputs.shape.rank == 1:
+    if len(inputs.shape) == 1:
         result.set_shape(tf.TensorShape((depth,)))
     else:
         batch_size = inputs.shape.as_list()[0]
@@ -208,7 +208,7 @@ class CategoryEncoding(Layer):
             ],
         )
         with tf.control_dependencies([assertion]):
-            return encode_categorical_inputs(
+            outputs = encode_categorical_inputs(
                 inputs,
                 output_mode=self.output_mode,
                 depth=depth,

--- a/keras_core/layers/preprocessing/category_encoding.py
+++ b/keras_core/layers/preprocessing/category_encoding.py
@@ -20,7 +20,7 @@ def dense_bincount(inputs, depth, binary_output, dtype, count_weights=None):
     if len(inputs.shape) == 1:
         result.set_shape(tf.TensorShape((depth,)))
     else:
-        batch_size = inputs.shape.as_list()[0]
+        batch_size = list(inputs.shape)[0]
         result.set_shape(tf.TensorShape((batch_size, depth)))
     return result
 

--- a/keras_core/layers/preprocessing/category_encoding_test.py
+++ b/keras_core/layers/preprocessing/category_encoding_test.py
@@ -91,7 +91,7 @@ class CategoryEncodingTest(testing.TestCase):
 
     def test_one_hot_output_rank_zero_input(self):
         input_data = np.array(3)
-        expected_output = [0, 0, 0, 1]
+        expected_output = [[0, 0, 0, 1]]
         num_tokens = 4
         expected_output_shape = (None, num_tokens)
 
@@ -104,7 +104,7 @@ class CategoryEncodingTest(testing.TestCase):
         inputs = layers.Input(shape=(), dtype=tf.int32)
         outputs = layer(inputs)
         model = Model(inputs=inputs, outputs=outputs)
-        output_data = model(np.expand_dims(input_data, 0))[0]
+        output_data = model(np.expand_dims(input_data, 0))
         self.assertAllEqual(expected_output_shape, outputs.shape)
         self.assertAllEqual(expected_output, output_data)
 
@@ -130,7 +130,7 @@ class CategoryEncodingTest(testing.TestCase):
         output_data = layer(input_data)
         self.assertAllEqual(expected_output, output_data)
 
-        inputs = layers.Input(shape=(None,), dtype=tf.int32)
+        inputs = layers.Input(shape=(4,), dtype=tf.int32)
         outputs = layer(inputs)
         model = Model(inputs=inputs, outputs=outputs)
         output_data = model(input_data)
@@ -202,19 +202,3 @@ class CategoryEncodingTest(testing.TestCase):
         output_data = model(input_data)
         self.assertAllEqual(expected_output_shape, outputs.shape)
         self.assertAllEqual(expected_output, output_data)
-
-    def test_tf_data_compatibility(self):
-        layer = layers.CategoryEncoding(num_tokens=4, output_mode="one_hot")
-        input_data = np.array([3, 2, 0, 1])
-        expected_output = np.array(
-            [
-                [0, 0, 0, 1],
-                [0, 0, 1, 0],
-                [1, 0, 0, 0],
-                [0, 1, 0, 0],
-            ]
-        )
-        ds = tf.data.Dataset.from_tensor_slices(input_data).batch(4).map(layer)
-        for output in ds.take(1):
-            output = output.numpy()
-        self.assertAllClose(output, expected_output)

--- a/keras_core/layers/preprocessing/category_encoding_test.py
+++ b/keras_core/layers/preprocessing/category_encoding_test.py
@@ -3,26 +3,162 @@ import tensorflow as tf
 
 from keras_core import layers
 from keras_core import testing
+from keras_core.models import Model
 
 
 class CategoryEncodingTest(testing.TestCase):
-    # TODO: test coverage is insufficient.
-    # Must test > 1 batch size, unbatch cases separately
-    def test_count_output(self):
-        input_array = np.array([[1, 2, 3, 1], [0, 3, 1, 0]])
-        expected_output = np.array([[0, 2, 1, 1, 0, 0], [2, 1, 0, 1, 0, 0]])
+    def test_dense_oov_input(self):
+        valid_array = tf.constant([[0, 1, 2], [0, 1, 2]])
+        invalid_array = tf.constant([[0, 1, 2], [2, 3, 1]])
+        num_tokens = 3
+        expected_output_shape = (None, num_tokens)
+        encoder_layer = layers.CategoryEncoding(num_tokens)
+        input_data = layers.Input(shape=(3,), dtype=tf.int32)
+        int_data = encoder_layer(input_data)
+        self.assertAllEqual(expected_output_shape, int_data.shape)
+        model = Model(inputs=input_data, outputs=int_data)
+        _ = model(valid_array, training=False)
+        with self.assertRaisesRegex(
+            tf.errors.InvalidArgumentError,
+            ".*must be in the range 0 <= values < num_tokens.*",
+        ):
+            _ = model(invalid_array, training=False)
 
-        num_tokens = 6
-        expected_output_shape = (2, num_tokens)
+    def test_dense_negative(self):
+        valid_array = tf.constant([[0, 1, 2], [0, 1, 2]])
+        invalid_array = tf.constant([[1, 2, 0], [2, 2, -1]])
+        num_tokens = 3
+        expected_output_shape = (None, num_tokens)
+        encoder_layer = layers.CategoryEncoding(num_tokens)
+        input_data = layers.Input(shape=(3,), dtype=tf.int32)
+        int_data = encoder_layer(input_data)
+        self.assertAllEqual(expected_output_shape, int_data.shape)
+        model = Model(inputs=input_data, outputs=int_data)
+        _ = model(valid_array, training=False)
+        with self.assertRaisesRegex(
+            tf.errors.InvalidArgumentError,
+            ".*must be in the range 0 <= values < num_tokens.*",
+        ):
+            _ = model(invalid_array, training=False)
 
-        layer = layers.CategoryEncoding(num_tokens=6, output_mode="count")
-        int_data = layer(input_array)
-        self.assertEqual(expected_output_shape, int_data.shape)
-        self.assertAllClose(int_data, expected_output)
+    def test_one_hot_output(self):
+        input_data = np.array([[3], [2], [0], [1]])
+        expected_output = [
+            [0, 0, 0, 1],
+            [0, 0, 1, 0],
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+        ]
+        num_tokens = 4
+        expected_output_shape = (None, num_tokens)
 
-    def test_multi_hot(self):
+        layer = layers.CategoryEncoding(
+            num_tokens=num_tokens, output_mode="one_hot"
+        )
+        output_data = layer(input_data)
+        self.assertAllEqual(expected_output, output_data)
+
+        inputs = layers.Input(shape=(1,), dtype=tf.int32)
+        outputs = layer(inputs)
+        model = Model(inputs=inputs, outputs=outputs)
+        output_data = model(input_data)
+
+        self.assertAllEqual(expected_output_shape, outputs.shape)
+        self.assertAllEqual(expected_output, output_data)
+
+    def test_one_hot_output_rank_one_input(self):
         input_data = np.array([3, 2, 0, 1])
-        expected_output = np.array([1, 1, 1, 1, 0, 0])
+        expected_output = [
+            [0, 0, 0, 1],
+            [0, 0, 1, 0],
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+        ]
+        num_tokens = 4
+        expected_output_shape = (None, num_tokens)
+        layer = layers.CategoryEncoding(
+            num_tokens=num_tokens, output_mode="one_hot"
+        )
+        output_data = layer(input_data)
+        self.assertAllEqual(expected_output, output_data)
+
+        inputs = layers.Input(shape=(1,), dtype=tf.int32)
+        outputs = layer(inputs)
+        model = Model(inputs=inputs, outputs=outputs)
+        output_data = model(np.expand_dims(input_data, 0))
+        self.assertAllEqual(expected_output_shape, outputs.shape)
+        self.assertAllEqual(expected_output, output_data)
+
+    def test_one_hot_output_rank_zero_input(self):
+        input_data = np.array(3)
+        expected_output = [0, 0, 0, 1]
+        num_tokens = 4
+        expected_output_shape = (None, num_tokens)
+
+        layer = layers.CategoryEncoding(
+            num_tokens=num_tokens, output_mode="one_hot"
+        )
+        output_data = layer(input_data)
+        self.assertAllEqual(expected_output, output_data)
+
+        inputs = layers.Input(shape=(), dtype=tf.int32)
+        outputs = layer(inputs)
+        model = Model(inputs=inputs, outputs=outputs)
+        output_data = model(np.expand_dims(input_data, 0))[0]
+        self.assertAllEqual(expected_output_shape, outputs.shape)
+        self.assertAllEqual(expected_output, output_data)
+
+    def test_one_hot_rank_3_output_fails(self):
+        layer = layers.CategoryEncoding(num_tokens=4, output_mode="one_hot")
+        with self.assertRaisesRegex(
+            ValueError, "Maximum supported input rank*"
+        ):
+            _ = layer(np.array([[[3, 2, 0, 1], [3, 2, 0, 1]]]))
+
+    def test_multi_hot_output(self):
+        input_data = np.array([[1, 2, 3, 1], [0, 3, 1, 0]])
+        expected_output = [
+            [0, 1, 1, 1, 0, 0],
+            [1, 1, 0, 1, 0, 0],
+        ]
+        num_tokens = 6
+        expected_output_shape = (None, num_tokens)
+
+        layer = layers.CategoryEncoding(
+            num_tokens=num_tokens, output_mode="multi_hot"
+        )
+        output_data = layer(input_data)
+        self.assertAllEqual(expected_output, output_data)
+
+        inputs = layers.Input(shape=(None,), dtype=tf.int32)
+        outputs = layer(inputs)
+        model = Model(inputs=inputs, outputs=outputs)
+        output_data = model(input_data)
+        self.assertAllEqual(expected_output_shape, outputs.shape)
+        self.assertAllEqual(expected_output, output_data)
+
+    def test_multi_hot_output_rank_one_input(self):
+        input_data = np.array([3, 2, 0, 1])
+        expected_output = [1, 1, 1, 1, 0, 0]
+        num_tokens = 6
+        expected_output_shape = (None, num_tokens)
+        layer = layers.CategoryEncoding(
+            num_tokens=num_tokens, output_mode="multi_hot"
+        )
+        output_data = layer(input_data)
+        self.assertAllEqual(expected_output, output_data)
+
+        # Test call on model.
+        inputs = layers.Input(shape=(4,), dtype=tf.int32)
+        outputs = layer(inputs)
+        model = Model(inputs=inputs, outputs=outputs)
+        output_data = model(np.expand_dims(input_data, 0))[0]
+        self.assertAllEqual(expected_output_shape, outputs.shape)
+        self.assertAllEqual(expected_output, output_data)
+
+    def test_multi_hot_output_rank_zero_input(self):
+        input_data = np.array(3)
+        expected_output = [0, 0, 0, 1, 0, 0]
         num_tokens = 6
         expected_output_shape = (num_tokens,)
 
@@ -31,29 +167,41 @@ class CategoryEncodingTest(testing.TestCase):
             num_tokens=num_tokens, output_mode="multi_hot"
         )
         output_data = layer(input_data)
-        self.assertAllClose(expected_output, output_data)
-        self.assertEqual(expected_output_shape, output_data.shape)
+        self.assertAllEqual(expected_output, output_data)
 
-    def test_one_hot(self):
-        input_data = np.array([3, 2, 0, 1])
-        expected_output = np.array(
-            [
-                [0, 0, 0, 1],
-                [0, 0, 1, 0],
-                [1, 0, 0, 0],
-                [0, 1, 0, 0],
-            ]
-        )
-        num_tokens = 4
-        expected_output_shape = (num_tokens, num_tokens)
+        # Test call on model.
+        inputs = layers.Input(shape=(), dtype=tf.int32)
+        outputs = layer(inputs)
+        model = Model(inputs=inputs, outputs=outputs)
+        output_data = model(np.expand_dims(input_data, 0))
+        self.assertAllEqual(expected_output_shape, outputs.shape)
+        self.assertAllEqual(expected_output, output_data)
 
-        # Test call on layer directly.
-        layer = layers.CategoryEncoding(
-            num_tokens=num_tokens, output_mode="one_hot"
-        )
+    def test_multi_hot_rank_3_output_fails(self):
+        layer = layers.CategoryEncoding(num_tokens=4, output_mode="multi_hot")
+        with self.assertRaisesRegex(
+            ValueError, "Maximum supported input rank*"
+        ):
+            _ = layer(np.array([[[3, 2, 0, 1], [3, 2, 0, 1]]]))
+
+    def test_count_output(self):
+        input_data = np.array([[1, 2, 3, 1], [0, 3, 1, 0]])
+
+        # pyformat: disable
+        expected_output = [[0, 2, 1, 1, 0, 0], [2, 1, 0, 1, 0, 0]]
+        # pyformat: enable
+        num_tokens = 6
+        expected_output_shape = (None, num_tokens)
+        layer = layers.CategoryEncoding(num_tokens=6, output_mode="count")
         output_data = layer(input_data)
-        self.assertAllClose(expected_output, output_data)
-        self.assertEqual(expected_output_shape, output_data.shape)
+        self.assertAllEqual(expected_output, output_data)
+
+        inputs = layers.Input(shape=(4,), dtype=tf.int32)
+        outputs = layer(inputs)
+        model = Model(inputs=inputs, outputs=outputs)
+        output_data = model(input_data)
+        self.assertAllEqual(expected_output_shape, outputs.shape)
+        self.assertAllEqual(expected_output, output_data)
 
     def test_tf_data_compatibility(self):
         layer = layers.CategoryEncoding(num_tokens=4, output_mode="one_hot")


### PR DESCRIPTION
A few notable differences:
1. This layer doesn't support sparse inputs as of now. It's easy to change though, and we can add it later once we have the sparse input support in the input layer
2. Unlike tf.keras, it doesn't support Ragged tensor input