### PR TITLE
Add random.categorical

### DIFF
--- a/keras_core/backend/jax/random.py
+++ b/keras_core/backend/jax/random.py
@@ -21,6 +21,17 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
     )
 
 
+def categorical(logits, num_samples, dtype="int32", seed=None):
+    seed = draw_seed(seed)
+    output_shape = list(logits.shape)
+    output_shape[1] = num_samples
+    output_shape = tuple(output_shape)
+    output = jax.random.categorical(
+        seed, logits[..., None], shape=output_shape, axis=1
+    )
+    return output.astype(dtype)
+
+
 def randint(shape, minval, maxval, dtype="int32", seed=None):
     seed = draw_seed(seed)
     return jax.random.randint(

--- a/keras_core/backend/tensorflow/random.py
+++ b/keras_core/backend/tensorflow/random.py
@@ -32,6 +32,14 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
     )
 
 
+def categorical(logits, num_samples, dtype="int64", seed=None):
+    seed = tf_draw_seed(seed)
+    output = tf.random.stateless_categorical(
+        logits, num_samples, seed=seed
+    )
+    return tf.cast(output, dtype)
+
+
 def randint(shape, minval, maxval, dtype="int32", seed=None):
     intemediate_dtype = dtype
     if standardize_dtype(dtype) not in ["int32", "int64"]:

--- a/keras_core/backend/torch/random.py
+++ b/keras_core/backend/torch/random.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn.functional as tnn
 
 from keras_core.backend.config import floatx
+from keras_core.backend.torch.core import convert_to_tensor
 from keras_core.backend.torch.core import get_device
 from keras_core.backend.torch.core import to_torch_dtype
 from keras_core.random.seed_generator import SeedGenerator
@@ -9,9 +10,9 @@ from keras_core.random.seed_generator import draw_seed
 from keras_core.random.seed_generator import make_default_seed
 
 
-def torch_seed_generator(seed):
+def torch_seed_generator(seed, device="cpu"):
     seed_val, _ = draw_seed(seed)
-    generator = torch.Generator()
+    generator = torch.Generator(device=device)
     generator.manual_seed(int(seed_val))
     return generator
 
@@ -23,6 +24,15 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     return torch.normal(
         mean, stddev, size=shape, generator=generator, dtype=dtype
     ).to(get_device())
+
+
+def categorical(logits, num_samples, dtype="int32", seed=None):
+    logits = convert_to_tensor(logits)
+    dtype = to_torch_dtype(dtype)
+    generator = torch_seed_generator(seed, device=get_device())
+    return torch.multinomial(
+        logits, num_samples, replacement=True, generator=generator,
+    ).type(dtype)
 
 
 def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):

--- a/keras_core/random/random.py
+++ b/keras_core/random/random.py
@@ -29,6 +29,51 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     )
 
 
+@keras_core_export("keras_core.random.categorical")
+def categorical(logits, num_samples, dtype="int32", seed=None):
+    """Draws samples from a categorical distribution.
+
+    This function takes as input `logits`, a 2-D input tensor with shape
+    (batch_size, num_classes). Each row of the input represents a categorical
+    distribution, with each column index containing the log-probability for a
+    given class.
+
+    The function will output a 2-D tensor with shape (batch_size, num_samples),
+    where each row contains samples from the corresponding row in `logits`.
+    Each column index contains an independent samples drawn from the input
+    distribution.
+
+    Args:
+        logits: 2-D Tensor with shape (batch_size, num_classes). Each row
+            should define a categorical distibution with the unnormalized
+            log-probabilities for all classes.
+        num_samples: Int, the number of independent samples to draw for each
+            row of the input. This will be the second dimension of the output
+            tensor's shape.
+        dtype: Optional dtype of the output tensor.
+        seed: A Python integer or instance of
+            `keras_core.random.SeedGenerator`.
+            Used to make the behavior of the initializer
+            deterministic. Note that an initializer seeded with an integer
+            or None (unseeded) will produce the same random values
+            across multiple calls. To get different random values
+            across multiple calls, use as seed an instance
+            of `keras_core.random.SeedGenerator`.
+
+    Returns:
+        A 2-D tensor with (batch_size, num_samples).
+    """
+    logits_shape = list(backend.convert_to_tensor(logits).shape)
+    if len(logits_shape) != 2:
+        raise ValueError(
+            "`logits` should be a 2-D tensor with shape "
+            f"[batch_size, num_classes]. Received: logits={logits}"
+        )
+    return backend.random.categorical(
+        logits, num_samples, dtype=dtype, seed=seed
+    )
+
+
 @keras_core_export("keras_core.random.uniform")
 def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
     """Draw samples from a uniform distribution.


### PR DESCRIPTION
Not very sure about the signature here, welcome feedback.

- `tf.random.stateless_categorical` only supports 2-D input
- `torch.multinomial` supports 1-D or 2-D
- `jax.random.categorical` has a more general form with any axis and output shape.

Went with the lowest common denominator of 2-D shape just because it was easiest. We could also try to replicate jax's more [general signature](https://jax.readthedocs.io/en/latest/_autosummary/jax.random.categorical.html) or imitate `numpy.random.Generator.multinomial`, which expects softmax probabilities, but has it's on wonkiness.