### PR TITLE
Fix `keras_core.operations.Repeat` op's `compute_output_spec` method

### DIFF
--- a/keras_core/operations/numpy.py
+++ b/keras_core/operations/numpy.py
@@ -2665,7 +2665,10 @@ class Repeat(Operation):
         size_on_ax = x_shape[self.axis]
         output_shape = x_shape
         if isinstance(self.repeats, int):
-            output_shape[self.axis] = size_on_ax * self.repeats
+            if size_on_ax is None:
+                output_shape[self.axis] = None
+            else:
+                output_shape[self.axis] = size_on_ax * self.repeats
         else:
             output_shape[self.axis] = int(np.sum(self.repeats))
         return KerasTensor(output_shape, dtype=x.dtype)

--- a/keras_core/operations/numpy_test.py
+++ b/keras_core/operations/numpy_test.py
@@ -1027,6 +1027,7 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.repeat(x, 2).shape, (None,))
         self.assertEqual(knp.repeat(x, 3, axis=1).shape, (None, 9))
         self.assertEqual(knp.repeat(x, [1, 2], axis=0).shape, (3, 3))
+        self.assertEqual(knp.repeat(x, 2, axis=0).shape, (None, 3))
 
     def test_reshape(self):
         x = KerasTensor([None, 3])


### PR DESCRIPTION
The `Repeat` operation failed when there was `None` in the repeating axis. This PR fixes the bug and adds a test for it.

cc @ianstenbit 