### PR TITLE
added Jax distributed training exammple using a Keras model

### DIFF
--- a/examples/demo_jax_distributed.py
+++ b/examples/demo_jax_distributed.py
@@ -156,18 +156,13 @@ devices = mesh_utils.create_device_mesh((8,))
 
 # data will be split along the batch axis
 data_mesh = Mesh(devices, axis_names=("batch",))  # naming axes of the mesh
-data_sharding = NamedSharding(
-    data_mesh,
-    P(
-        "batch",
-    ),
-)  # naming axes of the sharded partition
+# naming axes of the sharded partition
+data_sharding = NamedSharding(data_mesh,P("batch",),)
 
 # all variables will be replicated on all devices
 var_mesh = Mesh(devices, axis_names=("_"))
-var_replication = NamedSharding(
-    var_mesh, P()
-)  # in NamedSharding, axes that are not mentioned are replicated (all axes here)
+# in NamedSharding, axes that are not mentioned are replicated (all axes here)
+var_replication = NamedSharding(var_mesh, P())
 
 # for the demo, we will split the largest kernel 4-ways (and replicate 2-ways since we have 8 devices)
 large_kernel_mesh = Mesh(


### PR DESCRIPTION
Checked that the file runs on a GCP TPU VM.
Output:
```
Using JAX backend.

Identified local devices:
[TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0),
 TpuDevice(id=1, process_index=0, coords=(0,0,0), core_on_chip=1),
 TpuDevice(id=2, process_index=0, coords=(1,0,0), core_on_chip=0),
 TpuDevice(id=3, process_index=0, coords=(1,0,0), core_on_chip=1),
 TpuDevice(id=4, process_index=0, coords=(0,1,0), core_on_chip=0),
 TpuDevice(id=5, process_index=0, coords=(0,1,0), core_on_chip=1),
 TpuDevice(id=6, process_index=0, coords=(1,1,0), core_on_chip=0),
 TpuDevice(id=7, process_index=0, coords=(1,1,0), core_on_chip=1)]

Mostly data-parallel distribution. Data is sharded across devices while the model is replicated. For demo purposes, we split the largest kernel 4-ways (and replicate 2-ways since we have 8 devices).

Sharding of all other model variables (they are replicated)
┌──────────────────────────────┐
│                              │
│                              │
│                              │
│                              │
│     TPU 0,1,2,3,4,5,6,7      │
│                              │
│                              │
│                              │
│                              │
└──────────────────────────────┘
Sharding of convolutional kernel (6, 6, 24, 32)
┌───────┬───────┬───────┬───────┐
│       │       │       │       │
│       │       │       │       │
│       │       │       │       │
│       │       │       │       │
│TPU 0,6│TPU 1,7│TPU 2,4│TPU 3,5│
│       │       │       │       │
│       │       │       │       │
│       │       │       │       │
│       │       │       │       │
└───────┴───────┴───────┴───────┘
Data sharding
┌──────────────────────────────────────────────────────────────────────────────┐
│                                    TPU 0                                     │
├──────────────────────────────────────────────────────────────────────────────┤
│                                    TPU 1                                     │
├──────────────────────────────────────────────────────────────────────────────┤
│                                    TPU 2                                     │
├──────────────────────────────────────────────────────────────────────────────┤
│                                    TPU 3                                     │
├──────────────────────────────────────────────────────────────────────────────┤
│                                    TPU 6                                     │
├──────────────────────────────────────────────────────────────────────────────┤
│                                    TPU 7                                     │
├──────────────────────────────────────────────────────────────────────────────┤
│                                    TPU 4                                     │
├──────────────────────────────────────────────────────────────────────────────┤
│                                    TPU 5                                     │
└──────────────────────────────────────────────────────────────────────────────┘

Trainig:
100%|████████████████████████████████████████████████████████████████████████| 312/312 [00:09<00:00, 32.98it/s]
Epoch 0 loss: 0.029839508
100%|███████████████████████████████████████████████████████████████████████| 312/312 [00:02<00:00, 144.02it/s]
Epoch 1 loss: 0.0934235
100%|███████████████████████████████████████████████████████████████████████| 312/312 [00:02<00:00, 145.94it/s]
Epoch 2 loss: 0.015656712
100%|███████████████████████████████████████████████████████████████████████| 312/312 [00:02<00:00, 146.39it/s]
Epoch 3 loss: 0.0014929542
100%|███████████████████████████████████████████████████████████████████████| 312/312 [00:02<00:00, 147.72it/s]
Epoch 4 loss: 0.00050054514

Model output sharding follows data sharding:
┌───────┐
│ TPU 0 │
├───────┤
│ TPU 1 │
├───────┤
│ TPU 2 │
├───────┤
│ TPU 3 │
├───────┤
│ TPU 6 │
├───────┤
│ TPU 7 │
├───────┤
│ TPU 4 │
├───────┤
│ TPU 5 │
└───────┘

Updating model and running an eval:
1/1 ━━━━━━━━━━━━━━━━━━━━ 4s 4s/step - loss: 0.0344 - sparse_categorical_accuracy: 0.9922
The model achieved an evaluation accuracy of: 0.9921999573707581
```