### PR TITLE
Allow list shapes to truncated normal

### DIFF
--- a/keras_core/backend/torch/random.py
+++ b/keras_core/backend/torch/random.py
@@ -99,7 +99,7 @@ def randint(shape, minval, maxval, dtype="int32", seed=None):
 def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     # Take a larger standard normal dist, discard values outside 2 * stddev
     # Offset by mean and stddev
-    x = normal(shape + (4,), mean=0, stddev=1, dtype=dtype, seed=seed)
+    x = normal(tuple(shape) + (4,), mean=0, stddev=1, dtype=dtype, seed=seed)
     valid = (x > -2) & (x < 2)
     indexes = valid.max(-1, keepdim=True)[1]
     trunc_x = torch.empty(shape, device=get_device())

--- a/keras_core/random/random_test.py
+++ b/keras_core/random/random_test.py
@@ -91,6 +91,8 @@ class RandomTest(testing.TestCase, parameterized.TestCase):
         {"seed": 10, "shape": (2, 3, 4), "mean": 0, "stddev": 1},
         {"seed": 10, "shape": (2, 3), "mean": 10, "stddev": 1},
         {"seed": 10, "shape": (2, 3), "mean": 10, "stddev": 3},
+        # Test list shapes.
+        {"seed": 10, "shape": [2, 3], "mean": 10, "stddev": 3},
     )
     def test_truncated_normal(self, seed, shape, mean, stddev):
         np.random.seed(seed)
@@ -98,7 +100,7 @@ class RandomTest(testing.TestCase, parameterized.TestCase):
         res = random.truncated_normal(
             shape, mean=mean, stddev=stddev, seed=seed
         )
-        self.assertEqual(res.shape, shape)
+        self.assertEqual(res.shape, tuple(shape))
         self.assertEqual(res.shape, np_res.shape)
         self.assertLessEqual(knp.max(res), mean + 2 * stddev)
         self.assertGreaterEqual(knp.max(res), mean - 2 * stddev)


### PR DESCRIPTION
We could also update our `self.add_variable` code to always pass tuple shapes, but I think the right fix is to allow either tuple or list shapes with a defensive cast.