### PR TITLE
Support torch tensor inputs to data adapter

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+try:
+    # When using torch and tensorflow, torch needs to be imported first,
+    # otherwise it will segfault upon import. This should force the torch
+    # import to happen first for all tests.
+    import torch  # noqa: F401
+except ImportError:
+    pass

--- a/keras_core/saving/serialization_lib.py
+++ b/keras_core/saving/serialization_lib.py
@@ -5,7 +5,6 @@ import inspect
 import types
 import warnings
 
-import jax
 import numpy as np
 import tensorflow as tf
 
@@ -162,11 +161,7 @@ def serialize_keras_object(obj):
         }
     if isinstance(obj, tf.TensorShape):
         return obj.as_list() if obj._dims is not None else None
-    if isinstance(obj, (tf.Tensor, jax.numpy.ndarray)) or hasattr(
-        obj, "device"
-    ):
-        # Import torch creates circular dependency, so we use
-        # `hasattr(obj, "device")` to check if obj is a torch tensor.
+    if backend.is_tensor(obj):
         return {
             "class_name": "__tensor__",
             "config": {

--- a/keras_core/trainers/data_adapters/array_data_adapter_test.py
+++ b/keras_core/trainers/data_adapters/array_data_adapter_test.py
@@ -2,6 +2,7 @@ import jax
 import numpy as np
 import pandas
 import tensorflow as tf
+import torch
 from absl.testing import parameterized
 
 from keras_core import backend
@@ -10,7 +11,9 @@ from keras_core.trainers.data_adapters import array_data_adapter
 
 
 class TestArrayDataAdapter(testing.TestCase, parameterized.TestCase):
-    @parameterized.parameters([("np",), ("tf",), ("pandas")])
+    @parameterized.parameters(
+        [("np",), ("tf",), ("jax",), ("torch",), ("pandas")]
+    )
     def test_basic_flow(self, array_type):
         if array_type == "np":
             x = np.random.random((34, 4))
@@ -21,6 +24,9 @@ class TestArrayDataAdapter(testing.TestCase, parameterized.TestCase):
         elif array_type == "jax":
             x = jax.numpy.ones((34, 4))
             y = jax.numpy.ones((34, 2))
+        elif array_type == "torch":
+            x = torch.ones((34, 4))
+            y = torch.ones((34, 2))
         elif array_type == "pandas":
             x = pandas.DataFrame(np.random.random((34, 4)))
             y = pandas.DataFrame(np.random.random((34, 2)))

--- a/keras_core/trainers/data_adapters/data_adapter_utils.py
+++ b/keras_core/trainers/data_adapters/data_adapter_utils.py
@@ -1,6 +1,5 @@
 import math
 
-import jax
 import numpy as np
 import tensorflow as tf
 
@@ -12,15 +11,12 @@ except ImportError:
     pandas = None
 
 
-ARRAY_TYPES = (tf.Tensor, np.ndarray, jax.numpy.ndarray)
+# Leave jax, tf, and torch arrays off this list. Instead we will use
+# `__array__` to detect these types. Doing so allows us to avoid importing a
+# backend framework we are not currently using just to do type-checking.
+ARRAY_TYPES = (np.ndarray,)
 if pandas:
-    ARRAY_TYPES = ARRAY_TYPES + (
-        tf.Tensor,
-        np.ndarray,
-        pandas.Series,
-        pandas.DataFrame,
-    )
-# TODO: support torch tensors?
+    ARRAY_TYPES = ARRAY_TYPES + (pandas.Series, pandas.DataFrame)
 
 
 @keras_core_export("keras_core.utils.unpack_x_y_sample_weight")

--- a/keras_core/trainers/epoch_iterator.py
+++ b/keras_core/trainers/epoch_iterator.py
@@ -42,10 +42,8 @@ import types
 import warnings
 
 import tensorflow as tf
-from tensorflow import nest
 
 from keras_core.trainers.data_adapters import array_data_adapter
-from keras_core.trainers.data_adapters import data_adapter_utils
 from keras_core.trainers.data_adapters import generator_data_adapter
 from keras_core.trainers.data_adapters import py_dataset_adapter
 from keras_core.trainers.data_adapters import tf_dataset_adapter
@@ -68,8 +66,7 @@ class EpochIterator:
         if steps_per_epoch:
             self._current_iterator = None
             self._insufficient_data = False
-        first_element = next(iter(nest.flatten(x)), None)
-        if isinstance(first_element, data_adapter_utils.ARRAY_TYPES):
+        if array_data_adapter.can_convert_arrays((x, y, sample_weight)):
             self.data_adapter = array_data_adapter.ArrayDataAdapter(
                 x,
                 y,


### PR DESCRIPTION
We use the `ARRAY_TYPES` in the epoch iterator to decide if an input tensor to decide if an input type should be handle by the `ArrayDataAdapter`. Without this change was seeing some errors passing torch tensors to fit/predict on the torch backend.

Because this means that torch will be imported on all backends, we need to move out import hack to all backends as well.

Fixes #256.