### PR TITLE
Don't assign _keras_mask when `None`

### DIFF
--- a/keras_core/models/functional.py
+++ b/keras_core/models/functional.py
@@ -175,7 +175,8 @@ class Functional(Function, Model):
         else:
             masks = self._flatten_to_reference_inputs(mask)
             for x, mask in zip(inputs, masks):
-                x._keras_mask = mask
+                if mask is not None:
+                    x._keras_mask = mask
         outputs = self._run_through_graph(
             inputs, operation_fn=lambda op: operation_fn(op, training=training)
         )


### PR DESCRIPTION
Not totally sure this fix is right, here's the sequence I am seeing.
 - In jax, call a functional model with nested inputs and compilation.
 - In [this](https://github.com/keras-team/keras-core/blob/96debe6d38381055ddb3d929ec4816d0145cad5a/keras_core/layers/layer.py#L616) block of layer call, the mask argument is filled out to match the nested structure with all `None`s.
 - In functional call, these `None`s are attempted to be assigned to to the input tensors, which does not work for jax tracing inputs it looks like (no assignment to `DynamicJaxprTracer`).
 - The following error is triggered.

```python
    def call(self, inputs, training=None, mask=None):
        # Add support for traning, masking
        inputs = self._standardize_inputs(inputs)
        if mask is None:
            masks = [None] * len(inputs)
        else:
            masks = self._flatten_to_reference_inputs(mask)
            for x, mask in zip(inputs, masks):
>               x._keras_mask = mask
E               AttributeError: 'DynamicJaxprTracer' object has no attribute '_keras_mask'
```

This fixes things for our use cases, but if someone was really passing a non-zero mask argument here, we need a better fix for attaching state to jax inputs (or avoiding doing so at trace time).