### PR TITLE
Handle mixed scalars and tensors in torch convert_to_tensor

### DIFF
--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -129,9 +129,9 @@ def convert_to_tensor(x, dtype=None):
     # Convert to np in case of any array-like that is not list or tuple.
     if not isinstance(x, (list, tuple)):
         x = np.array(x)
-    elif len(x) > 0 and isinstance(x[0], torch.Tensor):
+    elif len(x) > 0 and any(isinstance(x1, torch.Tensor) for x1 in x):
         # Handle list or tuple of torch tensors
-        return torch.stack(x)
+        return torch.stack([convert_to_tensor(x1) for x1 in x])
     if isinstance(x, np.ndarray) and x.dtype == np.uint32:
         # Torch backend does not support uint32.
         x = x.astype(np.int64)

--- a/keras_core/operations/core_test.py
+++ b/keras_core/operations/core_test.py
@@ -239,5 +239,9 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         self.assertAllEqual(x, (1, 1))
         self.assertIsInstance(x, np.ndarray)
 
+        # Partially converted.
+        x = ops.convert_to_tensor((1, ops.array(2), 3))
+        self.assertAllEqual(x, (1, 2, 3))
+
         with self.assertRaises(ValueError):
             ops.convert_to_numpy(KerasTensor((2,)))


### PR DESCRIPTION
Most tf ops, and tf.convert_to_tensor itself, handle a "mixed" input where some elements are tensors and other python scalars. Most commonly that would be something like this

```python
batch_size = tf.shape(x)[0]
ones = tf.ones((batch_size, 128))
new_shape = tf.convert_to_tensor([batch_size, 128])
```

Would definitely be friendly and consistent to allow the same in the torch backend. The main place to do this is allowing mixed types in `convert_to_tensor`, so we can convert inputs to torch functions.