### PR TITLE
Copy torch tensor before update in `slice_update`

### DIFF
--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -302,8 +302,9 @@ def slice_update(inputs, start_indices, updates):
         python_slice(start_index, start_index + update_length)
         for start_index, update_length in zip(start_indices, updates.shape)
     ]
-    inputs[slices] = updates
-    return inputs
+    outputs = torch.clone(inputs)
+    outputs[slices] = updates
+    return outputs
 
 
 def while_loop(


### PR DESCRIPTION
Without this change, the `slice_update` call would fail when gradients are need for the input/output tensors:

```
RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.
```

With this change, the error goes away as the slice is no longer considered in place for the input variable.