### PR TITLE
fix tf assign

### DIFF
--- a/keras_core/backend/tensorflow/core.py
+++ b/keras_core/backend/tensorflow/core.py
@@ -28,7 +28,7 @@ class Variable(
         )
 
     def _direct_assign(self, value):
-        self.value.assign(value)
+        self._value.assign(tf.cast(value, self._value.dtype))
 
     def _convert_to_tensor(self, value, dtype=None):
         return convert_to_tensor(value, dtype=dtype)


### PR DESCRIPTION
We shouldn't assign to `value` property, which could be a `Tensor` in mixed precision. 