### PR TITLE
Use tf.repeat instead of tfnp.repeat

### DIFF
--- a/keras_core/backend/tensorflow/numpy.py
+++ b/keras_core/backend/tensorflow/numpy.py
@@ -444,7 +444,9 @@ def reciprocal(x):
 
 
 def repeat(x, repeats, axis=None):
-    return tfnp.repeat(x, repeats, axis=axis)
+    # tfnp.repeat has trouble with dynamic Tensors in compiled function.
+    # tf.repeat does not.
+    return tf.repeat(x, repeats, axis=axis)
 
 
 def reshape(x, new_shape):


### PR DESCRIPTION
tfnp.repeat has trouble with dynamic tensors in compiled functions. The specific error:

NotImplementedError: Cannot convert a symbolic tf.Tensor (strided_slice_8:0) to a numpy array. This error may indicate that you're trying to pass a Tensor to a NumPy call, which is not supported.