### PR TITLE
Fix the take op for the torch backend

### DIFF
--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -750,7 +750,14 @@ def take(x, indices, axis=None):
         # This case is equivalent to embedding lookup.
         return torch.nn.functional.embedding(indices, x)
     if axis is not None:
-        return torch.index_select(x, dim=axis, index=indices).squeeze(axis)
+        # make sure axis is non-negative
+        axis = len(x.shape) + axis if axis < 0 else axis
+        shape = x.shape[:axis] + indices.shape + x.shape[axis + 1 :]
+        # ravel the `indices` since `index_select` expects `indices`
+        # to be a vector (1-D tensor).
+        indices = indices.ravel()
+        out = torch.index_select(x, dim=axis, index=indices).squeeze(axis)
+        return out.reshape(shape)
     return torch.take(x, index=indices)
 
 

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -2814,16 +2814,16 @@ class Take(Operation):
 
     def compute_output_spec(self, x, indices):
         x_shape = list(x.shape)
-        indices_shape = list(getattr(np.array(indices), "shape", []))
+        if isinstance(indices, KerasTensor):
+            indices_shape = list(indices.shape)
+        else:
+            indices_shape = list(getattr(np.array(indices), "shape", []))
         if self.axis is None:
             return KerasTensor(indices_shape, dtype=x.dtype)
 
-        if self.axis == -1:
-            output_shape = x_shape[:-1] + indices_shape
-        else:
-            output_shape = (
-                x_shape[: self.axis] + indices_shape + x_shape[self.axis + 1 :]
-            )
+        # make sure axis is non-negative
+        axis = len(x_shape) + self.axis if self.axis < 0 else self.axis
+        output_shape = x_shape[:axis] + indices_shape + x_shape[axis + 1 :]
         return KerasTensor(output_shape, dtype=x.dtype)
 
 

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -203,6 +203,14 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
             knp.take(x, [[1, 2], [1, 2]], axis=1).shape, (None, 2, 2, 3)
         )
 
+        # test with negative axis
+        self.assertEqual(knp.take(x, 1, axis=-2).shape, (None, 3))
+
+        # test with multi-dimensional indices
+        x = KerasTensor([None, 3, None, 5])
+        indices = KerasTensor([6, 7])
+        self.assertEqual(knp.take(x, indices, axis=2).shape, (None, 3, 6, 7, 5))
+
     def test_take_along_axis(self):
         x = KerasTensor([None, 3])
         indices = KerasTensor([1, 3])
@@ -585,6 +593,11 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(knp.take(x, 1).shape, ())
         self.assertEqual(knp.take(x, [1, 2]).shape, (2,))
         self.assertEqual(knp.take(x, [[1, 2], [1, 2]], axis=1).shape, (2, 2, 2))
+
+        # test with multi-dimensional indices
+        x = KerasTensor([2, 3, 4, 5])
+        indices = KerasTensor([6, 7])
+        self.assertEqual(knp.take(x, indices, axis=2).shape, (2, 3, 6, 7, 5))
 
     def test_take_along_axis(self):
         x = KerasTensor([2, 3])
@@ -1979,6 +1992,21 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase):
         self.assertAllClose(knp.Take()(x, indices), np.take(x, indices))
         self.assertAllClose(knp.Take()(x, 0), np.take(x, 0))
         self.assertAllClose(knp.Take(axis=1)(x, 0), np.take(x, 0, axis=1))
+
+        # test with multi-dimensional indices
+        rng = np.random.default_rng(0)
+        x = rng.standard_normal((2, 3, 4, 5))
+        indices = rng.integers(0, 4, (6, 7))
+        self.assertAllClose(
+            knp.take(x, indices, axis=2),
+            np.take(x, indices, axis=2),
+        )
+
+        # test with negative axis
+        self.assertAllClose(
+            knp.take(x, indices, axis=-2),
+            np.take(x, indices, axis=-2),
+        )
 
     def test_take_along_axis(self):
         x = np.arange(24).reshape([1, 2, 3, 4])


### PR DESCRIPTION
The `take` op failed when the `indices` were multi-dimentional because `torch.index_select` expected the indices to be a vector (1-D tensor). This PR fixes this bug and also adds comprehensive tests for it.

Another bug I noticed in symbolic computation is that it'd break for negative `axis < -1`. This PR also fixes this bug and adds a test for it.

cc @ianstenbit 