### PR TITLE
Use detach instead of requires_grad_ for the torch backend

### DIFF
--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -340,4 +340,6 @@ def while_loop(
 
 
 def stop_gradient(variable):
-    return variable.requires_grad_(False)
+    # We can't use `.requires_grad_(False)` here since it only
+    # works when the tensor is a leaf node in the graph.
+    return variable.detach()


### PR DESCRIPTION
In the `stop_gradient` op, PyTorch raises if the input tensor is a non-leaf node in the graph.

<details>
<summary>Error message</summary>

```
RuntimeError: you can only change requires_grad flags of leaf variables. If you want to use a computed variable in a subgraph that doesn't require differentiation use var_no_grad = var.detach().
```

</details>

We should use the `.detach()` method instead of `._requires_grad(False)`.

cc @ianstenbit 