### PR TITLE
Fix the `get_device()` function for the torch backend

### DIFF
--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -46,7 +46,7 @@ def get_default_device():
 def get_device():
     device = global_state.get_global_attribute("torch_device", None)
     if device is None:
-        get_default_device()
+        return get_default_device()
     return device
 
 


### PR DESCRIPTION
The `get_device()` function returned `None` for non-symbolic tensors. This PR fixes that issue.