### PR TITLE
Support negative values in Torch implementation of ops.one_hot

### DIFF
--- a/keras_core/backend/torch/nn.py
+++ b/keras_core/backend/torch/nn.py
@@ -9,6 +9,9 @@ from keras_core.backend.common.backend_utils import (
 from keras_core.backend.config import epsilon
 from keras_core.backend.torch.core import convert_to_tensor
 from keras_core.backend.torch.core import get_device
+from keras_core.backend.torch.numpy import expand_dims
+from keras_core.backend.torch.numpy import maximum
+from keras_core.backend.torch.numpy import where
 from keras_core.utils.argument_validation import standardize_tuple
 
 
@@ -516,7 +519,13 @@ def one_hot(x, num_classes, axis=-1, dtype="float32"):
     # Axis is the output axis. By default, PyTorch, outputs to last axis.
     # If axis is not last, change output to axis and shift remaining elements.
     x = convert_to_tensor(x, dtype=torch.long)
-    output = tnn.one_hot(x, num_classes)
+
+    # Torch one_hot does not natively handle negative values, so we add some
+    # manual handling for negatives in the input to one_hot by using max(x, 0).
+    # The output will have some invalid results, so we set them back to 0 using
+    # `where` afterwards.
+    output = tnn.one_hot(maximum(x, 0), num_classes)
+    output = where(expand_dims(x, axis=-1) >= 0, output, 0)
     output = convert_to_tensor(output, dtype=dtype)
     dims = output.dim()
     if axis != -1 and axis != dims:

--- a/keras_core/ops/nn_test.py
+++ b/keras_core/ops/nn_test.py
@@ -1022,6 +1022,12 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             tf.one_hot(indices_2d, 4, axis=1),
         )
 
+        # Test 1D one-hot with negative inputs
+        indices_1d = np.array([0, -1, -1, 3])
+        self.assertAllClose(
+            knn.one_hot(indices_1d, 4), tf.one_hot(indices_1d, 4)
+        )
+
     def test_binary_crossentropy(self):
         # Test with from_logits=False
         target = np.array([[0.1], [0.9], [0.2], [1.0]])


### PR DESCRIPTION
I've verified that the new test fails prior to my change.