### PR TITLE
Fixed SeedGenerator in the torch backend

### DIFF
--- a/keras_core/backend/torch/random.py
+++ b/keras_core/backend/torch/random.py
@@ -11,13 +11,13 @@ from keras_core.random.seed_generator import make_default_seed
 
 
 def torch_seed_generator(seed):
-    seed_val, _ = draw_seed(seed)
+    first_seed, second_seed = draw_seed(seed)
     device = get_device()
     if device == "meta":
         # Generator is not supported by the meta device.
         return None
     generator = torch.Generator(device=get_device())
-    generator.manual_seed(int(seed_val))
+    generator.manual_seed(int(first_seed + second_seed))
     return generator
 
 

--- a/keras_core/initializers/random_initializers_test.py
+++ b/keras_core/initializers/random_initializers_test.py
@@ -27,6 +27,22 @@ class InitializersTest(testing.TestCase):
 
         self.run_class_serialization_test(initializer)
 
+        # Test that a fixed seed yields the same results each call.
+        initializer = initializers.RandomNormal(
+            mean=mean, stddev=stddev, seed=1337
+        )
+        values = initializer(shape=shape)
+        next_values = initializer(shape=shape)
+        self.assertAllClose(values, next_values)
+
+        # Test that a SeedGenerator yields different results each call.
+        initializer = initializers.RandomNormal(
+            mean=mean, stddev=stddev, seed=backend.random.SeedGenerator(1337)
+        )
+        values = initializer(shape=shape)
+        next_values = initializer(shape=shape)
+        self.assertNotAllClose(values, next_values)
+
         # Test serialization with SeedGenerator
         initializer = initializers.RandomNormal(
             mean=mean, stddev=stddev, seed=backend.random.SeedGenerator(1337)


### PR DESCRIPTION
We were ignoring the second seed entirely, which is quite incorrect as that is the only part of the seed we are incrementing.

I'm just summing the fixed seed and increment counter together for now. Not sure if that's the best approach for truly random seeding, or what approach torch is even using for their seeding/prng, but figure this is much better than nothing.