### PR TITLE
Add names to the input tensor, small typo

### DIFF
--- a/keras_core/models/functional.py
+++ b/keras_core/models/functional.py
@@ -31,10 +31,10 @@ class Functional(Function, Model):
     Example:
 
     ```
-    inputs = {'x1': keras_core.Input(shape=(10,)),
-              'x2': keras_core.Input(shape=(1,))}
+    inputs = {'x1': keras_core.Input(shape=(10,), name='x1'),
+              'x2': keras_core.Input(shape=(1,), name='x2')}
     t = keras_core.layers.Dense(1, activation='relu')(inputs['x1'])
-    outputs = keras_core.layers.Add()([t, inputs['x2'])
+    outputs = keras_core.layers.Add()([t, inputs['x2']])
     model = keras_core.Model(inputs, outputs)
     ```
 


### PR DESCRIPTION
If we don't specify the names in the input tensor, we get:

```python
ValueError: When providing `inputs` as a dict, all keys in the dict must match the names of
the corresponding tensors. Received key 'x1' mapping to value 
<KerasTensor shape=(None, 10), dtype=float32, name=keras_tensor_16> which has name
'keras_tensor_16'. Change the tensor name to 'x1' (via `Input(..., name='x1')`)
```

It works if we specify the names as suggested in the error.