### PR TITLE
Support "torch" and "pytorch" in Backend 

### DIFF
--- a/keras_core/backend/__init__.py
+++ b/keras_core/backend/__init__.py
@@ -1,6 +1,6 @@
 from keras_core.backend.config import backend
 
-if backend() == "torch":
+if backend() in ["torch", "pytorch"]:
     # When using the torch backend,
     # torch needs to be imported first, otherwise it will segfault
     # upon import.


### PR DESCRIPTION
Since Torch is famous as PyTorch and Torch, there should be option to treat both as similar. ref: https://github.com/keras-team/keras-core/issues/455