### PR TITLE
bug fix for seed generator

### DIFF
--- a/keras_core/random/seed_generator.py
+++ b/keras_core/random/seed_generator.py
@@ -2,7 +2,7 @@ import random as python_random
 
 import numpy as np
 
-import keras_core.backend
+from keras_core import backend
 from keras_core.api_export import keras_core_export
 
 
@@ -33,7 +33,7 @@ class SeedGenerator:
         if custom_backend is not None:
             self.backend = custom_backend
         else:
-            self.backend = keras_core.backend
+            self.backend = backend
 
         if seed is None:
             seed = make_default_seed()


### PR DESCRIPTION
The `self.backend=keras_core.backend` does not work with `namex` since it should be `keras_core.src.backend` when released.