### PR TITLE
Stop tensorflow from eating all GPU memory

### DIFF
--- a/keras_core/backend/config.py
+++ b/keras_core/backend/config.py
@@ -228,6 +228,13 @@ if "KERAS_BACKEND" in os.environ:
         _BACKEND = _backend
 
 
+if _BACKEND != "tensorflow":
+    # If we are not running on the tensorflow backend, we should stop tensorflow
+    # from using all available GPU memory. See
+    # https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth
+    os.environ["TF_FORCE_GPU_ALLOW_GROWTH"] = "true"
+
+
 @keras_core_export(
     [
         "keras_core.config.backend",


### PR DESCRIPTION
By default, tensorflow will consume all available GPU memory: https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth

Say you are running on KERAS_BACKEND=jax, and jax and tf have both been configured with GPU suport:
- keras_core will always import and initialize tensorflow
- tensorflow will use all available GPU memory
- jax will attempt any GPU allocation and immediately fail

Note this does not happen in colab because colab automatically exports the environment variable:
`TF_FORCE_GPU_ALLOW_GROWTH=true`

From keras-core, we can attempt to work around it by limiting tensorflow GPU growth. Long term we should work around it by not importing tensorflow on jax and torch backends.