### PR TITLE
Complete missing docstrings in keras-core/ops/core.py

### DIFF
--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -273,33 +273,19 @@ def stop_gradient(variable):
 
 @keras_core_export("keras_core.ops.shape")
 def shape(x):
-    """
-    Gets the shape of the tensor input.
+    """Gets the shape of the tensor input.
 
     Args:
         x: A tensor. This function will try to access the `shape` attribute of
-            the input tensor. When using TensorFlow backend the input can also
-            be a list.
+            the input tensor.
 
     Returns:
         A tuple of integers, the shape of the tensor.
 
     Examples:
-        TensorFlow Backend with a list:
-        >>> keras_core.ops.shape([812])
-        <tf.Tensor: shape=(1,), dtype=int32, numpy=array([1], dtype=int32)>
-
-        >>> keras_core.ops.shape([[1, 2, 3], [4, 5, 6]])
-        <tf.Tensor: shape=(2,), dtype=int32, numpy=array([2, 3], dtype=int32)>
-
-        PyTorch Tensor:
-        >>> keras_core.ops.shape(torch.Tensor([[1, 2, 3], [4, 5, 6]]))
-        >>> torch.Size([2, 3])
-
-        TensorFlow Tensor:
-        >>> keras_core.ops.shape(tf.constant([[1, 2, 3], [4, 5, 6]]))
-        <tf.Tensor: shape=(2,), dtype=int32,
-            numpy=array([2, 3], dtype=int32)>
+        >>> x = keras_core.zeros((8, 12))
+        >>> keras_core.ops.shape(x)
+        (8, 12)
 
     """
 
@@ -310,8 +296,7 @@ def shape(x):
 
 @keras_core_export("keras_core.ops.cast")
 def cast(x, dtype):
-    """
-    Cast a tensor to the desired dtype.
+    """Cast a tensor to the desired dtype.
 
     Args:
         x: A tensor or variable.
@@ -321,18 +306,8 @@ def cast(x, dtype):
         A tensor of the specified `dtype`.
 
     Examples:
-        TensorFlow Backend:
-            >>> keras_core.ops.cast([1, 2, 3], "float32")
-            <tf.Tensor: shape=(3,), dtype=float32,
-                numpy=array([1., 2., 3.], dtype=float32)>
-
-        PyTorch Backend:
-            >>> keras_core.ops.cast([1, 2, 3], "float32")
-            tensor([1., 2., 3.])
-
-        JAX Backend:
-            >>> keras_core.ops.cast([1, 2, 3], "float32")
-            Array([1., 2., 3.], dtype=float32)
+        >>> x = keras_core.ops.arange(4)
+        >>> keras_core.ops.cast(x, "float32")
 
     """
     dtype = backend.standardize_dtype(dtype)
@@ -344,29 +319,18 @@ def cast(x, dtype):
 
 @keras_core_export("keras_core.ops.convert_to_tensor")
 def convert_to_tensor(x, dtype=None):
-    """
-    Convert a NumPy array to a tensor.
+    """Convert a NumPy array to a tensor.
 
     Args:
-        x: A NumPy array or a tensor.
+        x: A NumPy array.
         dtype: The target type.
 
     Returns:
         A tensor of the specified `dtype`.
 
     Examples:
-        TensorFlow Backend:
-            >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
-            <tf.Tensor: shape=(3,), dtype=float32,
-                numpy=array([1., 2., 3.], dtype=float32)>
-
-        PyTorch Backend:
-            >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
-            tensor([1., 2., 3.])
-
-        JAX Backend:
-            >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
-            Array([1., 2., 3.], dtype=float32)
+        >>> x = np.array([1, 2, 3])
+        >>> keras_core.ops.convert_to_tensor(x)
 
     """
 
@@ -375,23 +339,13 @@ def convert_to_tensor(x, dtype=None):
 
 @keras_core_export("keras_core.ops.convert_to_numpy")
 def convert_to_numpy(x):
-    """
-    Convert a tensor to a NumPy array.
+    """Convert a tensor to a NumPy array.
 
     Args:
         x: A tensor.
 
     Returns:
         A NumPy array.
-
-    Examples:
-        TensorFlow Tensor:
-            >>> keras_core.ops.convert_to_numpy(tf.constant([1, 2, 3]))
-            array([1, 2, 3], dtype=int32)
-
-        PyTorch Tensor:
-            >>> keras_core.ops.convert_to_numpy(torch.Tensor([1, 2, 3]))
-            array([1, 2, 3])
 
     """
 

--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -283,10 +283,10 @@ def shape(x):
         A tuple of integers or None values, indicating the shape of the input
             tensor.
 
-    Examples:
-        >>> x = keras_core.zeros((8, 12))
-        >>> keras_core.ops.shape(x)
-        (8, 12)
+    Example:
+    >>> x = keras_core.zeros((8, 12))
+    >>> keras_core.ops.shape(x)
+    (8, 12)
 
     """
 
@@ -306,9 +306,9 @@ def cast(x, dtype):
     Returns:
         A tensor of the specified `dtype`.
 
-    Examples:
-        >>> x = keras_core.ops.arange(4)
-        >>> keras_core.ops.cast(x, "float32")
+    Example:
+    >>> x = keras_core.ops.arange(4)
+    >>> keras_core.ops.cast(x, "float32")
 
     """
     dtype = backend.standardize_dtype(dtype)
@@ -329,9 +329,9 @@ def convert_to_tensor(x, dtype=None):
     Returns:
         A tensor of the specified `dtype`.
 
-    Examples:
-        >>> x = np.array([1, 2, 3])
-        >>> keras_core.ops.convert_to_tensor(x)
+    Example:
+    >>> x = np.array([1, 2, 3])
+    >>> keras_core.ops.convert_to_tensor(x)
 
     """
 

--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -287,10 +287,10 @@ def shape(x):
     Examples:
         TensorFlow Backend with a list:
         >>> keras_core.ops.shape([812])
-        >>> <tf.Tensor: shape=(1,), dtype=int32, numpy=array([1], dtype=int32)>
+        <tf.Tensor: shape=(1,), dtype=int32, numpy=array([1], dtype=int32)>
 
         >>> keras_core.ops.shape([[1, 2, 3], [4, 5, 6]])
-        >>> <tf.Tensor: shape=(2,), dtype=int32, numpy=array([2, 3], dtype=int32)>
+        <tf.Tensor: shape=(2,), dtype=int32, numpy=array([2, 3], dtype=int32)>
 
         PyTorch Tensor:
         >>> keras_core.ops.shape(torch.Tensor([[1, 2, 3], [4, 5, 6]]))
@@ -298,8 +298,8 @@ def shape(x):
 
         TensorFlow Tensor:
         >>> keras_core.ops.shape(tf.constant([[1, 2, 3], [4, 5, 6]]))
-        >>> <tf.Tensor: shape=(2,), dtype=int32,
-        ...     numpy=array([2, 3], dtype=int32)>
+        <tf.Tensor: shape=(2,), dtype=int32,
+            numpy=array([2, 3], dtype=int32)>
 
     """
 
@@ -323,16 +323,16 @@ def cast(x, dtype):
     Examples:
         TensorFlow Backend:
             >>> keras_core.ops.cast([1, 2, 3], "float32")
-            >>> <tf.Tensor: shape=(3,), dtype=float32,
-            ...     numpy=array([1., 2., 3.], dtype=float32)>
+            <tf.Tensor: shape=(3,), dtype=float32,
+                numpy=array([1., 2., 3.], dtype=float32)>
 
         PyTorch Backend:
             >>> keras_core.ops.cast([1, 2, 3], "float32")
-            >>> tensor([1., 2., 3.])
+            tensor([1., 2., 3.])
 
         JAX Backend:
             >>> keras_core.ops.cast([1, 2, 3], "float32")
-            >>> Array([1., 2., 3.], dtype=float32)
+            Array([1., 2., 3.], dtype=float32)
 
     """
     dtype = backend.standardize_dtype(dtype)
@@ -357,16 +357,17 @@ def convert_to_tensor(x, dtype=None):
     Examples:
         TensorFlow Backend:
             >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
-            >>> <tf.Tensor: shape=(3,), dtype=float32,
-            ...     numpy=array([1., 2., 3.], dtype=float32)>
+            <tf.Tensor: shape=(3,), dtype=float32,
+                numpy=array([1., 2., 3.], dtype=float32)>
             
         PyTorch Backend:
             >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
-            >>> tensor([1., 2., 3.])
+            tensor([1., 2., 3.])
             
         JAX Backend:
             >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
-            >>> Array([1., 2., 3.], dtype=float32)
+            Array([1., 2., 3.], dtype=float32)
+
     """
 
     return backend.convert_to_tensor(x, dtype=dtype)
@@ -384,13 +385,13 @@ def convert_to_numpy(x):
         A NumPy array.
 
     Examples:
-        TensorFlow Backend:
+        TensorFlow Tensor:
             >>> keras_core.ops.convert_to_numpy(tf.constant([1, 2, 3]))
-            >>> array([1, 2, 3], dtype=int32)
+            array([1, 2, 3], dtype=int32)
 
-        PyTorch Backend:
+        PyTorch Tensor:
             >>> keras_core.ops.convert_to_numpy(torch.Tensor([1, 2, 3]))
-            >>> array([1, 2, 3])
+            array([1, 2, 3])
 
     """
 

--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -346,24 +346,24 @@ def cast(x, dtype):
 def convert_to_tensor(x, dtype=None):
     """
     Convert a NumPy array to a tensor.
-    
+
     Args:
         x: A NumPy array or a tensor.
         dtype: The target type.
-        
+
     Returns:
         A tensor of the specified `dtype`.
-        
+
     Examples:
         TensorFlow Backend:
             >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
             <tf.Tensor: shape=(3,), dtype=float32,
                 numpy=array([1., 2., 3.], dtype=float32)>
-            
+
         PyTorch Backend:
             >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
             tensor([1., 2., 3.])
-            
+
         JAX Backend:
             >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
             Array([1., 2., 3.], dtype=float32)

--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -298,7 +298,8 @@ def shape(x):
 
         TensorFlow Tensor:
         >>> keras_core.ops.shape(tf.constant([[1, 2, 3], [4, 5, 6]]))
-        >>> <tf.Tensor: shape=(2, 3), dtype=int32, numpy=
+        >>> <tf.Tensor: shape=(2,), dtype=int32,
+        ...     numpy=array([2, 3], dtype=int32)>
 
     """
 

--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -280,7 +280,8 @@ def shape(x):
             the input tensor.
 
     Returns:
-        A tuple of integers, the shape of the tensor.
+        A tuple of integers or None values, indicating the shape of the input
+            tensor.
 
     Examples:
         >>> x = keras_core.zeros((8, 12))

--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -273,7 +273,35 @@ def stop_gradient(variable):
 
 @keras_core_export("keras_core.ops.shape")
 def shape(x):
-    """Gets the shape of the tensor input."""
+    """
+    Gets the shape of the tensor input.
+
+    Args:
+        x: A tensor. This function will try to access the `shape` attribute of
+            the input tensor. When using TensorFlow backend the input can also
+            be a list.
+
+    Returns:
+        A tuple of integers, the shape of the tensor.
+
+    Examples:
+        TensorFlow Backend with a list:
+        >>> keras_core.ops.shape([812])
+        >>> <tf.Tensor: shape=(1,), dtype=int32, numpy=array([1], dtype=int32)>
+
+        >>> keras_core.ops.shape([[1, 2, 3], [4, 5, 6]])
+        >>> <tf.Tensor: shape=(2,), dtype=int32, numpy=array([2, 3], dtype=int32)>
+
+        PyTorch Tensor:
+        >>> keras_core.ops.shape(torch.Tensor([[1, 2, 3], [4, 5, 6]]))
+        >>> torch.Size([2, 3])
+
+        TensorFlow Tensor:
+        >>> keras_core.ops.shape(tf.constant([[1, 2, 3], [4, 5, 6]]))
+        >>> <tf.Tensor: shape=(2, 3), dtype=int32, numpy=
+
+    """
+
     if any_symbolic_tensors((x,)):
         return x.shape
     return backend.core.shape(x)
@@ -281,8 +309,33 @@ def shape(x):
 
 @keras_core_export("keras_core.ops.cast")
 def cast(x, dtype):
-    """Cast a tensor to the desired dtype."""
+    """
+    Cast a tensor to the desired dtype.
+
+    Args:
+        x: A tensor or variable.
+        dtype: The target type.
+
+    Returns:
+        A tensor of the specified `dtype`.
+
+    Examples:
+        TensorFlow Backend:
+            >>> keras_core.ops.cast([1, 2, 3], "float32")
+            >>> <tf.Tensor: shape=(3,), dtype=float32,
+            ...     numpy=array([1., 2., 3.], dtype=float32)>
+
+        PyTorch Backend:
+            >>> keras_core.ops.cast([1, 2, 3], "float32")
+            >>> tensor([1., 2., 3.])
+
+        JAX Backend:
+            >>> keras_core.ops.cast([1, 2, 3], "float32")
+            >>> Array([1., 2., 3.], dtype=float32)
+
+    """
     dtype = backend.standardize_dtype(dtype)
+
     if any_symbolic_tensors((x,)):
         return backend.KerasTensor(shape=x.shape, dtype=dtype)
     return backend.core.cast(x, dtype)
@@ -290,13 +343,56 @@ def cast(x, dtype):
 
 @keras_core_export("keras_core.ops.convert_to_tensor")
 def convert_to_tensor(x, dtype=None):
-    """Convert a NumPy array to a tensor."""
+    """
+    Convert a NumPy array to a tensor.
+    
+    Args:
+        x: A NumPy array or a tensor.
+        dtype: The target type.
+        
+    Returns:
+        A tensor of the specified `dtype`.
+        
+    Examples:
+        TensorFlow Backend:
+            >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
+            >>> <tf.Tensor: shape=(3,), dtype=float32,
+            ...     numpy=array([1., 2., 3.], dtype=float32)>
+            
+        PyTorch Backend:
+            >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
+            >>> tensor([1., 2., 3.])
+            
+        JAX Backend:
+            >>> keras_core.ops.convert_to_tensor(np.array([1, 2, 3]), "float32")
+            >>> Array([1., 2., 3.], dtype=float32)
+    """
+
     return backend.convert_to_tensor(x, dtype=dtype)
 
 
 @keras_core_export("keras_core.ops.convert_to_numpy")
 def convert_to_numpy(x):
-    """Convert a tensor to a NumPy array."""
+    """
+    Convert a tensor to a NumPy array.
+
+    Args:
+        x: A tensor.
+
+    Returns:
+        A NumPy array.
+
+    Examples:
+        TensorFlow Backend:
+            >>> keras_core.ops.convert_to_numpy(tf.constant([1, 2, 3]))
+            >>> array([1, 2, 3], dtype=int32)
+
+        PyTorch Backend:
+            >>> keras_core.ops.convert_to_numpy(torch.Tensor([1, 2, 3]))
+            >>> array([1, 2, 3])
+
+    """
+
     if any_symbolic_tensors((x,)):
         # This will raise a `ValueError` defined in the `KerasTensor` class. We
         # trigger it rather than duplicate it here.


### PR DESCRIPTION
Most of the py files have the functions defined in that module at top:

Example:
```python
"""
scatter
scatter_update
slice
slice_update
while_loop
stop_gradient
shape
cast
convert_to_tensor
convert_to_numpy
"""
```
Should they be removed?