### PR TITLE
split_dataset utils implementation to Keras Core from tf.keras

### DIFF
--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -747,8 +747,10 @@ def take(x, indices, axis=None):
     x = convert_to_tensor(x)
     indices = convert_to_tensor(indices).long()
     if x.ndim == 2 and (axis is None or axis == 0):
+
         # This case is equivalent to embedding lookup.
         return torch.nn.functional.embedding(indices, x)
+    
     if axis is not None:
         # make sure axis is non-negative
         axis = len(x.shape) + axis if axis < 0 else axis
@@ -758,6 +760,7 @@ def take(x, indices, axis=None):
         indices = indices.ravel()
         out = torch.index_select(x, dim=axis, index=indices).squeeze(axis)
         return out.reshape(shape)
+
     return torch.take(x, index=indices)
 
 

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -189,11 +189,11 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.outer(x, y).shape, (None, None))
 
     def test_take(self):
-        x = KerasTensor([None, 3])
+        x = KerasTensor([1, 3])
         self.assertEqual(knp.take(x, 1).shape, ())
         self.assertEqual(knp.take(x, [1, 2]).shape, (2,))
         self.assertEqual(
-            knp.take(x, [[1, 2], [1, 2]], axis=1).shape, (None, 2, 2)
+            knp.take(x, [[1, 2], [1, 2]], axis=1).shape, (1, 2, 2)
         )
 
         x = KerasTensor([None, 3, 3])
@@ -202,7 +202,6 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(
             knp.take(x, [[1, 2], [1, 2]], axis=1).shape, (None, 2, 2, 3)
         )
-
         # test with negative axis
         self.assertEqual(knp.take(x, 1, axis=-2).shape, (None, 3))
 
@@ -245,6 +244,8 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor([None, 1])
         y = KerasTensor([None, 3])
         self.assertEqual(knp.where(condition, x, y).shape, (2, None, 3))
+    
+    
 
 
 class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):

--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -1,4 +1,9 @@
 import tensorflow as tf
+import torch 
+from torch.utils.data import Dataset as torchDataset
+import numpy as np
+import random
+import time
 
 from keras_core.api_export import keras_core_export
 
@@ -7,21 +12,19 @@ from keras_core.api_export import keras_core_export
 def split_dataset(
     dataset, left_size=None, right_size=None, shuffle=False, seed=None
 ):
-    """Splits a dataset into a left half and a right half (e.g. train / test).
+    """Split a dataset into a left half and a right half (e.g. train / test).
 
     Args:
         dataset: A `tf.data.Dataset` object, or a list/tuple of arrays with the
-            same length.
+          same length.
         left_size: If float (in the range `[0, 1]`), it signifies
-            the fraction of the data to pack in the left dataset.
-            If integer, it signifies the number of samples to pack
-            in the left dataset. If `None`, it defaults to the complement
-            to `right_size`.
+          the fraction of the data to pack in the left dataset. If integer, it
+          signifies the number of samples to pack in the left dataset. If
+          `None`, it uses the complement to `right_size`. Defaults to `None`.
         right_size: If float (in the range `[0, 1]`), it signifies
-            the fraction of the data to pack in the right dataset.
-            If integer, it signifies the number of samples to pack
-            in the right dataset. If `None`, it defaults to the complement
-            to `left_size`.
+          the fraction of the data to pack in the right dataset. If integer, it
+          signifies the number of samples to pack in the right dataset. If
+          `None`, it uses the complement to `left_size`. Defaults to `None`.
         shuffle: Boolean, whether to shuffle the data before splitting it.
         seed: A random seed for shuffling.
 
@@ -31,20 +34,362 @@ def split_dataset(
     Example:
 
     >>> data = np.random.random(size=(1000, 4))
-    >>> left_ds, right_ds = split_dataset(data, left_size=0.8)
+    >>> left_ds, right_ds = tf.keras.utils.split_dataset(data, left_size=0.8)
     >>> int(left_ds.cardinality())
     800
     >>> int(right_ds.cardinality())
     200
+
     """
-    # TODO: long-term, port implementation.
-    return tf.keras.utils.split_dataset(
-        dataset,
-        left_size=left_size,
-        right_size=right_size,
-        shuffle=shuffle,
-        seed=seed,
+
+    dataset_type_spec = _get_type_spec(dataset)
+
+    if dataset_type_spec not in [torchDataset, tf.data.Dataset, list, tuple, np.ndarray]:
+        raise TypeError(
+            "The `dataset` argument must be either a `tf.data.Dataset` "
+            "object or a list/tuple of arrays. "
+            f"Received: dataset={dataset} of type {type(dataset)}"
+        )
+
+    if right_size is None and left_size is None:
+        raise ValueError(
+            "At least one of the `left_size` or `right_size` "
+            "must be specified. Received: left_size=None and "
+            "right_size=None"
+        )
+
+    dataset_as_list = _convert_dataset_to_list(dataset, dataset_type_spec)
+
+    if shuffle:
+        if seed is None:
+            seed = random.randint(0, int(1e6))
+        random.seed(seed)
+        random.shuffle(dataset_as_list)
+
+    total_length = len(dataset_as_list)
+
+    left_size, right_size = _rescale_dataset_split_sizes(
+        left_size, right_size, total_length
     )
+    left_split = list(dataset_as_list[:left_size])
+    right_split = list(dataset_as_list[-right_size:])
+
+    left_split = _restore_dataset_from_list(
+        left_split, dataset_type_spec, dataset
+    )
+    right_split = _restore_dataset_from_list(
+        right_split, dataset_type_spec, dataset
+    )
+
+    left_split = tf.data.Dataset.from_tensor_slices(left_split)
+    right_split = tf.data.Dataset.from_tensor_slices(right_split)
+
+    # apply batching to the splits if the dataset is batched
+    if dataset_type_spec is tf.data.Dataset and is_batched(dataset):
+        batch_size = get_batch_size(dataset)
+        if batch_size is not None:
+            left_split = left_split.batch(batch_size)
+            right_split = right_split.batch(batch_size)
+
+    left_split = left_split.prefetch(tf.data.AUTOTUNE)
+    right_split = right_split.prefetch(tf.data.AUTOTUNE)
+
+    return left_split, right_split
+
+
+def _convert_dataset_to_list(
+    dataset,
+    dataset_type_spec,
+    data_size_warning_flag=True,
+    ensure_shape_similarity=True,
+):
+    """Convert `tf.data.Dataset` object or list/tuple of NumPy arrays to a list.
+
+    Args:
+        dataset : A `tf.data.Dataset` object or a list/tuple of arrays.
+        dataset_type_spec : the type of the dataset
+        data_size_warning_flag (bool, optional): If set to True, a warning will
+          be issued if the dataset takes longer than 10 seconds to iterate.
+          Defaults to `True`.
+        ensure_shape_similarity (bool, optional): If set to True, the shape of
+          the first sample will be used to validate the shape of rest of the
+          samples. Defaults to `True`.
+
+    Returns:
+        List: A list of tuples/NumPy arrays.
+    """
+    dataset_iterator = _get_data_iterator_from_dataset(
+        dataset, dataset_type_spec
+    )
+    dataset_as_list = []
+
+    start_time = time.time()
+    for sample in _get_next_sample(
+        dataset_iterator,
+        ensure_shape_similarity,
+        data_size_warning_flag,
+        start_time,
+    ):
+        if dataset_type_spec in [tuple, list]:
+            # The try-except here is for NumPy 1.24 compatibility, see:
+            # https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
+            try:
+                arr = np.array(sample)
+            except ValueError:
+                arr = np.array(sample, dtype=object)
+            dataset_as_list.append(arr)
+        else:
+            dataset_as_list.append(sample)
+
+    return dataset_as_list
+
+def _get_data_iterator_from_dataset(dataset, dataset_type_spec):
+    """Get the iterator from a dataset.
+
+    Args:
+        dataset :  A `tf.data.Dataset` object or a list/tuple of arrays.
+        dataset_type_spec : the type of the dataset
+
+    Raises:
+        ValueError:
+                  - If the dataset is empty.
+                  - If the dataset is not a `tf.data.Dataset` object
+                    or a list/tuple of arrays.
+                  - If the dataset is a list/tuple of arrays and the
+                    length of the list/tuple is not equal to the number
+
+    Returns:
+        iterator: An `iterator` object.
+    """
+    if dataset_type_spec == list:
+        if len(dataset) == 0:
+            raise ValueError(
+                "Received an empty list dataset. "
+                "Please provide a non-empty list of arrays."
+            )
+
+        if _get_type_spec(dataset[0]) is np.ndarray:
+            expected_shape = dataset[0].shape
+            for i, element in enumerate(dataset):
+                if np.array(element).shape[0] != expected_shape[0]:
+                    raise ValueError(
+                        "Received a list of NumPy arrays with different "
+                        f"lengths. Mismatch found at index {i}, "
+                        f"Expected shape={expected_shape} "
+                        f"Received shape={np.array(element).shape}."
+                        "Please provide a list of NumPy arrays with "
+                        "the same length."
+                    )
+        else:
+            raise ValueError(
+                "Expected a list of `numpy.ndarray` objects,"
+                f"Received: {type(dataset[0])}"
+            )
+
+        return iter(zip(*dataset))
+    elif dataset_type_spec == tuple:
+        if len(dataset) == 0:
+            raise ValueError(
+                "Received an empty list dataset."
+                "Please provide a non-empty tuple of arrays."
+            )
+
+        if _get_type_spec(dataset[0]) is np.ndarray:
+            expected_shape = dataset[0].shape
+            for i, element in enumerate(dataset):
+                if np.array(element).shape[0] != expected_shape[0]:
+                    raise ValueError(
+                        "Received a tuple of NumPy arrays with different "
+                        f"lengths. Mismatch found at index {i}, "
+                        f"Expected shape={expected_shape} "
+                        f"Received shape={np.array(element).shape}."
+                        "Please provide a tuple of NumPy arrays with "
+                        "the same length."
+                    )
+        else:
+            raise ValueError(
+                "Expected a tuple of `numpy.ndarray` objects, "
+                f"Received: {type(dataset[0])}"
+            )
+
+        return iter(zip(*dataset))
+    elif dataset_type_spec == tf.data.Dataset:
+        if is_batched(dataset):
+            dataset = dataset.unbatch()
+        return iter(dataset)
+    elif dataset_type_spec == np.ndarray:
+        return iter(dataset)
+
+def _rescale_dataset_split_sizes(left_size, right_size, total_length):
+    """Rescale the dataset split sizes.
+
+    We want to ensure that the sum of
+    the split sizes is equal to the total length of the dataset.
+
+    Args:
+        left_size : The size of the left dataset split.
+        right_size : The size of the right dataset split.
+        total_length : The total length of the dataset.
+
+    Raises:
+        TypeError: - If `left_size` or `right_size` is not an integer or float.
+        ValueError: - If `left_size` or `right_size` is negative or greater
+                      than 1 or greater than `total_length`.
+
+    Returns:
+        tuple: A tuple of rescaled left_size and right_size
+    """
+    left_size_type = type(left_size)
+    right_size_type = type(right_size)
+
+    # check both left_size and right_size are integers or floats
+    if (left_size is not None and left_size_type not in [int, float]) and (
+        right_size is not None and right_size_type not in [int, float]
+    ):
+        raise TypeError(
+            "Invalid `left_size` and `right_size` Types. Expected: "
+            "integer or float or None, Received: type(left_size)="
+            f"{left_size_type} and type(right_size)={right_size_type}"
+        )
+
+    # check left_size is a integer or float
+    if left_size is not None and left_size_type not in [int, float]:
+        raise TypeError(
+            "Invalid `left_size` Type. Expected: int or float or None, "
+            f"Received: type(left_size)={left_size_type}.  "
+        )
+
+    # check right_size is a integer or float
+    if right_size is not None and right_size_type not in [int, float]:
+        raise TypeError(
+            "Invalid `right_size` Type. "
+            "Expected: int or float or None,"
+            f"Received: type(right_size)={right_size_type}."
+        )
+
+    # check left_size and right_size are non-zero
+    if left_size == 0 and right_size == 0:
+        raise ValueError(
+            "Both `left_size` and `right_size` are zero. "
+            "At least one of the split sizes must be non-zero."
+        )
+
+    # check left_size is non-negative and less than 1 and less than total_length
+    if (
+        left_size_type == int
+        and (left_size <= 0 or left_size >= total_length)
+        or left_size_type == float
+        and (left_size <= 0 or left_size >= 1)
+    ):
+        raise ValueError(
+            "`left_size` should be either a positive integer "
+            f"smaller than {total_length}, or a float "
+            "within the range `[0, 1]`. Received: left_size="
+            f"{left_size}"
+        )
+
+    # check right_size is non-negative and less than 1 and less than
+    # total_length
+    if (
+        right_size_type == int
+        and (right_size <= 0 or right_size >= total_length)
+        or right_size_type == float
+        and (right_size <= 0 or right_size >= 1)
+    ):
+        raise ValueError(
+            "`right_size` should be either a positive integer "
+            f"and smaller than {total_length} or a float "
+            "within the range `[0, 1]`. Received: right_size="
+            f"{right_size}"
+        )
+
+    # check sum of left_size and right_size is less than or equal to
+    # total_length
+    if (
+        right_size_type == left_size_type == float
+        and right_size + left_size > 1
+    ):
+        raise ValueError(
+            "The sum of `left_size` and `right_size` is greater "
+            "than 1. It must be less than or equal to 1."
+        )
+
+    if left_size_type == float:
+        left_size = round(left_size * total_length)
+    elif left_size_type == int:
+        left_size = float(left_size)
+
+    if right_size_type == float:
+        right_size = round(right_size * total_length)
+    elif right_size_type == int:
+        right_size = float(right_size)
+
+    if left_size is None:
+        left_size = total_length - right_size
+    elif right_size is None:
+        right_size = total_length - left_size
+
+    if left_size + right_size > total_length:
+        raise ValueError(
+            "The sum of `left_size` and `right_size` should "
+            "be smaller than the {total_length}. "
+            f"Received: left_size + right_size = {left_size+right_size}"
+            f"and total_length = {total_length}"
+        )
+
+    for split, side in [(left_size, "left"), (right_size, "right")]:
+        if split == 0:
+            raise ValueError(
+                f"With `dataset` of length={total_length}, `left_size`="
+                f"{left_size} and `right_size`={right_size}."
+                f"Resulting {side} side dataset split will be empty. "
+                "Adjust any of the aforementioned parameters"
+            )
+
+    left_size, right_size = int(left_size), int(right_size)
+    return left_size, right_size
+
+def _restore_dataset_from_list(
+    dataset_as_list, dataset_type_spec, original_dataset
+):
+    """Restore the dataset from the list of arrays."""
+    if dataset_type_spec in [tuple, list]:
+        return tuple(np.array(sample) for sample in zip(*dataset_as_list))
+    elif dataset_type_spec == tf.data.Dataset:
+        if isinstance(original_dataset.element_spec, dict):
+            restored_dataset = {}
+            for d in dataset_as_list:
+                for k, v in d.items():
+                    if k not in restored_dataset:
+                        restored_dataset[k] = [v]
+                    else:
+                        restored_dataset[k].append(v)
+            return restored_dataset
+        else:
+            return tuple(np.array(sample) for sample in zip(*dataset_as_list))
+    return dataset_as_list
+
+def is_batched(dataset):
+    """ "Check if the `tf.data.Dataset` is batched."""
+    return hasattr(dataset, "_batch_size")
+
+def _get_type_spec(dataset):
+    """Get the type spec of the dataset."""
+    if isinstance(dataset, tuple):
+        return tuple
+    elif isinstance(dataset, list):
+        return list
+    elif isinstance(dataset, np.ndarray):
+        return np.ndarray
+    elif isinstance(dataset, dict):
+        return dict
+    elif isinstance(dataset, tf.data.Dataset):
+        return tf.data.Dataset
+    elif isinstance(dataset, torchDataset):
+        return torchDataset
+    else:
+        return None
+
 
 
 @keras_core_export(


### PR DESCRIPTION
Hi Team, 

This PR made following changes to following functions

- moving `keras` data-utils for split_dataset  from [here](https://github.com/keras-team/keras/blob/v2.13.1/keras/utils/dataset_utils.py) making sure all the settings stay's intact.
- need to rewrite following functions since all of them accept `tf.Dataset` and we need to support `torch` and `Jax`.
    -  `split_dataset`
    -  `_convert_dataset_to_list` 
    - `_get_data_iterator_from_dataset`
    - `_get_next_sample` 
    - `_get_type_spec` 
    - `_get_next_sample` 
    - `_rescale_dataset_split_sizes` 
    - `_restore_dataset_from_list` 