### PR TITLE
[split_dataset] migrating from tf.keras to keras_core

### DIFF
--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -1,4 +1,4 @@
-import torch 
+import torch
 import numpy as np
 import warnings
 import random
@@ -42,10 +42,15 @@ def split_dataset(
     """
     from torch.utils.data import Dataset as torchDataset
 
-
     dataset_type_spec = _get_type_spec(dataset)
 
-    if dataset_type_spec not in [torchDataset, tf.data.Dataset, list, tuple, np.ndarray]:
+    if dataset_type_spec not in [
+        torchDataset,
+        tf.data.Dataset,
+        list,
+        tuple,
+        np.ndarray,
+    ]:
         raise TypeError(
             "The `dataset` argument must be either a `tf.data.Dataset` "
             "object or a list/tuple of arrays. "
@@ -75,16 +80,14 @@ def split_dataset(
     left_split = list(dataset_as_list[:left_size])
     right_split = list(dataset_as_list[-right_size:])
 
-    
     left_split = _restore_dataset_from_list(
         left_split, dataset_type_spec, dataset
     )
     right_split = _restore_dataset_from_list(
         right_split, dataset_type_spec, dataset
     )
-    
+
     if dataset_type_spec != torchDataset:
-    
         left_split = tf.data.Dataset.from_tensor_slices(left_split)
         right_split = tf.data.Dataset.from_tensor_slices(right_split)
 
@@ -101,7 +104,6 @@ def split_dataset(
 
     elif dataset_type_spec == torchDataset:
         return dataset.__class__(*left_split), dataset.__class__(*right_split)
-
 
 
 def _convert_dataset_to_list(
@@ -150,6 +152,7 @@ def _convert_dataset_to_list(
 
     return dataset_as_list
 
+
 def _get_data_iterator_from_dataset(dataset, dataset_type_spec):
     """Get the iterator from a dataset.
 
@@ -169,6 +172,7 @@ def _get_data_iterator_from_dataset(dataset, dataset_type_spec):
         iterator: An `iterator` object.
     """
     from torch.utils.data import Dataset as torchDataset
+
     if dataset_type_spec == list:
         if len(dataset) == 0:
             raise ValueError(
@@ -225,14 +229,15 @@ def _get_data_iterator_from_dataset(dataset, dataset_type_spec):
         if is_batched(dataset):
             dataset = dataset.unbatch()
         return iter(dataset)
-    
+
     # torch dataset iterator might be required to change
     elif dataset_type_spec == torchDataset:
         return iter(dataset)
-    
+
     elif dataset_type_spec == np.ndarray:
         return iter(dataset)
-    
+
+
 def _get_next_sample(
     dataset_iterator,
     ensure_shape_similarity,
@@ -264,7 +269,9 @@ def _get_next_sample(
     try:
         dataset_iterator = iter(dataset_iterator)
         first_sample = next(dataset_iterator)
-        if isinstance(first_sample, (tf.Tensor, np.ndarray)) or torch.is_tensor(first_sample):
+        if isinstance(first_sample, (tf.Tensor, np.ndarray)) or torch.is_tensor(
+            first_sample
+        ):
             first_sample_shape = np.array(first_sample).shape
         else:
             first_sample_shape = None
@@ -433,10 +440,12 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
     left_size, right_size = int(left_size), int(right_size)
     return left_size, right_size
 
+
 def _restore_dataset_from_list(
     dataset_as_list, dataset_type_spec, original_dataset
 ):
     from torch.utils.data import Dataset as torchDataset
+
     """Restore the dataset from the list of arrays."""
     if dataset_type_spec in [tuple, list]:
         return tuple(np.array(sample) for sample in zip(*dataset_as_list))
@@ -452,14 +461,16 @@ def _restore_dataset_from_list(
             return restored_dataset
         else:
             return tuple(np.array(sample) for sample in zip(*dataset_as_list))
-        
+
     elif dataset_type_spec == torchDataset:
         return tuple(np.array(sample) for sample in zip(*dataset_as_list))
     return dataset_as_list
 
+
 def is_batched(dataset):
     """ "Check if the `tf.data.Dataset` is batched."""
     return hasattr(dataset, "_batch_size")
+
 
 def get_batch_size(dataset):
     """Get the batch size of the dataset."""
@@ -468,8 +479,10 @@ def get_batch_size(dataset):
     else:
         return None
 
+
 def _get_type_spec(dataset):
     from torch.utils.data import Dataset as torchDataset
+
     """Get the type spec of the dataset."""
     if isinstance(dataset, tuple):
         return tuple
@@ -485,7 +498,6 @@ def _get_type_spec(dataset):
         return torchDataset
     else:
         return None
-
 
 
 @keras_core_export(

--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -38,7 +38,7 @@ def split_dataset(
     Example:
 
     >>> data = np.random.random(size=(1000, 4))
-    >>> left_ds, right_ds = tf.keras.utils.split_dataset(data, left_size=0.8)
+    >>> left_ds, right_ds = keras_core.utils.split_dataset(data, left_size=0.8)
     >>> int(left_ds.cardinality())
     800
     >>> int(right_ds.cardinality())

--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -17,8 +17,7 @@ def split_dataset(
     Args:
         dataset:
             A `tf.data.Dataset or torchDataset`  object,
-            or a list/tuple of arrays with the
-          same length.
+            or a list/tuple of arrays with the same length.
         left_size: If float (in the range `[0, 1]`), it signifies
           the fraction of the data to pack in the left dataset. If integer, it
           signifies the number of samples to pack in the left dataset. If

--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -1,8 +1,10 @@
-import torch
-import numpy as np
-import warnings
 import random
 import time
+import warnings
+
+import numpy as np
+import torch
+
 from keras_core.api_export import keras_core_export
 from keras_core.utils.module_utils import tensorflow as tf
 
@@ -14,7 +16,9 @@ def split_dataset(
     """Split a dataset into a left half and a right half (e.g. train / test).
 
     Args:
-        dataset: A `tf.data.Dataset or torchDataset`  object, or a list/tuple of arrays with the
+        dataset:
+            A `tf.data.Dataset or torchDataset`  object,
+            or a list/tuple of arrays with the
           same length.
         left_size: If float (in the range `[0, 1]`), it signifies
           the fraction of the data to pack in the left dataset. If integer, it
@@ -28,7 +32,8 @@ def split_dataset(
         seed: A random seed for shuffling.
 
     Returns:
-        A tuple of two `tf.data.Dataset or torchDataset` objects: the left and right splits.
+        A tuple of two `tf.data.Dataset or torchDataset` objects:
+        the left and right splits.
 
     Example:
 
@@ -112,10 +117,13 @@ def _convert_dataset_to_list(
     data_size_warning_flag=True,
     ensure_shape_similarity=True,
 ):
-    """Convert `tf.data.Dataset or torchDataset` object or list/tuple of NumPy arrays to a list.
+    """Convert `tf.data.Dataset or torchDataset` object
+        or list/tuple of NumPy arrays to a list.
 
     Args:
-        dataset : A `tf.data.Dataset or torchDataset` object or a list/tuple of arrays.
+        dataset :
+            A `tf.data.Dataset or torchDataset` object
+            or a list/tuple of arrays.
         dataset_type_spec : the type of the dataset
         data_size_warning_flag (bool, optional): If set to True, a warning will
           be issued if the dataset takes longer than 10 seconds to iterate.
@@ -157,8 +165,11 @@ def _get_data_iterator_from_dataset(dataset, dataset_type_spec):
     """Get the iterator from a dataset.
 
     Args:
-        dataset :  A `tf.data.Dataset or torchDataset` object or a list/tuple of arrays.
-        dataset_type_spec : the type of the dataset
+        dataset :
+            A `tf.data.Dataset or torchDataset` object
+            or a list/tuple of arrays.
+        dataset_type_spec :
+             the type of the dataset
 
     Raises:
         ValueError:

--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -3,7 +3,6 @@ import time
 import warnings
 
 import numpy as np
-import torch
 
 from keras_core.api_export import keras_core_export
 from keras_core.utils.module_utils import tensorflow as tf
@@ -278,6 +277,7 @@ def _get_next_sample(
         data_sample: A tuple/list of numpy arrays.
     """
     try:
+        import torch
         dataset_iterator = iter(dataset_iterator)
         first_sample = next(dataset_iterator)
         if isinstance(first_sample, (tf.Tensor, np.ndarray)) or torch.is_tensor(

--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -1,11 +1,8 @@
-import tensorflow as tf
 import torch 
-from torch.utils.data import Dataset as torchDataset
 import numpy as np
 import warnings
 import random
 import time
-
 from keras_core.api_export import keras_core_export
 from keras_core.utils.module_utils import tensorflow as tf
 
@@ -17,7 +14,7 @@ def split_dataset(
     """Split a dataset into a left half and a right half (e.g. train / test).
 
     Args:
-        dataset: A `tf.data.Datasetor torchDataset`  object, or a list/tuple of arrays with the
+        dataset: A `tf.data.Dataset or torchDataset`  object, or a list/tuple of arrays with the
           same length.
         left_size: If float (in the range `[0, 1]`), it signifies
           the fraction of the data to pack in the left dataset. If integer, it
@@ -43,6 +40,8 @@ def split_dataset(
     200
 
     """
+    from torch.utils.data import Dataset as torchDataset
+
 
     dataset_type_spec = _get_type_spec(dataset)
 
@@ -169,6 +168,7 @@ def _get_data_iterator_from_dataset(dataset, dataset_type_spec):
     Returns:
         iterator: An `iterator` object.
     """
+    from torch.utils.data import Dataset as torchDataset
     if dataset_type_spec == list:
         if len(dataset) == 0:
             raise ValueError(
@@ -436,6 +436,7 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
 def _restore_dataset_from_list(
     dataset_as_list, dataset_type_spec, original_dataset
 ):
+    from torch.utils.data import Dataset as torchDataset
     """Restore the dataset from the list of arrays."""
     if dataset_type_spec in [tuple, list]:
         return tuple(np.array(sample) for sample in zip(*dataset_as_list))
@@ -468,6 +469,7 @@ def get_batch_size(dataset):
         return None
 
 def _get_type_spec(dataset):
+    from torch.utils.data import Dataset as torchDataset
     """Get the type spec of the dataset."""
     if isinstance(dataset, tuple):
         return tuple

--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -1,3 +1,10 @@
+import tensorflow as tf
+import torch 
+from torch.utils.data import Dataset as torchDataset
+import numpy as np
+import random
+import time
+
 from keras_core.api_export import keras_core_export
 from keras_core.utils.module_utils import tensorflow as tf
 
@@ -6,21 +13,19 @@ from keras_core.utils.module_utils import tensorflow as tf
 def split_dataset(
     dataset, left_size=None, right_size=None, shuffle=False, seed=None
 ):
-    """Splits a dataset into a left half and a right half (e.g. train / test).
+    """Split a dataset into a left half and a right half (e.g. train / test).
 
     Args:
         dataset: A `tf.data.Dataset` object, or a list/tuple of arrays with the
-            same length.
+          same length.
         left_size: If float (in the range `[0, 1]`), it signifies
-            the fraction of the data to pack in the left dataset.
-            If integer, it signifies the number of samples to pack
-            in the left dataset. If `None`, it defaults to the complement
-            to `right_size`.
+          the fraction of the data to pack in the left dataset. If integer, it
+          signifies the number of samples to pack in the left dataset. If
+          `None`, it uses the complement to `right_size`. Defaults to `None`.
         right_size: If float (in the range `[0, 1]`), it signifies
-            the fraction of the data to pack in the right dataset.
-            If integer, it signifies the number of samples to pack
-            in the right dataset. If `None`, it defaults to the complement
-            to `left_size`.
+          the fraction of the data to pack in the right dataset. If integer, it
+          signifies the number of samples to pack in the right dataset. If
+          `None`, it uses the complement to `left_size`. Defaults to `None`.
         shuffle: Boolean, whether to shuffle the data before splitting it.
         seed: A random seed for shuffling.
 
@@ -30,20 +35,362 @@ def split_dataset(
     Example:
 
     >>> data = np.random.random(size=(1000, 4))
-    >>> left_ds, right_ds = split_dataset(data, left_size=0.8)
+    >>> left_ds, right_ds = tf.keras.utils.split_dataset(data, left_size=0.8)
     >>> int(left_ds.cardinality())
     800
     >>> int(right_ds.cardinality())
     200
+
     """
-    # TODO: long-term, port implementation.
-    return tf.keras.utils.split_dataset(
-        dataset,
-        left_size=left_size,
-        right_size=right_size,
-        shuffle=shuffle,
-        seed=seed,
+
+    dataset_type_spec = _get_type_spec(dataset)
+
+    if dataset_type_spec not in [torchDataset, tf.data.Dataset, list, tuple, np.ndarray]:
+        raise TypeError(
+            "The `dataset` argument must be either a `tf.data.Dataset` "
+            "object or a list/tuple of arrays. "
+            f"Received: dataset={dataset} of type {type(dataset)}"
+        )
+
+    if right_size is None and left_size is None:
+        raise ValueError(
+            "At least one of the `left_size` or `right_size` "
+            "must be specified. Received: left_size=None and "
+            "right_size=None"
+        )
+
+    dataset_as_list = _convert_dataset_to_list(dataset, dataset_type_spec)
+
+    if shuffle:
+        if seed is None:
+            seed = random.randint(0, int(1e6))
+        random.seed(seed)
+        random.shuffle(dataset_as_list)
+
+    total_length = len(dataset_as_list)
+
+    left_size, right_size = _rescale_dataset_split_sizes(
+        left_size, right_size, total_length
     )
+    left_split = list(dataset_as_list[:left_size])
+    right_split = list(dataset_as_list[-right_size:])
+
+    left_split = _restore_dataset_from_list(
+        left_split, dataset_type_spec, dataset
+    )
+    right_split = _restore_dataset_from_list(
+        right_split, dataset_type_spec, dataset
+    )
+
+    left_split = tf.data.Dataset.from_tensor_slices(left_split)
+    right_split = tf.data.Dataset.from_tensor_slices(right_split)
+
+    # apply batching to the splits if the dataset is batched
+    if dataset_type_spec is tf.data.Dataset and is_batched(dataset):
+        batch_size = get_batch_size(dataset)
+        if batch_size is not None:
+            left_split = left_split.batch(batch_size)
+            right_split = right_split.batch(batch_size)
+
+    left_split = left_split.prefetch(tf.data.AUTOTUNE)
+    right_split = right_split.prefetch(tf.data.AUTOTUNE)
+
+    return left_split, right_split
+
+
+def _convert_dataset_to_list(
+    dataset,
+    dataset_type_spec,
+    data_size_warning_flag=True,
+    ensure_shape_similarity=True,
+):
+    """Convert `tf.data.Dataset` object or list/tuple of NumPy arrays to a list.
+
+    Args:
+        dataset : A `tf.data.Dataset` object or a list/tuple of arrays.
+        dataset_type_spec : the type of the dataset
+        data_size_warning_flag (bool, optional): If set to True, a warning will
+          be issued if the dataset takes longer than 10 seconds to iterate.
+          Defaults to `True`.
+        ensure_shape_similarity (bool, optional): If set to True, the shape of
+          the first sample will be used to validate the shape of rest of the
+          samples. Defaults to `True`.
+
+    Returns:
+        List: A list of tuples/NumPy arrays.
+    """
+    dataset_iterator = _get_data_iterator_from_dataset(
+        dataset, dataset_type_spec
+    )
+    dataset_as_list = []
+
+    start_time = time.time()
+    for sample in _get_next_sample(
+        dataset_iterator,
+        ensure_shape_similarity,
+        data_size_warning_flag,
+        start_time,
+    ):
+        if dataset_type_spec in [tuple, list]:
+            # The try-except here is for NumPy 1.24 compatibility, see:
+            # https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
+            try:
+                arr = np.array(sample)
+            except ValueError:
+                arr = np.array(sample, dtype=object)
+            dataset_as_list.append(arr)
+        else:
+            dataset_as_list.append(sample)
+
+    return dataset_as_list
+
+def _get_data_iterator_from_dataset(dataset, dataset_type_spec):
+    """Get the iterator from a dataset.
+
+    Args:
+        dataset :  A `tf.data.Dataset` object or a list/tuple of arrays.
+        dataset_type_spec : the type of the dataset
+
+    Raises:
+        ValueError:
+                  - If the dataset is empty.
+                  - If the dataset is not a `tf.data.Dataset` object
+                    or a list/tuple of arrays.
+                  - If the dataset is a list/tuple of arrays and the
+                    length of the list/tuple is not equal to the number
+
+    Returns:
+        iterator: An `iterator` object.
+    """
+    if dataset_type_spec == list:
+        if len(dataset) == 0:
+            raise ValueError(
+                "Received an empty list dataset. "
+                "Please provide a non-empty list of arrays."
+            )
+
+        if _get_type_spec(dataset[0]) is np.ndarray:
+            expected_shape = dataset[0].shape
+            for i, element in enumerate(dataset):
+                if np.array(element).shape[0] != expected_shape[0]:
+                    raise ValueError(
+                        "Received a list of NumPy arrays with different "
+                        f"lengths. Mismatch found at index {i}, "
+                        f"Expected shape={expected_shape} "
+                        f"Received shape={np.array(element).shape}."
+                        "Please provide a list of NumPy arrays with "
+                        "the same length."
+                    )
+        else:
+            raise ValueError(
+                "Expected a list of `numpy.ndarray` objects,"
+                f"Received: {type(dataset[0])}"
+            )
+
+        return iter(zip(*dataset))
+    elif dataset_type_spec == tuple:
+        if len(dataset) == 0:
+            raise ValueError(
+                "Received an empty list dataset."
+                "Please provide a non-empty tuple of arrays."
+            )
+
+        if _get_type_spec(dataset[0]) is np.ndarray:
+            expected_shape = dataset[0].shape
+            for i, element in enumerate(dataset):
+                if np.array(element).shape[0] != expected_shape[0]:
+                    raise ValueError(
+                        "Received a tuple of NumPy arrays with different "
+                        f"lengths. Mismatch found at index {i}, "
+                        f"Expected shape={expected_shape} "
+                        f"Received shape={np.array(element).shape}."
+                        "Please provide a tuple of NumPy arrays with "
+                        "the same length."
+                    )
+        else:
+            raise ValueError(
+                "Expected a tuple of `numpy.ndarray` objects, "
+                f"Received: {type(dataset[0])}"
+            )
+
+        return iter(zip(*dataset))
+    elif dataset_type_spec == tf.data.Dataset:
+        if is_batched(dataset):
+            dataset = dataset.unbatch()
+        return iter(dataset)
+    elif dataset_type_spec == np.ndarray:
+        return iter(dataset)
+
+def _rescale_dataset_split_sizes(left_size, right_size, total_length):
+    """Rescale the dataset split sizes.
+
+    We want to ensure that the sum of
+    the split sizes is equal to the total length of the dataset.
+
+    Args:
+        left_size : The size of the left dataset split.
+        right_size : The size of the right dataset split.
+        total_length : The total length of the dataset.
+
+    Raises:
+        TypeError: - If `left_size` or `right_size` is not an integer or float.
+        ValueError: - If `left_size` or `right_size` is negative or greater
+                      than 1 or greater than `total_length`.
+
+    Returns:
+        tuple: A tuple of rescaled left_size and right_size
+    """
+    left_size_type = type(left_size)
+    right_size_type = type(right_size)
+
+    # check both left_size and right_size are integers or floats
+    if (left_size is not None and left_size_type not in [int, float]) and (
+        right_size is not None and right_size_type not in [int, float]
+    ):
+        raise TypeError(
+            "Invalid `left_size` and `right_size` Types. Expected: "
+            "integer or float or None, Received: type(left_size)="
+            f"{left_size_type} and type(right_size)={right_size_type}"
+        )
+
+    # check left_size is a integer or float
+    if left_size is not None and left_size_type not in [int, float]:
+        raise TypeError(
+            "Invalid `left_size` Type. Expected: int or float or None, "
+            f"Received: type(left_size)={left_size_type}.  "
+        )
+
+    # check right_size is a integer or float
+    if right_size is not None and right_size_type not in [int, float]:
+        raise TypeError(
+            "Invalid `right_size` Type. "
+            "Expected: int or float or None,"
+            f"Received: type(right_size)={right_size_type}."
+        )
+
+    # check left_size and right_size are non-zero
+    if left_size == 0 and right_size == 0:
+        raise ValueError(
+            "Both `left_size` and `right_size` are zero. "
+            "At least one of the split sizes must be non-zero."
+        )
+
+    # check left_size is non-negative and less than 1 and less than total_length
+    if (
+        left_size_type == int
+        and (left_size <= 0 or left_size >= total_length)
+        or left_size_type == float
+        and (left_size <= 0 or left_size >= 1)
+    ):
+        raise ValueError(
+            "`left_size` should be either a positive integer "
+            f"smaller than {total_length}, or a float "
+            "within the range `[0, 1]`. Received: left_size="
+            f"{left_size}"
+        )
+
+    # check right_size is non-negative and less than 1 and less than
+    # total_length
+    if (
+        right_size_type == int
+        and (right_size <= 0 or right_size >= total_length)
+        or right_size_type == float
+        and (right_size <= 0 or right_size >= 1)
+    ):
+        raise ValueError(
+            "`right_size` should be either a positive integer "
+            f"and smaller than {total_length} or a float "
+            "within the range `[0, 1]`. Received: right_size="
+            f"{right_size}"
+        )
+
+    # check sum of left_size and right_size is less than or equal to
+    # total_length
+    if (
+        right_size_type == left_size_type == float
+        and right_size + left_size > 1
+    ):
+        raise ValueError(
+            "The sum of `left_size` and `right_size` is greater "
+            "than 1. It must be less than or equal to 1."
+        )
+
+    if left_size_type == float:
+        left_size = round(left_size * total_length)
+    elif left_size_type == int:
+        left_size = float(left_size)
+
+    if right_size_type == float:
+        right_size = round(right_size * total_length)
+    elif right_size_type == int:
+        right_size = float(right_size)
+
+    if left_size is None:
+        left_size = total_length - right_size
+    elif right_size is None:
+        right_size = total_length - left_size
+
+    if left_size + right_size > total_length:
+        raise ValueError(
+            "The sum of `left_size` and `right_size` should "
+            "be smaller than the {total_length}. "
+            f"Received: left_size + right_size = {left_size+right_size}"
+            f"and total_length = {total_length}"
+        )
+
+    for split, side in [(left_size, "left"), (right_size, "right")]:
+        if split == 0:
+            raise ValueError(
+                f"With `dataset` of length={total_length}, `left_size`="
+                f"{left_size} and `right_size`={right_size}."
+                f"Resulting {side} side dataset split will be empty. "
+                "Adjust any of the aforementioned parameters"
+            )
+
+    left_size, right_size = int(left_size), int(right_size)
+    return left_size, right_size
+
+def _restore_dataset_from_list(
+    dataset_as_list, dataset_type_spec, original_dataset
+):
+    """Restore the dataset from the list of arrays."""
+    if dataset_type_spec in [tuple, list]:
+        return tuple(np.array(sample) for sample in zip(*dataset_as_list))
+    elif dataset_type_spec == tf.data.Dataset:
+        if isinstance(original_dataset.element_spec, dict):
+            restored_dataset = {}
+            for d in dataset_as_list:
+                for k, v in d.items():
+                    if k not in restored_dataset:
+                        restored_dataset[k] = [v]
+                    else:
+                        restored_dataset[k].append(v)
+            return restored_dataset
+        else:
+            return tuple(np.array(sample) for sample in zip(*dataset_as_list))
+    return dataset_as_list
+
+def is_batched(dataset):
+    """ "Check if the `tf.data.Dataset` is batched."""
+    return hasattr(dataset, "_batch_size")
+
+def _get_type_spec(dataset):
+    """Get the type spec of the dataset."""
+    if isinstance(dataset, tuple):
+        return tuple
+    elif isinstance(dataset, list):
+        return list
+    elif isinstance(dataset, np.ndarray):
+        return np.ndarray
+    elif isinstance(dataset, dict):
+        return dict
+    elif isinstance(dataset, tf.data.Dataset):
+        return tf.data.Dataset
+    elif isinstance(dataset, torchDataset):
+        return torchDataset
+    else:
+        return None
+
 
 
 @keras_core_export(

--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -77,6 +77,7 @@ def split_dataset(
     left_split = list(dataset_as_list[:left_size])
     right_split = list(dataset_as_list[-right_size:])
 
+    return left_split, right_split
     left_split = _restore_dataset_from_list(
         left_split, dataset_type_spec, dataset
     )
@@ -84,7 +85,7 @@ def split_dataset(
         right_split, dataset_type_spec, dataset
     )
 
-    return left_split, right_split
+    
     left_split = tf.data.Dataset.from_tensor_slices(left_split)
     right_split = tf.data.Dataset.from_tensor_slices(right_split)
 

--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -23,9 +23,11 @@ def split_dataset(
             signifies the number of samples to pack in the left dataset. If
             `None`, it uses the complement to `right_size`. Defaults to `None`.
         right_size: If float (in the range `[0, 1]`), it signifies
-            the fraction of the data to pack in the right dataset. If integer, it
-            signifies the number of samples to pack in the right dataset. If
-            `None`, it uses the complement to `left_size`. Defaults to `None`.
+            the fraction of the data to pack in the right dataset.
+            If integer, it signifies the number of samples to pack
+            in the right dataset.
+            If `None`, it uses the complement to `left_size`.
+            Defaults to `None`.
         shuffle: Boolean, whether to shuffle the data before splitting it.
         seed: A random seed for shuffling.
 
@@ -47,7 +49,8 @@ def split_dataset(
 
     if dataset_type_spec is None:
         raise TypeError(
-            "The `dataset` argument must be either a `tf.data.Dataset` or `torch.utils.data.Dataset`"
+            "The `dataset` argument must be either"
+            "a `tf.data.Dataset` or `torch.utils.data.Dataset`"
             "object or a list/tuple of arrays. "
             f"Received: dataset={dataset} of type {type(dataset)}"
         )
@@ -82,7 +85,6 @@ def split_dataset(
         right_split, dataset_type_spec, dataset
     )
 
-    
     left_split = tf.data.Dataset.from_tensor_slices(left_split)
     right_split = tf.data.Dataset.from_tensor_slices(right_split)
 
@@ -254,7 +256,7 @@ def _get_next_sample(
             used only if `data_size_warning_flag` is set to true.
 
     Raises:
-        ValueError: 
+        ValueError:
             - If the dataset is empty.
             - If `ensure_shape_similarity` is set to True and the
             shape of the first sample is not equal to the shape of
@@ -264,7 +266,6 @@ def _get_next_sample(
         data_sample: A tuple/list of numpy arrays.
     """
     try:
-        
         dataset_iterator = iter(dataset_iterator)
         first_sample = next(dataset_iterator)
         if isinstance(first_sample, (tf.Tensor, np.ndarray)) or is_torch_tensor(
@@ -308,14 +309,16 @@ def _get_next_sample(
                     data_size_warning_flag = False
         yield sample
 
+
 def is_torch_tensor(value):
     if hasattr(value, "__class__"):
         for parent in value.__class__.__mro__:
-            if parent.__name__ == "Tensor" and str(
-                parent.__module__
-            ).endswith("torch"):
+            if parent.__name__ == "Tensor" and str(parent.__module__).endswith(
+                "torch"
+            ):
                 return True
     return False
+
 
 def is_torch_dataset(dataset):
     if hasattr(dataset, "__class__"):
@@ -460,7 +463,6 @@ def _rescale_dataset_split_sizes(left_size, right_size, total_length):
 def _restore_dataset_from_list(
     dataset_as_list, dataset_type_spec, original_dataset
 ):
-   
     """Restore the dataset from the list of arrays."""
     if dataset_type_spec in [tuple, list]:
         return tuple(np.array(sample) for sample in zip(*dataset_as_list))
@@ -509,6 +511,7 @@ def _get_type_spec(dataset):
         return tf.data.Dataset
     elif is_torch_dataset(dataset):
         from torch.utils.data import Dataset as torchDataset
+
         return torchDataset
     else:
         return None

--- a/keras_core/utils/dataset_utils.py
+++ b/keras_core/utils/dataset_utils.py
@@ -1,7 +1,6 @@
 import tensorflow as tf
 import torch 
 from torch.utils.data import Dataset as torchDataset
-from torch.utils.data import DataLoader as torchDataLoader
 import numpy as np
 import warnings
 import random
@@ -229,7 +228,7 @@ def _get_data_iterator_from_dataset(dataset, dataset_type_spec):
     
     # torch dataset iterator might be required to change
     elif dataset_type_spec == torchDataset:
-        return torchDataLoader(dataset)
+        return iter(dataset)
     
     elif dataset_type_spec == np.ndarray:
         return iter(dataset)
@@ -454,7 +453,7 @@ def _restore_dataset_from_list(
             return tuple(np.array(sample) for sample in zip(*dataset_as_list))
         
     elif dataset_type_spec == torchDataset:
-        return tuple(np.array(sample, dtype=object) for sample in zip(*dataset_as_list))
+        return tuple(np.array(sample) for sample in zip(*dataset_as_list))
     return dataset_as_list
 
 def is_batched(dataset):

--- a/keras_core/utils/dataset_utils_test.py
+++ b/keras_core/utils/dataset_utils_test.py
@@ -1,8 +1,8 @@
-from keras_core.testing import test_case
-from keras_core.utils import naming
-from keras_core.utils.module_utils import tensorflow as tf
-from keras_core.utils.dataset_utils import split_dataset
 import numpy as np
+
+from keras_core.testing import test_case
+from keras_core.utils.dataset_utils import split_dataset
+from keras_core.utils.module_utils import tensorflow as tf
 
 
 class DatasetUtilsTest(test_case.TestCase):

--- a/keras_core/utils/dataset_utils_test.py
+++ b/keras_core/utils/dataset_utils_test.py
@@ -4,148 +4,331 @@ from keras_core.utils.module_utils import tensorflow as tf
 from keras_core.utils.dataset_utils import split_dataset
 import numpy as np
 
+
 class DatasetUtilsTest(test_case.TestCase):
     def test_split_dataset_list(self):
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = [np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred))]
-        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols))
+        dataset = [
+            np.random.sample((n_sample, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        ]
+        dataset_left, dataset_right = split_dataset(
+            dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = [np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred))]
-        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
+        dataset = [
+            np.random.sample((n_sample, 100, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        ]
+        dataset_left, dataset_right = split_dataset(
+            dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (100, n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = [np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred))]
-        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
+        dataset = [
+            np.random.sample((n_sample, 10, 10, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        ]
+        dataset_left, dataset_right = split_dataset(
+            dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (10, 10, n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = [np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred))]
-        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
+        dataset = [
+            np.random.sample((n_sample, 100, 10, 30, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        ]
+        dataset_left, dataset_right = split_dataset(
+            dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape,
+            (100, 10, 30, n_cols),
+        )
 
     def test_split_dataset_tuple(self):
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = (np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred)))
-        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols))
+        dataset = (
+            np.random.sample((n_sample, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        dataset_left, dataset_right = split_dataset(
+            dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = (np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred)))
-        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
+        dataset = (
+            np.random.sample((n_sample, 100, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        dataset_left, dataset_right = split_dataset(
+            dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (100, n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = (np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred)))
-        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
+        dataset = (
+            np.random.sample((n_sample, 10, 10, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        dataset_left, dataset_right = split_dataset(
+            dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (10, 10, n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        dataset = (np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred)))
-        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
+        dataset = (
+            np.random.sample((n_sample, 100, 10, 30, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        dataset_left, dataset_right = split_dataset(
+            dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape,
+            (100, 10, 30, n_cols),
+        )
 
     def test_split_dataset_tensorflow(self):
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels  = (np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred)))
-        tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
-        dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols))
+        features, labels = (
+            np.random.sample((n_sample, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        tf_dataset = tf.data.Dataset.from_tensor_slices((features, labels))
+        dataset_left, dataset_right = split_dataset(
+            tf_dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred)))
-        tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
-        dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
+        features, labels = (
+            np.random.sample((n_sample, 100, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        tf_dataset = tf.data.Dataset.from_tensor_slices((features, labels))
+        dataset_left, dataset_right = split_dataset(
+            tf_dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (100, n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred)))
-        tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
-        dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
+        features, labels = (
+            np.random.sample((n_sample, 10, 10, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        tf_dataset = tf.data.Dataset.from_tensor_slices((features, labels))
+        dataset_left, dataset_right = split_dataset(
+            tf_dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (10, 10, n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred)))
-        tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
-        dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
-        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
+        features, labels = (
+            np.random.sample((n_sample, 100, 10, 30, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        tf_dataset = tf.data.Dataset.from_tensor_slices((features, labels))
+        dataset_left, dataset_right = split_dataset(
+            tf_dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            int(dataset_left.cardinality()), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            int(dataset_right.cardinality()), int(n_sample * right_size)
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape,
+            (100, 10, 30, n_cols),
+        )
 
     def test_split_dataset_torch(self):
-
         # sample torch dataset class
         from torch.utils.data import Dataset as torchDataset
+
         class Dataset(torchDataset):
-            'Characterizes a dataset for PyTorch'
+            "Characterizes a dataset for PyTorch"
+
             def __init__(self, x, y):
-                'Initialization'
+                "Initialization"
                 self.x = x
                 self.y = y
 
             def __len__(self):
-                'Denotes the total number of samples'
+                "Denotes the total number of samples"
                 return len(self.x)
 
             def __getitem__(self, index):
-                'Generates one sample of data'
+                "Generates one sample of data"
                 return self.x[index], self.y[index]
 
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        features, labels = (
+            np.random.sample((n_sample, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        torch_dataset = Dataset(features, labels)
+        dataset_left, dataset_right = split_dataset(
+            torch_dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            len([sample for sample in dataset_left]), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            len([sample for sample in dataset_right]),
+            int(n_sample * right_size),
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (n_cols,)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels  = (np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred)))
-        torch_dataset = Dataset(features,labels)
-        dataset_left, dataset_right = split_dataset(torch_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols,))
+        features, labels = (
+            np.random.sample((n_sample, 100, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        torch_dataset = Dataset(features, labels)
+        dataset_left, dataset_right = split_dataset(
+            torch_dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            len([sample for sample in dataset_left]), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            len([sample for sample in dataset_right]),
+            int(n_sample * right_size),
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (100, n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred)))
-        torch_dataset = Dataset(features,labels)
-        dataset_left, dataset_right = split_dataset(torch_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
+        features, labels = (
+            np.random.sample((n_sample, 10, 10, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        torch_dataset = Dataset(features, labels)
+        dataset_left, dataset_right = split_dataset(
+            torch_dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            len([sample for sample in dataset_left]), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            len([sample for sample in dataset_right]),
+            int(n_sample * right_size),
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape, (10, 10, n_cols)
+        )
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred)))
-        torch_dataset = Dataset(features,labels)
-        dataset_left, dataset_right = split_dataset(torch_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
-
-        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
-        features, labels = (np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred)))
-        torch_dataset = Dataset(features,labels)
-        dataset_left, dataset_right = split_dataset(torch_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
-        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
-
-
+        features, labels = (
+            np.random.sample((n_sample, 100, 10, 30, n_cols)),
+            np.random.sample((n_sample, n_pred)),
+        )
+        torch_dataset = Dataset(features, labels)
+        dataset_left, dataset_right = split_dataset(
+            torch_dataset, left_size=left_size, right_size=right_size
+        )
+        self.assertEqual(
+            len([sample for sample in dataset_left]), int(n_sample * left_size)
+        )
+        self.assertEqual(
+            len([sample for sample in dataset_right]),
+            int(n_sample * right_size),
+        )
+        self.assertEqual(
+            [sample for sample in dataset_right][0][0].shape,
+            (100, 10, 30, n_cols),
+        )

--- a/keras_core/utils/dataset_utils_test.py
+++ b/keras_core/utils/dataset_utils_test.py
@@ -1,0 +1,151 @@
+from keras_core.testing import test_case
+from keras_core.utils import naming
+from keras_core.utils.module_utils import tensorflow as tf
+from keras_core.utils.dataset_utils import split_dataset
+import numpy as np
+
+class DatasetUtilsTest(test_case.TestCase):
+    def test_split_dataset_list(self):
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        dataset = [np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred))]
+        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        dataset = [np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred))]
+        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        dataset = [np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred))]
+        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        dataset = [np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred))]
+        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
+
+    def test_split_dataset_tuple(self):
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        dataset = (np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred)))
+        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        dataset = (np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred)))
+        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        dataset = (np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred)))
+        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        dataset = (np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred)))
+        dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
+
+    def test_split_dataset_tensorflow(self):
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        features, labels  = (np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred)))
+        tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
+        dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        features, labels = (np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred)))
+        tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
+        dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        features, labels = (np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred)))
+        tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
+        dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        features, labels = (np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred)))
+        tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
+        dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
+
+    def test_split_dataset_torch(self):
+
+        # sample torch dataset class
+        from torch.utils.data import Dataset as torchDataset
+        class Dataset(torchDataset):
+            'Characterizes a dataset for PyTorch'
+            def __init__(self, x, y):
+                'Initialization'
+                self.x = x
+                self.y = y
+
+            def __len__(self):
+                'Denotes the total number of samples'
+                return len(self.x)
+
+            def __getitem__(self, index):
+                'Generates one sample of data'
+                return self.x[index], self.y[index]
+
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        features, labels  = (np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred)))
+        torch_dataset = Dataset(features,labels)
+        dataset_left, dataset_right = split_dataset(torch_dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols,))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        features, labels = (np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred)))
+        torch_dataset = Dataset(features,labels)
+        dataset_left, dataset_right = split_dataset(torch_dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        features, labels = (np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred)))
+        torch_dataset = Dataset(features,labels)
+        dataset_left, dataset_right = split_dataset(torch_dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
+
+        n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
+        features, labels = (np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred)))
+        torch_dataset = Dataset(features,labels)
+        dataset_left, dataset_right = split_dataset(torch_dataset, left_size=left_size, right_size=right_size)
+        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
+        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
+
+

--- a/keras_core/utils/dataset_utils_test.py
+++ b/keras_core/utils/dataset_utils_test.py
@@ -9,58 +9,58 @@ class DatasetUtilsTest(test_case.TestCase):
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         dataset = [np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred))]
         dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols))
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         dataset = [np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred))]
         dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         dataset = [np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred))]
         dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         dataset = [np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred))]
         dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
 
     def test_split_dataset_tuple(self):
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         dataset = (np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred)))
         dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols))
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         dataset = (np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred)))
         dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         dataset = (np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred)))
         dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         dataset = (np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred)))
         dataset_left, dataset_right = split_dataset(dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
 
     def test_split_dataset_tensorflow(self):
@@ -68,32 +68,32 @@ class DatasetUtilsTest(test_case.TestCase):
         features, labels  = (np.random.sample((n_sample,n_cols)), np.random.sample((n_sample,n_pred)))
         tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
         dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (n_cols))
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         features, labels = (np.random.sample((n_sample, 100, n_cols)), np.random.sample((n_sample,n_pred)))
         tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
         dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, n_cols))
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         features, labels = (np.random.sample((n_sample,10, 10, n_cols)), np.random.sample((n_sample,n_pred)))
         tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
         dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (10, 10, n_cols))
 
         n_sample, n_cols, n_pred, left_size, right_size = 100, 2, 1, 0.2, 0.8
         features, labels = (np.random.sample((n_sample, 100, 10, 30, n_cols)), np.random.sample((n_sample,n_pred)))
         tf_dataset = tf.data.Dataset.from_tensor_slices((features,labels))
         dataset_left, dataset_right = split_dataset(tf_dataset, left_size=left_size, right_size=right_size)
-        self.assertEqual(len([sample for sample in dataset_left]), int(n_sample * left_size))
-        self.assertEqual(len([sample for sample in dataset_right]), int(n_sample * right_size))
+        self.assertEqual(int(dataset_left.cardinality()), int(n_sample * left_size))
+        self.assertEqual(int(dataset_right.cardinality()), int(n_sample * right_size))
         self.assertEqual([sample for sample in dataset_right][0][0].shape, (100, 10, 30, n_cols))
 
     def test_split_dataset_torch(self):


### PR DESCRIPTION
Hi Team, 

This PR made following changes to following functions

- moving `keras` data-utils for split_dataset  from [here](https://github.com/keras-team/keras/blob/v2.13.1/keras/utils/dataset_utils.py) making sure all the settings stay's intact.
- need to rewrite following functions since all of them accept `tf.Dataset` and we need to support `torch` and `Jax`.
    -  `split_dataset`
    -  `_convert_dataset_to_list` 
    - `_get_data_iterator_from_dataset`
    - `_get_next_sample` 
    - `_get_type_spec` 
    - `_get_next_sample` 
    - `_rescale_dataset_split_sizes` 
    - `_restore_dataset_from_list` 