### PR TITLE
Resolve shape via ops in broadcast_to operation

### DIFF
--- a/keras_core/metrics/iou_metrics.py
+++ b/keras_core/metrics/iou_metrics.py
@@ -106,7 +106,7 @@ class _IoUBase(Metric):
         if len(sample_weight.shape) > 1:
             sample_weight = ops.reshape(sample_weight, [-1])
 
-        sample_weight = ops.broadcast_to(sample_weight, y_true.shape)
+        sample_weight = ops.broadcast_to(sample_weight, ops.shape(y_true))
 
         if self.ignore_class is not None:
             ignore_class = ops.convert_to_tensor(

--- a/keras_core/metrics/metric.py
+++ b/keras_core/metrics/metric.py
@@ -72,7 +72,9 @@ class Metric:
             values = ops.cast(values, self.dtype)
             if sample_weight is not None:
                 sample_weight = ops.cast(sample_weight, self.dtype)
-                sample_weight = ops.broadcast_to(sample_weight, values.shape)
+                sample_weight = ops.broadcast_to(
+                    sample_weight, ops.shape(values)
+                )
                 values = ops.multiply(values, sample_weight)
             self.true_positives.assign(self.true_positives + ops.sum(values))
 

--- a/keras_core/metrics/metrics_utils.py
+++ b/keras_core/metrics/metrics_utils.py
@@ -195,7 +195,7 @@ def _update_confusion_matrix_variables_optimized(
         sample_weights = 1.0
     else:
         sample_weights = ops.broadcast_to(
-            ops.cast(sample_weights, dtype=y_pred.dtype), y_pred.shape
+            ops.cast(sample_weights, dtype=y_pred.dtype), ops.shape(y_pred)
         )
         if not multi_label:
             sample_weights = ops.reshape(sample_weights, [-1])
@@ -203,7 +203,7 @@ def _update_confusion_matrix_variables_optimized(
         label_weights = 1.0
     else:
         label_weights = ops.expand_dims(label_weights, 0)
-        label_weights = ops.broadcast_to(label_weights, y_pred.shape)
+        label_weights = ops.broadcast_to(label_weights, ops.shape(y_pred))
         if not multi_label:
             label_weights = ops.reshape(label_weights, [-1])
     weights = ops.cast(
@@ -533,7 +533,7 @@ def update_confusion_matrix_variables(
 
     if label_weights is not None and not multi_label:
         label_weights = ops.expand_dims(label_weights, 0)
-        label_weights = ops.broadcast_to(label_weights, y_pred.shape)
+        label_weights = ops.broadcast_to(label_weights, ops.shape(y_pred))
         label_weights_tiled = ops.tile(
             ops.reshape(label_weights, thresh_tiles), data_tiles
         )


### PR DESCRIPTION
Resolves the following issues -
1. When `ops.broadcast_to`, requires the shape to be resolved via `ops.shape` and fails when used with tensor.shape attribute for TensorFlow backend.
2. When multiplying `sample_weight` with `y_true`, it needs to be cast to the target tensor.  Many times, `self.dtype` is None and for regression metrics like `R2Score`, `y_true` is a float and `sample_weight` is an int, causing type mismatch in TensorFlow backend.
3. Remove the dtype specification in `self.num_samples` in `R2Score` metric initialization.  Having the dtype specified in the init, causes the variable to be put in CPU, causing CPU / GPU error when assigning value in `update_state` method.

There is still couple of more issues with how `sample_weight` is used in `iou_metric` that needs to be resolved.