### PR TITLE
Add Nadam for torch backend

### DIFF
--- a/keras_core/backend/torch/optimizers/torch_nadam.py
+++ b/keras_core/backend/torch/optimizers/torch_nadam.py
@@ -1,0 +1,74 @@
+import torch
+
+from keras_core import ops
+from keras_core import optimizers
+from keras_core.backend.torch import core
+from keras_core.backend.torch.optimizers import torch_parallel_optimizer
+
+
+class Nadam(torch_parallel_optimizer.TorchParallelOptimizer, optimizers.Nadam):
+    def _parallel_update_step(
+        self,
+        grads,
+        variables,
+        learning_rate,
+    ):
+        keras_variables = variables
+        variables = [v.value for v in variables]
+
+        dtype = variables[0].dtype
+        lr = ops.cast(learning_rate, dtype)
+
+        local_step = ops.cast(self.iterations + 1, dtype)
+        next_step = ops.cast(self.iterations + 2, dtype)
+        decay = ops.cast(0.96, dtype)
+        beta_1 = ops.cast(self.beta_1, dtype)
+        beta_2 = ops.cast(self.beta_2, dtype)
+        u_t = beta_1 * (1.0 - 0.5 * (ops.power(decay, local_step)))
+        u_t_1 = beta_1 * (1.0 - 0.5 * (ops.power(decay, next_step)))
+        u_product_t = self._u_product.value * u_t
+        u_product_t_1 = u_product_t * u_t_1
+        beta_2_power = ops.power(beta_2, local_step)
+
+        self._u_product.assign(u_product_t)
+
+        m_list = [
+            self._momentums[self._get_variable_index(variable)].value
+            for variable in keras_variables
+        ]
+        v_list = [
+            self._velocities[self._get_variable_index(variable)].value
+            for variable in keras_variables
+        ]
+
+        torch._foreach_mul_(m_list, self.beta_1)
+        torch._foreach_add_(m_list, grads, alpha=1 - self.beta_1)
+
+        torch._foreach_mul_(v_list, self.beta_2)
+        torch._foreach_add_(
+            v_list, torch._foreach_mul(grads, grads), alpha=1 - self.beta_2
+        )
+
+        m_hat_list = torch._foreach_add(
+            torch._foreach_div(
+                torch._foreach_mul(m_list, u_t_1),
+                1 - core.convert_to_numpy(u_product_t_1),
+            ),
+            torch._foreach_div(
+                torch._foreach_mul(grads, 1 - u_t),
+                1 - core.convert_to_numpy(u_product_t),
+            ),
+        )
+
+        v_hat_list = torch._foreach_div(v_list, 1 - beta_2_power)
+
+        torch._foreach_add_(
+            variables,
+            torch._foreach_div(
+                torch._foreach_mul(m_hat_list, lr),
+                torch._foreach_add(
+                    torch._foreach_sqrt(v_hat_list), self.epsilon
+                ),
+            ),
+            alpha=-1,
+        )

--- a/keras_core/backend/torch/optimizers/torch_optimizer.py
+++ b/keras_core/backend/torch/optimizers/torch_optimizer.py
@@ -11,6 +11,7 @@ class TorchOptimizer(BaseOptimizer):
         from keras_core.backend.torch.optimizers import torch_adagrad
         from keras_core.backend.torch.optimizers import torch_adam
         from keras_core.backend.torch.optimizers import torch_adamw
+        from keras_core.backend.torch.optimizers import torch_nadam
         from keras_core.backend.torch.optimizers import torch_rmsprop
         from keras_core.backend.torch.optimizers import torch_sgd
 
@@ -19,6 +20,7 @@ class TorchOptimizer(BaseOptimizer):
             optimizers.Adagrad: torch_adagrad.Adagrad,
             optimizers.Adam: torch_adam.Adam,
             optimizers.AdamW: torch_adamw.AdamW,
+            optimizers.Nadam: torch_nadam.Nadam,
             optimizers.RMSprop: torch_rmsprop.RMSprop,
             optimizers.SGD: torch_sgd.SGD,
         }

--- a/keras_core/optimizers/nadam.py
+++ b/keras_core/optimizers/nadam.py
@@ -97,6 +97,18 @@ class Nadam(optimizer.Optimizer):
                 )
             )
 
+    def _internal_apply_gradients(self, grads_and_vars):
+        dtype = self._u_product.dtype
+        self._u_product.assign(
+            self._u_product
+            * self.beta_1
+            * (
+                1.0
+                - 0.5 * ops.power(0.96, ops.cast(self.iterations + 1, dtype))
+            )
+        )
+        super()._internal_apply_gradients(grads_and_vars)
+
     def update_step(self, gradient, variable, learning_rate):
         """Update step given gradient and the associated model variable."""
         var_dtype = variable.dtype
@@ -110,9 +122,7 @@ class Nadam(optimizer.Optimizer):
         beta_2 = ops.cast(self.beta_2, var_dtype)
         u_t = beta_1 * (1.0 - 0.5 * (ops.power(decay, local_step)))
         u_t_1 = beta_1 * (1.0 - 0.5 * (ops.power(decay, next_step)))
-
-        u_product_t = self._u_product * u_t
-        self._u_product.assign(u_product_t)
+        u_product_t = ops.cast(self._u_product, var_dtype)
 
         u_product_t_1 = u_product_t * u_t_1
         beta_2_power = ops.power(beta_2, local_step)

--- a/keras_core/optimizers/nadam_test.py
+++ b/keras_core/optimizers/nadam_test.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from keras_core import backend
+from keras_core import ops
 from keras_core import testing
 from keras_core.optimizers.nadam import Nadam
 
@@ -20,7 +21,7 @@ class NadamTest(testing.TestCase):
 
     def test_single_step(self):
         optimizer = Nadam(learning_rate=0.5)
-        grads = np.array([1.0, 6.0, 7.0, 2.0])
+        grads = ops.array([1.0, 6.0, 7.0, 2.0])
         vars = backend.Variable([1.0, 2.0, 3.0, 4.0])
         optimizer.apply_gradients(zip([grads], [vars]))
         self.assertAllClose(
@@ -29,7 +30,7 @@ class NadamTest(testing.TestCase):
 
     def test_weight_decay(self):
         grads, var1, var2, var3 = (
-            np.zeros(()),
+            ops.zeros(()),
             backend.Variable(2.0),
             backend.Variable(2.0, name="exclude"),
             backend.Variable(2.0),
@@ -58,8 +59,8 @@ class NadamTest(testing.TestCase):
         )
 
         x = backend.Variable(np.ones([10]))
-        grads = np.arange(0.1, 1.1, 0.1)
-        first_grads = np.full((10,), 0.01)
+        grads = ops.arange(0.1, 1.1, 0.1)
+        first_grads = ops.full((10,), 0.01)
 
         # fmt: off
         golden = np.array(


### PR DESCRIPTION
Fixed a bug in Nadam.
`numerical_test` passed for TF, JAX, and Torch backends (need to set the `tf.keras` model to `run_eagerly=True` due to a bug in `tf.keras`).
