### PR TITLE
Fix multi-dimension sample weights passed to mean metrics

### DIFF
--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -44,6 +44,9 @@ def mean(x, axis=None, keepdims=False):
     if isinstance(x, (list, tuple)):
         x = stack(x)
     x = convert_to_tensor(x)
+    if axis == () or axis == []:
+        # Torch handles the empty axis case differently from numpy.
+        return x
     # Conversion to float necessary for `torch.mean`
     x = cast(x, "float32") if x.dtype in TORCH_INT_TYPES else x
     return torch.mean(x, axis=axis, keepdims=keepdims)
@@ -886,6 +889,9 @@ def sum(x, axis=None, keepdims=False):
     if isinstance(x, (list, tuple)):
         x = stack(x)
     x = convert_to_tensor(x)
+    if axis == () or axis == []:
+        # Torch handles the empty axis case differently from numpy.
+        return x
     if axis is not None:
         return torch.sum(x, axis=axis, keepdim=keepdims)
     return torch.sum(x)

--- a/keras_core/metrics/reduction_metrics.py
+++ b/keras_core/metrics/reduction_metrics.py
@@ -26,6 +26,10 @@ def reduce_to_samplewise_values(values, sample_weight, reduce_fn, dtype):
                 values, axis=list(range(weight_ndim, values_ndim))
             )
         values = values * sample_weight
+        if values_ndim > 1:
+            sample_weight = reduce_fn(
+                sample_weight, axis=list(range(1, weight_ndim))
+            )
 
     values_ndim = len(values.shape)
     if values_ndim > 1:
@@ -127,9 +131,7 @@ class Mean(Metric):
         else:
             num_samples = 1
         if sample_weight is not None:
-            num_samples = ops.sum(
-                ops.ones(shape=(num_samples,)) * sample_weight
-            )
+            num_samples = ops.sum(sample_weight)
         self.count.assign(self.count + ops.cast(num_samples, dtype=self.dtype))
 
     def reset_state(self):

--- a/keras_core/metrics/reduction_metrics_test.py
+++ b/keras_core/metrics/reduction_metrics_test.py
@@ -24,6 +24,12 @@ class SumTest(testing.TestCase):
         result = sum_obj.result()
         self.assertAllClose(result, 4.0, atol=1e-3)
 
+    def test_weighted_nd(self):
+        sum_obj = reduction_metrics.Sum(name="sum", dtype="float32")
+        sum_obj.update_state([[1, 3], [5, 7]], sample_weight=[[1, 1], [1, 0]])
+        result = sum_obj.result()
+        self.assertAllClose(result, 9.0, atol=1e-3)
+
 
 class MeanTest(testing.TestCase):
     def test_config(self):
@@ -44,6 +50,12 @@ class MeanTest(testing.TestCase):
         mean_obj.update_state([1, 3, 5, 7], sample_weight=[1, 1, 0, 0])
         result = mean_obj.result()
         self.assertAllClose(result, 2.0, atol=1e-3)
+
+    def test_weighted_nd(self):
+        mean_obj = reduction_metrics.Mean(name="mean", dtype="float32")
+        mean_obj.update_state([[1, 3], [5, 7]], sample_weight=[[1, 1], [1, 0]])
+        result = mean_obj.result()
+        self.assertAllClose(result, 3.0, atol=1e-3)
 
 
 def mse(y_true, y_pred):

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -2068,6 +2068,8 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.mean(x), np.mean(x))
         self.assertAllClose(knp.mean(x, axis=1), np.mean(x, axis=1))
+        self.assertAllClose(knp.mean(x, axis=()), np.mean(x, axis=()))
+        self.assertAllClose(knp.mean(x, axis=(1,)), np.mean(x, axis=(1,)))
         self.assertAllClose(
             knp.mean(x, axis=1, keepdims=True),
             np.mean(x, axis=1, keepdims=True),
@@ -2132,6 +2134,8 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.sum(x), np.sum(x))
         self.assertAllClose(knp.sum(x, axis=1), np.sum(x, axis=1))
+        self.assertAllClose(knp.sum(x, axis=(1,)), np.sum(x, axis=(1,)))
+        self.assertAllClose(knp.sum(x, axis=()), np.sum(x, axis=()))
         self.assertAllClose(
             knp.sum(x, axis=1, keepdims=True),
             np.sum(x, axis=1, keepdims=True),


### PR DESCRIPTION
I'm still not sure what broke this, but it appeared to change with the 0.1.1 release.

Please help me check if the outputs here are what we would expect.