### PR TITLE
Add random seed support for torch dropout

### DIFF
--- a/keras_core/backend/torch/random.py
+++ b/keras_core/backend/torch/random.py
@@ -126,9 +126,10 @@ def _get_concrete_noise_shape(inputs, noise_shape):
 
 
 def dropout(inputs, rate, noise_shape=None, seed=None):
-    if noise_shape is not None or not (
-        (seed is None)
-        or (isinstance(seed, SeedGenerator) and seed.initialized_with_none)
+    if (
+        seed is not None
+        and not (isinstance(seed, SeedGenerator) and seed._initial_seed is None)
+        or noise_shape is not None
     ):
         keep_prob = 1.0 - rate
         noise_shape = _get_concrete_noise_shape(inputs, noise_shape)

--- a/keras_core/backend/torch/random.py
+++ b/keras_core/backend/torch/random.py
@@ -126,7 +126,10 @@ def _get_concrete_noise_shape(inputs, noise_shape):
 
 
 def dropout(inputs, rate, noise_shape=None, seed=None):
-    if noise_shape is not None:
+    if noise_shape is not None or not (
+        (seed is None)
+        or (isinstance(seed, SeedGenerator) and seed.initialized_with_none)
+    ):
         keep_prob = 1.0 - rate
         noise_shape = _get_concrete_noise_shape(inputs, noise_shape)
         keep_prob_matrix = torch.full(

--- a/keras_core/random/seed_generator.py
+++ b/keras_core/random/seed_generator.py
@@ -35,7 +35,7 @@ class SeedGenerator:
         else:
             self.backend = backend
 
-        self.initialized_with_none = seed is None
+        self._initial_seed = seed
         if seed is None:
             seed = make_default_seed()
 

--- a/keras_core/random/seed_generator.py
+++ b/keras_core/random/seed_generator.py
@@ -35,8 +35,10 @@ class SeedGenerator:
         else:
             self.backend = backend
 
+        self.initialized_with_none = seed is None
         if seed is None:
             seed = make_default_seed()
+
         if not isinstance(seed, int):
             raise ValueError(
                 "Argument `seed` must be an integer. " f"Received: seed={seed}"


### PR DESCRIPTION
As tested, there is no noticable overhead for the added conditions in the if statement.
It now can reproduce the same dropout with the same seed.
