### PR TITLE
Fixes Torch-GPU Test failure on initializers/random_initializers_test.py

### DIFF
--- a/keras_core/initializers/random_initializers_test.py
+++ b/keras_core/initializers/random_initializers_test.py
@@ -133,7 +133,7 @@ class InitializersTest(testing.TestCase):
         self.assertEqual(initializer.gain, gain)
 
         self.assertEqual(values.shape, shape)
-        array = np.array(values)
+        array = backend.convert_to_numpy(values)
         # Making sure that the columns have gain * unit norm value
         for column in array.T:
             self.assertAlmostEqual(np.linalg.norm(column), gain * 1.0)


### PR DESCRIPTION
Uses `convert_to_numpy(values)` API instead of `np.array(values)`, as it doesn't work in torch backend when the tensor is on GPU.