### PR TITLE
set torch device when converting to tensor

### DIFF
--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -111,8 +111,8 @@ class Variable(KerasVariable):
 def convert_to_tensor(x, dtype=None):
     if is_tensor(x):
         if dtype is None:
-            return x
-        return x.to(to_torch_dtype(dtype))
+            return x.to(device=get_device())
+        return x.to(dtype=to_torch_dtype(dtype), device=get_device())
     if isinstance(x, Variable):
         # TorchDynamo has bugs supporting nn.Parameter type check.
         # Return it directly instead of pass it to the rest of the logic in the


### PR DESCRIPTION
`keras-core`, by default puts `torch` tensors into cuda when available.  When users create tensors outside of `keras-core` and try to combine with `keras-core` tensors, it causes errors as one tensor is in cuda and other in CPU.
Before the manual created torch tensor is combined with model outputs, we need to `convert_to_tensor` to put it in the same device as model data.

For example in [example](https://github.com/keras-team/keras-io/blob/master/guides/keras_core/custom_train_step_in_torch.py), following snippet would fail when running on a machine with GPU: 

```
# Decode them to fake images
generated_images = self.generator(random_latent_vectors)

# Combine them with real images
real_images = torch.tensor(real_images)
combined_images = torch.concat([generated_images, real_images], axis=0)  # Fails since two tensors are on different devices.
```
To Fix it, we need to modify it as - 

```
# Combine them with real images
real_images = torch.tensor(real_images)
real_images = keras.ops.convert_to_tensor(real_images)  # Required before combining with model outputs.
combined_images = torch.concat([generated_images, real_images], axis=0) 
```
