### PR TITLE
implement patch extraction in ops

### DIFF
--- a/keras_core/ops/image.py
+++ b/keras_core/ops/image.py
@@ -340,7 +340,7 @@ def extract_patches(
     >>> y.shape
     (2, 3, 64, 80)
     """
-    if any_symbolic_tensors((image)):
+    if any_symbolic_tensors((image,)):
         return ExtractPatches(
             size, strides, dilation_rate, padding, data_format=data_format
         ).symbolic_call(image)

--- a/keras_core/ops/image.py
+++ b/keras_core/ops/image.py
@@ -397,8 +397,8 @@ def _extract_patches(
         patch_h, patch_w = size[0], size[1]
     else:
         raise TypeError(
-            f"Received invalid patch size expected "
-            "int or tuple of length 2, received {size}"
+            "Received invalid patch size expected "
+            f"int or tuple of length 2, received {size}"
         )
     if data_format == "channels_last":
         channels_in = image.shape[-1]

--- a/keras_core/ops/image.py
+++ b/keras_core/ops/image.py
@@ -6,7 +6,6 @@ from keras_core.ops.operation import Operation
 from keras_core.ops.operation_utils import compute_conv_output_shape
 
 
-
 class Resize(Operation):
     def __init__(
         self,
@@ -278,7 +277,7 @@ class ExtractPatches(Operation):
         image_shape = image.shape
         if not self.strides:
             strides = (self.size[0], self.size[1])
-        if self.data_format == 'channels_last':
+        if self.data_format == "channels_last":
             channels_in = image.shape[-1]
         else:
             channels_in = image.shape[-3]
@@ -286,13 +285,15 @@ class ExtractPatches(Operation):
             image_shape = (1,) + image_shape
         filters = self.size[0] * self.size[1] * channels_in
         kernel_size = (self.size[0], self.size[1])
-        out_shape = compute_conv_output_shape(image_shape,
-                        filters,
-                        kernel_size,
-                        strides=strides,
-                        padding=self.padding,
-                        data_format=self.data_format,
-                        dilation_rate=self.rates)
+        out_shape = compute_conv_output_shape(
+            image_shape,
+            filters,
+            kernel_size,
+            strides=strides,
+            padding=self.padding,
+            data_format=self.data_format,
+            dilation_rate=self.rates,
+        )
         if len(image.shape) == 3:
             out_shape = out_shape[1:]
         return KerasTensor(shape=out_shape, dtype=image.dtype)

--- a/keras_core/ops/image.py
+++ b/keras_core/ops/image.py
@@ -312,14 +312,14 @@ def extract_patches(
 
     Args:
         image: Input image or batch of images. Must be 3D or 4D.
-        size: Patch size int or tuple (patch_height, patch_widht) 
-        strides: strides along height and width. if not specified or 
+        size: Patch size int or tuple (patch_height, patch_widht)
+        strides: strides along height and width. if not specified or
                 None it is same patch_size
-        dilation_rate: This is the input stride, specifying how far two 
+        dilation_rate: This is the input stride, specifying how far two
             consecutive patch samples are in the input. For value other than 1,
-            strides must be 1. NOTE: `strides > 1` not supported in 
+            strides must be 1. NOTE: `strides > 1` not supported in
             conjunction with `dilation_rate > 1`
-        padding: The type of padding algorithm to use. 
+        padding: The type of padding algorithm to use.
             'same' or 'valid'.
         data_format: string, either `"channels_last"` or `"channels_first"`.
             The ordering of the dimensions in the inputs. `"channels_last"`
@@ -385,7 +385,7 @@ def _extract_patches(
     _unbatched = False
     if len(image.shape) == 3:
         _unbatched = True
-        image=backend.numpy.expand_dims(image, axis=0)
+        image = backend.numpy.expand_dims(image, axis=0)
     patches = backend.nn.conv(
         inputs=image,
         kernel=kernel,

--- a/keras_core/ops/image.py
+++ b/keras_core/ops/image.py
@@ -450,10 +450,10 @@ def _extract_patches(
         kernel, (patch_h, patch_w, channels_in, out_dim)
     )
     return backend.nn.conv(
-        image,
-        kernel,
-        strides,
-        padding,
+        inputs=image,
+        kernel=kernel,
+        strides=strides,
+        padding=padding,
         data_format=data_format,
         dilation_rate=dilation_rate,
     )

--- a/keras_core/ops/image.py
+++ b/keras_core/ops/image.py
@@ -292,15 +292,16 @@ class ExtractPatches(Operation):
             patch_h, patch_w = self.size[0], self.size[1]
         else:
             raise TypeError(
-                f"Received invalid patch size expected int or tuple of length 2, received {self.size}"
+                f"Received invalid patch size expected"
+                "int or tuple of length 2, received {self.size}"
             )
 
         if not strides:
             strides = (patch_h, patch_w)
         if len(strides) != 2:
             raise ValueError(
-                "Invalid stride: expected tuple of shape (s_h, s_w)"
-                " Received input: "
+                "Invalid stride: expected tu"
+                "ple of shape (s_h, s_w)  Received input: "
                 f"strides={strides}"
             )
         strides_h = strides[0]
@@ -436,7 +437,8 @@ def _extract_patches(
         patch_h, patch_w = size[0], size[1]
     else:
         raise TypeError(
-            f"Received invalid patch size expected int or tuple of length 2, received {size}"
+            f"Received invalid patch size expected "
+            "int or tuple of length 2, received {size}"
         )
     if data_format == "channels_last":
         channels_in = image.shape[-1]

--- a/keras_core/ops/image.py
+++ b/keras_core/ops/image.py
@@ -252,24 +252,24 @@ class ExtractPatches(Operation):
         self,
         size,
         strides=None,
-        rates=1,
+        dilation_rate=1,
         padding="valid",
         data_format="channels_last",
     ):
         super().__init__()
         self.size = size
         self.strides = strides
-        self.rates = rates
+        self.dilation_rate = dilation_rate
         self.padding = padding
         self.data_format = data_format
 
     def call(self, image):
         return _extract_patches(
-            image,
-            self.size,
-            self.strides,
-            self.rates,
-            self.padding,
+            image=image,
+            size=self.size,
+            strides=self.strides,
+            dilation_rate=self.dilation_rate,
+            padding=self.padding,
             data_format=self.data_format,
         )
 
@@ -292,7 +292,7 @@ class ExtractPatches(Operation):
             strides=strides,
             padding=self.padding,
             data_format=self.data_format,
-            dilation_rate=self.rates,
+            dilation_rate=self.dilation_rate,
         )
         if len(image.shape) == 3:
             out_shape = out_shape[1:]
@@ -346,7 +346,11 @@ def extract_patches(
     """
     if any_symbolic_tensors((image,)):
         return ExtractPatches(
-            size, strides, dilation_rate, padding, data_format=data_format
+            size=size,
+            strides=strides,
+            dilation_rate=dilation_rate,
+            padding=padding,
+            data_format=data_format,
         ).symbolic_call(image)
 
     return _extract_patches(
@@ -368,8 +372,8 @@ def _extract_patches(
         patch_h, patch_w = size[0], size[1]
     else:
         raise TypeError(
-            "Received invalid patch size expected "
-            f"int or tuple of length 2, received {size}"
+            "invalid size argument "
+            f"int or tuple of length 2. Received {size}"
         )
     if data_format == "channels_last":
         channels_in = image.shape[-1]

--- a/keras_core/ops/image_test.py
+++ b/keras_core/ops/image_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
+import pytest
 
 from keras_core import backend
 from keras_core import testing
@@ -236,58 +237,49 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
     def test_extract_patches(
         self, size, strides, dilation_rate, padding, data_format
     ):
-        if data_format == "channels_last":
-            patch_h, patch_w = size[0], size[1]
-            image = tf.random.uniform((1, 20, 20, 3))
-            if strides is None:
-                strides_h, strides_w = patch_h, patch_w
-            else:
-                strides_h, strides_w = strides[0], strides[1]
-
-            patches_tf = tf.image.extract_patches(
-                image,
-                sizes=(1, patch_h, patch_w, 1),
-                strides=(1, strides_h, strides_w, 1),
-                rates=[1, dilation_rate, dilation_rate, 1],
-                padding=padding.upper(),
+        if data_format =='channels_first':
+            image = np.random.uniform(size=(1, 3, 20, 20))
+        else:
+            image = np.random.uniform(size=(1, 20, 20, 3))
+        if (
+            data_format == "channels_first"
+            and backend.backend() == "tensorflow"
+        ):
+            pytest.skip("channels_first unsupported on CPU with TF")
+        
+        patch_h, patch_w = size[0], size[1]  
+        if strides is None:
+            strides_h, strides_w = patch_h, patch_w
+        else:
+            strides_h, strides_w = strides[0], strides[1]
+        if backend.backend() != 'torch':
+            patches_out = kimage.extract_patches(
+                    image,
+                    size,
+                    strides=strides,
+                    dilation_rate=dilation_rate,
+                    padding=padding,
+                    data_format=data_format,
             )
-            patches_ops = kimage.extract_patches(
-                image,
-                size,
-                strides=strides,
-                dilation_rate=dilation_rate,
-                padding=padding,
-                data_format=data_format,
-            )
-            self.assertIsNone(
-                tf.debugging.assert_equal(patches_tf, patches_ops)
+        else:
+            patches_out = kimage.extract_patches(
+                    backend.convert_to_tensor(image, dtype='float32'),
+                    size,
+                    strides=strides,
+                    dilation_rate=dilation_rate,
+                    padding=padding,
+                    data_format=data_format,
             )
         if data_format == "channels_first":
-            patch_h, patch_w = size[0], size[1]
-            image = tf.random.uniform((1, 3, 20, 20))
-            if strides is None:
-                strides_h, strides_w = patch_h, patch_w
-            else:
-                strides_h, strides_w = strides[0], strides[1]
-            image_c = tf.transpose(image, perm=[0, 2, 3, 1])
-            patches_tf = tf.image.extract_patches(
-                image_c,
-                sizes=(1, patch_h, patch_w, 1),
-                strides=(1, strides_h, strides_w, 1),
-                rates=[1, dilation_rate, dilation_rate, 1],
-                padding=padding.upper(),
-            )
-            patches_ops = kimage.extract_patches(
-                image,
-                size,
-                strides=strides,
-                dilation_rate=dilation_rate,
-                padding=padding,
-                data_format=data_format,
-            )
-            patches_ops = backend.numpy.transpose(
-                patches_ops, axes=[0, 2, 3, 1]
-            )
-            self.assertIsNone(
-                tf.debugging.assert_equal(patches_tf, patches_ops)
-            )
+            patches_out = backend.numpy.transpose(patches_out, axes=[0, 2, 3, 1])
+        if data_format == "channels_first":
+            image = np.transpose(image, [0, 2, 3, 1])
+        patches_ref = tf.image.extract_patches(image, sizes=(1, patch_h, patch_w, 1), 
+                                               strides=(1, strides_h, strides_w, 1), 
+                                               rates=(1, dilation_rate, dilation_rate, 1), 
+                                               padding=padding.upper())
+        
+        
+
+        self.assertEqual(tuple(patches_out.shape), tuple(patches_ref.shape))
+        self.assertAllClose(patches_ref.numpy(), patches_out.numpy(), atol=0.3)

--- a/keras_core/ops/image_test.py
+++ b/keras_core/ops/image_test.py
@@ -232,6 +232,9 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             ((3, 3), (2, 2), 1, "same", "channels_last"),
             ((5, 5), None, 1, "same", "channels_first"),
             ((3, 3), (2, 2), 1, "same", "channels_first"),
+            ((5, 5), (1, 1), 3, "same", "channels_first"),
+            ((5, 5), (2, 2), 3, "same", "channels_first"),
+            ((5, 5), (2, 2), 3, "same", "channels_last"),
         ]
     )
     def test_extract_patches(
@@ -242,6 +245,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             and backend.backend() == "tensorflow"
         ):
             pytest.skip("channels_first unsupported on CPU with TF")
+            
         if data_format == "channels_first":
             image = np.random.uniform(size=(1, 3, 20, 20))
         else:

--- a/keras_core/ops/image_test.py
+++ b/keras_core/ops/image_test.py
@@ -237,39 +237,31 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
     def test_extract_patches(
         self, size, strides, dilation_rate, padding, data_format
     ):
-        if data_format == "channels_first":
-            image = np.random.uniform(size=(1, 3, 20, 20))
-        else:
-            image = np.random.uniform(size=(1, 20, 20, 3))
         if (
             data_format == "channels_first"
             and backend.backend() == "tensorflow"
         ):
             pytest.skip("channels_first unsupported on CPU with TF")
 
+        if data_format == "channels_first":
+            image = np.random.uniform(size=(1, 3, 20, 20))
+        else:
+            image = np.random.uniform(size=(1, 20, 20, 3))
+        
         patch_h, patch_w = size[0], size[1]
         if strides is None:
             strides_h, strides_w = patch_h, patch_w
         else:
             strides_h, strides_w = strides[0], strides[1]
-        if backend.backend() != "torch":
-            patches_out = kimage.extract_patches(
-                image,
-                size,
-                strides=strides,
-                dilation_rate=dilation_rate,
-                padding=padding,
-                data_format=data_format,
-            )
-        else:
-            patches_out = kimage.extract_patches(
-                backend.convert_to_tensor(image, dtype="float32"),
-                size,
-                strides=strides,
-                dilation_rate=dilation_rate,
-                padding=padding,
-                data_format=data_format,
-            )
+
+        patches_out = kimage.extract_patches(
+            backend.convert_to_tensor(image, dtype="float32"),
+            size,
+            strides=strides,
+            dilation_rate=dilation_rate,
+            padding=padding,
+            data_format=data_format,
+        )
         if data_format == "channels_first":
             patches_out = backend.numpy.transpose(
                 patches_out, axes=[0, 2, 3, 1]
@@ -283,6 +275,5 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             rates=(1, dilation_rate, dilation_rate, 1),
             padding=padding.upper(),
         )
-
         self.assertEqual(tuple(patches_out.shape), tuple(patches_ref.shape))
-        self.assertAllClose(patches_ref.numpy(), patches_out.numpy(), atol=0.3)
+        self.assertAllClose(patches_ref.numpy(), backend.convert_to_numpy(patches_out), atol=0.3)

--- a/keras_core/ops/image_test.py
+++ b/keras_core/ops/image_test.py
@@ -237,7 +237,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
     def test_extract_patches(
         self, size, strides, dilation_rate, padding, data_format
     ):
-        if data_format =='channels_first':
+        if data_format == "channels_first":
             image = np.random.uniform(size=(1, 3, 20, 20))
         else:
             image = np.random.uniform(size=(1, 20, 20, 3))
@@ -246,40 +246,43 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             and backend.backend() == "tensorflow"
         ):
             pytest.skip("channels_first unsupported on CPU with TF")
-        
-        patch_h, patch_w = size[0], size[1]  
+
+        patch_h, patch_w = size[0], size[1]
         if strides is None:
             strides_h, strides_w = patch_h, patch_w
         else:
             strides_h, strides_w = strides[0], strides[1]
-        if backend.backend() != 'torch':
+        if backend.backend() != "torch":
             patches_out = kimage.extract_patches(
-                    image,
-                    size,
-                    strides=strides,
-                    dilation_rate=dilation_rate,
-                    padding=padding,
-                    data_format=data_format,
+                image,
+                size,
+                strides=strides,
+                dilation_rate=dilation_rate,
+                padding=padding,
+                data_format=data_format,
             )
         else:
             patches_out = kimage.extract_patches(
-                    backend.convert_to_tensor(image, dtype='float32'),
-                    size,
-                    strides=strides,
-                    dilation_rate=dilation_rate,
-                    padding=padding,
-                    data_format=data_format,
+                backend.convert_to_tensor(image, dtype="float32"),
+                size,
+                strides=strides,
+                dilation_rate=dilation_rate,
+                padding=padding,
+                data_format=data_format,
             )
         if data_format == "channels_first":
-            patches_out = backend.numpy.transpose(patches_out, axes=[0, 2, 3, 1])
+            patches_out = backend.numpy.transpose(
+                patches_out, axes=[0, 2, 3, 1]
+            )
         if data_format == "channels_first":
             image = np.transpose(image, [0, 2, 3, 1])
-        patches_ref = tf.image.extract_patches(image, sizes=(1, patch_h, patch_w, 1), 
-                                               strides=(1, strides_h, strides_w, 1), 
-                                               rates=(1, dilation_rate, dilation_rate, 1), 
-                                               padding=padding.upper())
-        
-        
+        patches_ref = tf.image.extract_patches(
+            image,
+            sizes=(1, patch_h, patch_w, 1),
+            strides=(1, strides_h, strides_w, 1),
+            rates=(1, dilation_rate, dilation_rate, 1),
+            padding=padding.upper(),
+        )
 
         self.assertEqual(tuple(patches_out.shape), tuple(patches_ref.shape))
         self.assertAllClose(patches_ref.numpy(), patches_out.numpy(), atol=0.3)

--- a/keras_core/ops/image_test.py
+++ b/keras_core/ops/image_test.py
@@ -274,6 +274,6 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding.upper(),
         )
         self.assertEqual(tuple(patches_out.shape), tuple(patches_ref.shape))
-        self.assertAllClose(patches_ref.numpy(), 
+        self.assertAllClose(patches_ref.numpy(),
                             backend.convert_to_numpy(patches_out),
                             atol=0.3)

--- a/keras_core/ops/image_test.py
+++ b/keras_core/ops/image_test.py
@@ -246,6 +246,14 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         ):
             pytest.skip("channels_first unsupported on CPU with TF")
 
+        if (
+            isinstance(strides, tuple)
+            and backend.backend() == "tensorflow"
+            and dilation_rate > 1
+        ):
+            pytest.skip(
+                "dilation_rate>1 with strides>1 than not supported with TF"
+            )
         if data_format == "channels_first":
             image = np.random.uniform(size=(1, 3, 20, 20))
         else:
@@ -258,7 +266,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
         patches_out = kimage.extract_patches(
             backend.convert_to_tensor(image, dtype="float32"),
-            size,
+            size=size,
             strides=strides,
             dilation_rate=dilation_rate,
             padding=padding,

--- a/keras_core/ops/image_test.py
+++ b/keras_core/ops/image_test.py
@@ -245,7 +245,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             and backend.backend() == "tensorflow"
         ):
             pytest.skip("channels_first unsupported on CPU with TF")
-            
+
         if data_format == "channels_first":
             image = np.random.uniform(size=(1, 3, 20, 20))
         else:
@@ -278,6 +278,6 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding.upper(),
         )
         self.assertEqual(tuple(patches_out.shape), tuple(patches_ref.shape))
-        self.assertAllClose(patches_ref.numpy(),
-                            backend.convert_to_numpy(patches_out),
-                            atol=0.3)
+        self.assertAllClose(
+            patches_ref.numpy(), backend.convert_to_numpy(patches_out), atol=0.3
+        )

--- a/keras_core/ops/image_test.py
+++ b/keras_core/ops/image_test.py
@@ -242,12 +242,10 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             and backend.backend() == "tensorflow"
         ):
             pytest.skip("channels_first unsupported on CPU with TF")
-
         if data_format == "channels_first":
             image = np.random.uniform(size=(1, 3, 20, 20))
         else:
             image = np.random.uniform(size=(1, 20, 20, 3))
-        
         patch_h, patch_w = size[0], size[1]
         if strides is None:
             strides_h, strides_w = patch_h, patch_w
@@ -276,4 +274,6 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding.upper(),
         )
         self.assertEqual(tuple(patches_out.shape), tuple(patches_ref.shape))
-        self.assertAllClose(patches_ref.numpy(), backend.convert_to_numpy(patches_out), atol=0.3)
+        self.assertAllClose(patches_ref.numpy(), 
+                            backend.convert_to_numpy(patches_out),
+                            atol=0.3)


### PR DESCRIPTION
As discussed in #529, this pull request implements [tf.image.extract_patches](https://www.tensorflow.org/api_docs/python/tf/image/extract_patches)  in keras ops