### PR TITLE
Backend-agnostic port of Image classification with Vision Transformer

### DIFF
--- a/examples/keras_io/vision/image_classification_with_vision_transformer.py
+++ b/examples/keras_io/vision/image_classification_with_vision_transformer.py
@@ -95,7 +95,7 @@ data_augmentation.layers[0].adapt(x_train)
 
 def mlp(x, hidden_units, dropout_rate):
     for units in hidden_units:
-        x = layers.Dense(units, activation=tf.nn.gelu)(x)
+        x = layers.Dense(units, activation=keras.activations.gelu)(x)
         x = layers.Dropout(dropout_rate)(x)
     return x
 

--- a/examples/keras_io/vision/image_classification_with_vision_transformer.py
+++ b/examples/keras_io/vision/image_classification_with_vision_transformer.py
@@ -24,6 +24,7 @@ image patches, without using convolution layers.
 """
 
 import os
+
 os.environ["KERAS_BACKEND"] = "jax"  # @param ["tensorflow", "jax", "torch"]
 
 import keras_core as keras
@@ -118,9 +119,26 @@ class Patches(layers.Layer):
         channels = input_shape[3]
         num_patches_h = height // self.patch_size
         num_patches_w = width // self.patch_size
-        patches = ops.reshape(images, (batch_size, num_patches_h, self.patch_size, num_patches_w, self.patch_size, channels))
+        patches = ops.reshape(
+            images,
+            (
+                batch_size,
+                num_patches_h,
+                self.patch_size,
+                num_patches_w,
+                self.patch_size,
+                channels,
+            ),
+        )
         patches = ops.transpose(patches, (0, 1, 3, 2, 4, 5))
-        patches = ops.reshape(patches, (batch_size, num_patches_h * num_patches_w, self.patch_size * self.patch_size * channels))
+        patches = ops.reshape(
+            patches,
+            (
+                batch_size,
+                num_patches_h * num_patches_w,
+                self.patch_size * self.patch_size * channels,
+            ),
+        )
         return patches
 
     def get_config(self):
@@ -174,11 +192,13 @@ class PatchEncoder(layers.Layer):
         )
 
     def call(self, patch):
-        positions = ops.expand_dims(ops.arange(start=0, stop=self.num_patches, step=1), axis=0)
+        positions = ops.expand_dims(
+            ops.arange(start=0, stop=self.num_patches, step=1), axis=0
+        )
         projected_patches = self.projection(patch)
         encoded = projected_patches + self.position_embedding(positions)
         return encoded
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({"num_patches": self.num_patches})
@@ -236,7 +256,9 @@ def create_vit_classifier():
     representation = layers.Flatten()(representation)
     representation = layers.Dropout(0.5)(representation)
     # Add MLP.
-    features = mlp(representation, hidden_units=mlp_head_units, dropout_rate=0.5)
+    features = mlp(
+        representation, hidden_units=mlp_head_units, dropout_rate=0.5
+    )
     # Classify outputs.
     logits = layers.Dense(num_classes)(features)
     # Create the Keras model.

--- a/examples/keras_io/vision/image_classification_with_vision_transformer.py
+++ b/examples/keras_io/vision/image_classification_with_vision_transformer.py
@@ -119,25 +119,13 @@ class Patches(layers.Layer):
         channels = input_shape[3]
         num_patches_h = height // self.patch_size
         num_patches_w = width // self.patch_size
+        patches = keras.ops.image.extract_patches(images, size=self.patch_size)
         patches = ops.reshape(
-            images,
-            (
-                batch_size,
-                num_patches_h,
-                self.patch_size,
-                num_patches_w,
-                self.patch_size,
-                channels,
-            ),
-        )
-        patches = ops.transpose(patches, (0, 1, 3, 2, 4, 5))
-        patches = ops.reshape(
-            patches,
-            (
+            patches, (
                 batch_size,
                 num_patches_h * num_patches_w,
                 self.patch_size * self.patch_size * channels,
-            ),
+            )
         )
         return patches
 

--- a/examples/keras_io/vision/image_classification_with_vision_transformer.py
+++ b/examples/keras_io/vision/image_classification_with_vision_transformer.py
@@ -1,6 +1,7 @@
 """
 Title: Image classification with Vision Transformer
 Author: [Khalid Salama](https://www.linkedin.com/in/khalid-salama-24403144/)
+Converted to Keras Core by: [divyasreepat](https://github.com/divyashreepathihalli), [Soumik Rakshit](http://github.com/soumik12345)
 Date created: 2021/01/18
 Last modified: 2021/01/18
 Description: Implementing the Vision Transformer (ViT) model for image classification.
@@ -22,10 +23,15 @@ image patches, without using convolution layers.
 ## Setup
 """
 
-import numpy as np
-import tensorflow as tf
+import os
+os.environ["KERAS_BACKEND"] = "jax"  # @param ["tensorflow", "jax", "torch"]
+
 import keras_core as keras
 from keras_core import layers
+from keras_core import ops
+
+import numpy as np
+import matplotlib.pyplot as plt
 
 """
 ## Prepare the data
@@ -105,32 +111,35 @@ class Patches(layers.Layer):
         self.patch_size = patch_size
 
     def call(self, images):
-        batch_size = tf.shape(images)[0]
-        patches = tf.image.extract_patches(
-            images=images,
-            sizes=[1, self.patch_size, self.patch_size, 1],
-            strides=[1, self.patch_size, self.patch_size, 1],
-            rates=[1, 1, 1, 1],
-            padding="VALID",
-        )
-        patch_dims = patches.shape[-1]
-        patches = tf.reshape(patches, [batch_size, -1, patch_dims])
+        input_shape = ops.backend.shape(images)
+        batch_size = input_shape[0]
+        height = input_shape[1]
+        width = input_shape[2]
+        channels = input_shape[3]
+        num_patches_h = height // self.patch_size
+        num_patches_w = width // self.patch_size
+        patches = ops.reshape(images, (batch_size, num_patches_h, self.patch_size, num_patches_w, self.patch_size, channels))
+        patches = ops.transpose(patches, (0, 1, 3, 2, 4, 5))
+        patches = ops.reshape(patches, (batch_size, num_patches_h * num_patches_w, self.patch_size * self.patch_size * channels))
         return patches
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"patch_size": self.patch_size})
+        return config
 
 
 """
 Let's display patches for a sample image
 """
 
-import matplotlib.pyplot as plt
-
 plt.figure(figsize=(4, 4))
 image = x_train[np.random.choice(range(x_train.shape[0]))]
 plt.imshow(image.astype("uint8"))
 plt.axis("off")
 
-resized_image = tf.image.resize(
-    tf.convert_to_tensor([image]), size=(image_size, image_size)
+resized_image = ops.image.resize(
+    ops.convert_to_tensor([image]), size=(image_size, image_size)
 )
 patches = Patches(patch_size)(resized_image)
 print(f"Image size: {image_size} X {image_size}")
@@ -142,8 +151,8 @@ n = int(np.sqrt(patches.shape[1]))
 plt.figure(figsize=(4, 4))
 for i, patch in enumerate(patches[0]):
     ax = plt.subplot(n, n, i + 1)
-    patch_img = tf.reshape(patch, (patch_size, patch_size, 3))
-    plt.imshow(patch_img.numpy().astype("uint8"))
+    patch_img = ops.reshape(patch, (patch_size, patch_size, 3))
+    plt.imshow(ops.convert_to_numpy(patch_img).astype("uint8"))
     plt.axis("off")
 
 """
@@ -165,9 +174,15 @@ class PatchEncoder(layers.Layer):
         )
 
     def call(self, patch):
-        positions = tf.range(start=0, limit=self.num_patches, delta=1)
-        encoded = self.projection(patch) + self.position_embedding(positions)
+        positions = ops.expand_dims(ops.arange(start=0, stop=self.num_patches, step=1), axis=0)
+        projected_patches = self.projection(patch)
+        encoded = projected_patches + self.position_embedding(positions)
         return encoded
+    
+    def get_config(self):
+        config = super().get_config()
+        config.update({"num_patches": self.num_patches})
+        return config
 
 
 """
@@ -191,7 +206,7 @@ especially when the number of patches and the projection dimensions are large.
 
 
 def create_vit_classifier():
-    inputs = layers.Input(shape=input_shape)
+    inputs = keras.Input(shape=input_shape)
     # Augment data.
     augmented = data_augmentation(inputs)
     # Create patches.
@@ -221,9 +236,7 @@ def create_vit_classifier():
     representation = layers.Flatten()(representation)
     representation = layers.Dropout(0.5)(representation)
     # Add MLP.
-    features = mlp(
-        representation, hidden_units=mlp_head_units, dropout_rate=0.5
-    )
+    features = mlp(representation, hidden_units=mlp_head_units, dropout_rate=0.5)
     # Classify outputs.
     logits = layers.Dense(num_classes)(features)
     # Create the Keras model.
@@ -279,6 +292,21 @@ def run_experiment(model):
 
 vit_classifier = create_vit_classifier()
 history = run_experiment(vit_classifier)
+
+
+def plot_history(item):
+    plt.plot(history.history[item], label=item)
+    plt.plot(history.history["val_" + item], label="val_" + item)
+    plt.xlabel("Epochs")
+    plt.ylabel(item)
+    plt.title("Train and Validation {} Over Epochs".format(item), fontsize=14)
+    plt.legend()
+    plt.grid()
+    plt.show()
+
+
+plot_history("loss")
+plot_history("top-5-accuracy")
 
 
 """


### PR DESCRIPTION
Added a backend-agnostic port of the example [Image classification with Vision Transformer](https://keras.io/examples/vision/image_classification_with_vision_transformer/) that works with TF, Jax, and Torch backends. Based on the TF-compatible port originally contributed by @divyashreepathihalli as part of https://github.com/keras-team/keras-core/pull/388.

Linked Issue: https://github.com/keras-team/keras-core/issues/222

Colab: https://colab.research.google.com/drive/15djhD0aS5qqCbeUDAhhg_7R9uZCmdpJb?usp=sharing