### PR TITLE
Backend consistency in handling of empty tensor in `min` and `max`

### DIFF
--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -558,7 +558,7 @@ def min(x, axis=None, keepdims=False, initial=None):
     x = convert_to_tensor(x)
     if 0 in x.shape:
         if initial is None:
-            raise ValueError("Cannot compute the max of an empty tensor.")
+            raise ValueError("Cannot compute the min of an empty tensor.")
         elif keepdims:
             return torch.full((1,) * len(x.shape), initial)
         else:

--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -55,7 +55,13 @@ def mean(x, axis=None, keepdims=False):
 def max(x, axis=None, keepdims=False, initial=None):
     x = convert_to_tensor(x)
     if 0 in x.shape:
-        return 0
+        if initial is None:
+            raise ValueError("Cannot compute the max of an empty tensor.")
+        elif keepdims:
+            return torch.full((1,) * len(x.shape), initial)
+        else:
+            return torch.tensor(initial)
+
     if axis is None:
         result = torch.max(x)
     else:
@@ -550,6 +556,14 @@ def meshgrid(*x, indexing="xy"):
 
 def min(x, axis=None, keepdims=False, initial=None):
     x = convert_to_tensor(x)
+    if 0 in x.shape:
+        if initial is None:
+            raise ValueError("Cannot compute the max of an empty tensor.")
+        elif keepdims:
+            return torch.full((1,) * len(x.shape), initial)
+        else:
+            return torch.tensor(initial)
+
     if axis is None:
         result = torch.min(x)
     else:

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -2652,6 +2652,14 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         # test max with initial
         self.assertAllClose(knp.max(x, initial=4), 4)
 
+        # test empty tensor
+        x = np.array([[]])
+        self.assertAllClose(knp.max(x, initial=1), np.max(x, initial=1))
+        self.assertAllClose(
+            knp.max(x, initial=1, keepdims=True),
+            np.max(x, initial=1, keepdims=True),
+        )
+
     def test_min(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.min(x), np.min(x))
@@ -2665,6 +2673,14 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
 
         # test min with initial
         self.assertAllClose(knp.min(x, initial=0), 0)
+
+        # test empty tensor
+        x = np.array([[]])
+        self.assertAllClose(knp.min(x, initial=1), np.min(x, initial=1))
+        self.assertAllClose(
+            knp.min(x, initial=1, keepdims=True),
+            np.min(x, initial=1, keepdims=True),
+        )
 
     def test_meshgrid(self):
         x = np.array([1, 2, 3])


### PR DESCRIPTION
Correct a slight inconsistency between Torch and the other backends in the handling of empty tensors for `max` and `min`:

- All backends but Torch follow the numpy behaviour, which is to throw an exception on empty tensor, except if the argument `initial` is passed. See screenshot 1, on JAX as an example.
- On backend Torch, it returns 0 for `max`, and it fails for `min`, irrespective of the argument `initial`. See screenshot 2 for `max`.

This PR aligns the behaviour of Torch backend on numpy (see screenshot 3). Also adds a test.

Screenshot 1 - JAX `max`
![Pasted Graphic](https://github.com/keras-team/keras-core/assets/104828547/65ec3c57-b787-4f08-b2ce-c4763f01209f)

Screenshot 2 - Torch `max`, before PR
![Pasted Graphic 1](https://github.com/keras-team/keras-core/assets/104828547/47de58e9-382a-49fd-90a9-3f93af6da8e6)

Screenshot 3 - Torch `max`, after PR
![Pasted Graphic 2](https://github.com/keras-team/keras-core/assets/104828547/70162be2-4411-414a-add2-2d666a97a3fe)
