### PR TITLE
Always install the correct version with pip_build

### DIFF
--- a/pip_build.py
+++ b/pip_build.py
@@ -81,7 +81,7 @@ def build():
 
         # Find the .whl file path
         for fname in os.listdir(dist_directory):
-            if fname.endswith(".whl"):
+            if __version__ in fname and fname.endswith(".whl"):
                 whl_path = os.path.abspath(os.path.join(dist_directory, fname))
         print(f"Build successful. Wheel file available at {whl_path}")
     finally:


### PR DESCRIPTION
pip_build while create whl files in `/dist`, which aren't cleaned up by the script unless you do so manually.

The script would install the first `.whl` it saw in `/dist`, which means if you have been building multiple versions of keras-core, the install script might grab the wrong one.

This makes sure to always grab the correct versioned `.whl`. Alternately we could clear the `/dist` dir each time we build.