### PR TITLE
Add the unstack operation to keras core

### DIFF
--- a/keras_core/backend/jax/core.py
+++ b/keras_core/backend/jax/core.py
@@ -287,3 +287,10 @@ def fori_loop(lower, upper, body_fun, init_val):
 
 def stop_gradient(variable):
     return jax.lax.stop_gradient(variable)
+
+
+def unstack(x, axis=0):
+    return [
+        jax.lax.index_in_dim(x, i, axis, keepdims=False)
+        for i in range(x.shape[axis])
+    ]

--- a/keras_core/backend/numpy/core.py
+++ b/keras_core/backend/numpy/core.py
@@ -217,3 +217,8 @@ def fori_loop(lower, upper, body_fun, init_val):
 
 def stop_gradient(x):
     pass
+
+
+def unstack(x, axis=0):
+    x = np.moveaxis(x, axis, 0)
+    return [x[i] for i in range(x.shape[0])]

--- a/keras_core/backend/tensorflow/core.py
+++ b/keras_core/backend/tensorflow/core.py
@@ -183,3 +183,7 @@ def fori_loop(lower, upper, body_fun, init_val):
 
 def stop_gradient(variable):
     return tf.stop_gradient(variable)
+
+
+def unstack(x, axis=0):
+    return tf.unstack(x, axis=axis)

--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -353,3 +353,7 @@ def stop_gradient(variable):
     # We can't use `.requires_grad_(False)` here since it only
     # works when the tensor is a leaf node in the graph.
     return variable.detach()
+
+
+def unstack(x, axis=0):
+    return x.unbind(axis)

--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -344,6 +344,30 @@ def fori_loop(lower, upper, body_fun, init_val):
     return backend.core.fori_loop(lower, upper, body_fun, init_val)
 
 
+@keras_core_export("keras_core.ops.unstack")
+def unstack(x, axis=0):
+    """Unpacks the given dimension of a rank-R tensor into rank-(R-1) tensors.
+
+    Args:
+        x: The input tensor (must be non-symbolic).
+        axis: The axis along which to unpack.
+
+    Returns:
+        A list of tensors unpacked along the given axis.
+
+    Example:
+
+    >>> x = keras_core.ops.array([[1, 2], [3, 4]])
+    >>> keras_core.ops.unstack(x, axis=0)
+    [array([1, 2]), array([3, 4])]
+    """
+    if any_symbolic_tensors((x, axis)):
+        raise NotImplementedError(
+            "Symbolic inputs are not support for the unstack operation"
+        )
+    return backend.core.unstack(x, axis=axis)
+
+
 @keras_core_export("keras_core.ops.shape")
 def shape(x):
     """Gets the shape of the tensor input.

--- a/keras_core/ops/core_test.py
+++ b/keras_core/ops/core_test.py
@@ -298,3 +298,15 @@ class CoreOpsCorrectnessTest(testing.TestCase):
                 lambda: KerasTensor((3,)),
                 lambda: KerasTensor((4,)),
             )
+
+    def test_unstack(self):
+        rng = np.random.default_rng(0)
+        x = rng.uniform(size=(2, 3, 4))
+        x_tensor = ops.convert_to_tensor(x)
+        axis = 1
+        out = ops.unstack(x_tensor, axis)
+        out_ex = [x[:, i, :] for i in range(x.shape[axis])]
+        self.assertEqual(len(out), len(out_ex))
+        for o, o_e in zip(out, out_ex):
+            o = ops.convert_to_numpy(o)
+            self.assertAllClose(o, o_e)


### PR DESCRIPTION
I recently got a use-case for the [`unstack`](https://www.tensorflow.org/api_docs/python/tf/unstack) operation while working with the [segment anything model tensorflow port](https://github.com/tirthasheshpatel/segment_anything_tensorflow/blob/b93d715e96ad6838541972debfac76e56d1f6bfe/sam_tf/image_encoder.py#L105). This PR adds the op.

Note that, if the input tensor is symbolic, it is not straight-forward to compute the output spec since the output list length might be arbitrary. So, this PR only adds support for non-symbolic tensors for the time being. Support for symbolic tensors can be added as a follow-up enhancement.

cc @ianstenbit 