### PR TITLE
Improve `TensorFlowTrainer` compatibility for TF<2.9

### DIFF
--- a/keras_core/backend/tensorflow/trainer.py
+++ b/keras_core/backend/tensorflow/trainer.py
@@ -24,7 +24,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
         self.test_function = None
         self.predict_function = None
 
-        if Version(tf.__version__) > Version('2.8.0'):
+        if Version(tf.__version__) >= Version('2.9.0'):
             self.support_reduce_retracing = True
         else:
             self.support_reduce_retracing = False

--- a/keras_core/backend/tensorflow/trainer.py
+++ b/keras_core/backend/tensorflow/trainer.py
@@ -25,9 +25,9 @@ class TensorFlowTrainer(base_trainer.Trainer):
         self.predict_function = None
 
         if Version(tf.__version__) >= Version('2.9.0'):
-            self.support_reduce_retracing = True
+            self._support_reduce_retracing = True
         else:
-            self.support_reduce_retracing = False
+            self._support_reduce_retracing = False
 
         # Model must be created under scope of DistStrat it will be trained
         # with.
@@ -107,7 +107,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         if not self.run_eagerly:
             kwargs = {'jit_compile': self.jit_compile}
-            if self.support_reduce_retracing is True:
+            if self._support_reduce_retracing:
                 kwargs.update({'reduce_retracing': True})
             one_step_on_data = tf.function(one_step_on_data, **kwargs)
 
@@ -138,7 +138,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         if not self.run_eagerly:
             kwargs = {}
-            if self.support_reduce_retracing is True:
+            if self._support_reduce_retracing:
                 kwargs.update({'reduce_retracing': True})
             train_function = tf.function(train_function, **kwargs)
 
@@ -155,7 +155,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         if not self.run_eagerly and self.jit_compile:
             kwargs = {'jit_compile': True}
-            if self.support_reduce_retracing is True:
+            if self._support_reduce_retracing:
                 kwargs.update({'reduce_retracing': True})
             one_step_on_data = tf.function(one_step_on_data, **kwargs)
 
@@ -186,7 +186,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         if not self.run_eagerly:
             kwargs = {}
-            if self.support_reduce_retracing is True:
+            if self._support_reduce_retracing:
                 kwargs.update({'reduce_retracing': True})
             test_function = tf.function(test_function, **kwargs)
 
@@ -203,7 +203,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         if not self.run_eagerly and self.jit_compile:
             kwargs = {'jit_compile': True}
-            if self.support_reduce_retracing is True:
+            if self._support_reduce_retracing:
                 kwargs.update({'reduce_retracing': True})
             one_step_on_data = tf.function(one_step_on_data, **kwargs)
 
@@ -237,7 +237,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         if not self.run_eagerly:
             kwargs = {}
-            if self.support_reduce_retracing is True:
+            if self._support_reduce_retracing:
                 kwargs.update({'reduce_retracing': True})
 
             predict_function = tf.function(predict_function, **kwargs)

--- a/keras_core/backend/tensorflow/trainer.py
+++ b/keras_core/backend/tensorflow/trainer.py
@@ -4,6 +4,8 @@ import warnings
 import numpy as np
 import tensorflow as tf
 import tree
+
+from packaging.version import Version
 from tensorflow.python.eager import context as tf_context
 
 from keras_core import callbacks as callbacks_module
@@ -21,6 +23,11 @@ class TensorFlowTrainer(base_trainer.Trainer):
         self.train_function = None
         self.test_function = None
         self.predict_function = None
+
+        if Version(tf.__version__) > Version('2.8.0'):
+            self.support_reduce_retracing = True
+        else:
+            self.support_reduce_retracing = False
 
         # Model must be created under scope of DistStrat it will be trained
         # with.
@@ -99,11 +106,10 @@ class TensorFlowTrainer(base_trainer.Trainer):
             return self.train_step(data)
 
         if not self.run_eagerly:
-            one_step_on_data = tf.function(
-                one_step_on_data,
-                jit_compile=self.jit_compile,
-                reduce_retracing=True,
-            )
+            kwargs = {'jit_compile': self.jit_compile}
+            if self.support_reduce_retracing is True:
+                kwargs.update({'reduce_retracing': True})
+            one_step_on_data = tf.function(one_step_on_data, **kwargs)
 
         @tf.autograph.experimental.do_not_convert
         def one_step_on_iterator(iterator):
@@ -131,7 +137,10 @@ class TensorFlowTrainer(base_trainer.Trainer):
             train_function = one_step_on_iterator
 
         if not self.run_eagerly:
-            train_function = tf.function(train_function, reduce_retracing=True)
+            kwargs = {}
+            if self.support_reduce_retracing is True:
+                kwargs.update({'reduce_retracing': True})
+            train_function = tf.function(train_function, **kwargs)
 
         self.train_function = train_function
 
@@ -145,9 +154,10 @@ class TensorFlowTrainer(base_trainer.Trainer):
             return self.test_step(data)
 
         if not self.run_eagerly and self.jit_compile:
-            one_step_on_data = tf.function(
-                one_step_on_data, jit_compile=True, reduce_retracing=True
-            )
+            kwargs = {'jit_compile': True}
+            if self.support_reduce_retracing is True:
+                kwargs.update({'reduce_retracing': True})
+            one_step_on_data = tf.function(one_step_on_data, **kwargs)
 
         @tf.autograph.experimental.do_not_convert
         def one_step_on_iterator(iterator):
@@ -175,7 +185,10 @@ class TensorFlowTrainer(base_trainer.Trainer):
             test_function = one_step_on_iterator
 
         if not self.run_eagerly:
-            test_function = tf.function(test_function, reduce_retracing=True)
+            kwargs = {}
+            if self.support_reduce_retracing is True:
+                kwargs.update({'reduce_retracing': True})
+            test_function = tf.function(test_function, **kwargs)
 
         self.test_function = test_function
 
@@ -189,9 +202,10 @@ class TensorFlowTrainer(base_trainer.Trainer):
             return self.predict_step(data)
 
         if not self.run_eagerly and self.jit_compile:
-            one_step_on_data = tf.function(
-                one_step_on_data, jit_compile=True, reduce_retracing=True
-            )
+            kwargs = {'jit_compile': True}
+            if self.support_reduce_retracing is True:
+                kwargs.update({'reduce_retracing': True})
+            one_step_on_data = tf.function(one_step_on_data, **kwargs)
 
         @tf.autograph.experimental.do_not_convert
         def one_step_on_data_distributed(data):
@@ -222,9 +236,11 @@ class TensorFlowTrainer(base_trainer.Trainer):
             predict_function = one_step_on_data_distributed
 
         if not self.run_eagerly:
-            predict_function = tf.function(
-                predict_function, reduce_retracing=True
-            )
+            kwargs = {}
+            if self.support_reduce_retracing is True:
+                kwargs.update({'reduce_retracing': True})
+
+            predict_function = tf.function(predict_function, **kwargs)
 
         self.predict_function = predict_function
 


### PR DESCRIPTION
I'm not sure if support for TensorFlow older versions is intended, but it would be nice to take care of backward compatability because not everyone uses the latest TensorFlow. The current `TensorFlowTrainer` uses `tf.function` with the parameter `reduce_retracing` (e.g., [here](https://github.com/keras-team/keras-core/blob/main/keras_core/backend/tensorflow/trainer.py#L105)), but the `reduce_retracing` has been introduced since TF 2.9. This PR is able to handle this issue with adaptive keyword arguments.

- TF 2.8 docs: https://www.tensorflow.org/versions/r2.8/api_docs/python/tf/function
- TF 2.9 docs: https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function