### PR TITLE
Add an exception for `torch.numpy.mean`

### DIFF
--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -44,7 +44,7 @@ def mean(x, axis=None, keepdims=False):
     if isinstance(x, (list, tuple)):
         x = stack(x)
     x = convert_to_tensor(x)
-    if axis == () or axis == []:
+    if axis == None or axis == () or axis == []:
         # Torch handles the empty axis case differently from numpy.
         return x
     # Conversion to float necessary for `torch.mean`


### PR DESCRIPTION
I found a minor bug during tests of the "examples" folder. When using torch backend, "examples/demo_subclass.py" raises an error as follows:
```
$ KERAS_BACKEND=tensorflow python examples/demo_subclass.py  #  no problem
$ KERAS_BACKEND=jax python examples/demo_subclass.py  #  no problem
$ KERAS_BACKEND=torch python examples/demo_subclass.py
Using PyTorch backend.
Epoch 1/6
Traceback (most recent call last):
  File "examples/demo_subclass.py", line 35, in <module>
    history = model.fit(
  File "/Users/taehoonlee/conda/envs/py38/lib/python3.8/site-packages/keras_core/src/utils/traceback_utils.py", line 123, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/Users/taehoonlee/conda/envs/py38/lib/python3.8/site-packages/keras_core/src/backend/torch/numpy.py", line 52, in mean
    return torch.mean(x, axis=axis, keepdims=keepdims)
RuntimeError: Please look up dimensions by name, got: name = None.
```

The main reason is that `update` method in `Progbar` ([utils/progbar.py#L163](https://github.com/keras-team/keras-core/blob/main/keras_core/utils/progbar.py#L163)) calls `torch.numpy.mean` with `axis=None`, which causes following errors in torch. (I tested `torch==1.11.0`)
```
>>> torch.mean(torch.zeros(size=(3,)), axis=None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Please look up dimensions by name, got: name = None.
>>> torch.mean(torch.zeros(size=(3,5)), axis=None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Please look up dimensions by name, got: name = None.
```

This PR makes a detour of `torch.numpy.mean` in case of `axis=None`, but it would be nice to improve the way of handling `mean` in progress bars. I think there are alternatives for `backend.convert_to_numpy(backend.numpy.mean(...))` such as `np.mean(nparray_converted_from_tensor)`.