### PR TITLE
Set Jit compile only if Model supports it

### DIFF
--- a/keras_core/trainers/trainer.py
+++ b/keras_core/trainers/trainer.py
@@ -100,7 +100,14 @@ class Trainer:
 
     @jit_compile.setter
     def jit_compile(self, value):
-        self._jit_compile = value
+        if value is True and not model_supports_jit(self):
+            warnings.warn(
+                "Model doesn't support `jit_compile=True`. "
+                "Proceeding with `jit_compile=False`."
+            )
+            self._jit_compile = False
+        else:
+            self._jit_compile = value
 
     @property
     def run_eagerly(self):

--- a/keras_core/trainers/trainer.py
+++ b/keras_core/trainers/trainer.py
@@ -100,7 +100,7 @@ class Trainer:
 
     @jit_compile.setter
     def jit_compile(self, value):
-        if value is True and not model_supports_jit(self):
+        if value and not model_supports_jit(self):
             warnings.warn(
                 "Model doesn't support `jit_compile=True`. "
                 "Proceeding with `jit_compile=False`."


### PR DESCRIPTION
Fixes #611.  Allows setting `jit_compile` on Model or in `model.compile` only if model supports it.  This prevents `LSTM`, `GRU` in TF backend from being run with `jit_compile` even if the user tries to override it in `model.compile`.