### PR TITLE
Set min TF Version

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -3,6 +3,8 @@ black>=22
 flake8
 isort
 pytest
+numpy
+scipy
 pandas
 absl-py
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# Tensorflow.
-tensorflow
+# Tensorflow
+tensorflow>=2.13.0
 
 # Torch.
 # TODO: Use Torch CPU, remove after resolving Cuda version differences with TF


### PR DESCRIPTION
Explicitly add `numpy`, `scipy` dependency and also set the minimum TF Version supported.

Pre-processing layers of `random_brightness` and other preprocessing layer tests fail in TF 2.12.  They are not caught in CI since CI installs latest Tensorflow (2.13).

This only fails for other backends (Jax / Torch), not for TF itself.
```
KERAS_BACKEND=torch pytest keras_core/layers/preprocessing/random_brightness_test.py
```
Fails on `RandomBrightnessTest::tf_data_compatibility` when used with TF 2.12
![torch-tf-data-comp](https://github.com/keras-team/keras-core/assets/1437573/7589011d-c236-44a3-b1fc-3bb6ce7cae04)

