### PR TITLE
fix load of models with Add and Concat layers

### DIFF
--- a/keras_core/layers/merging/base_merge.py
+++ b/keras_core/layers/merging/base_merge.py
@@ -61,7 +61,7 @@ class Merge(Layer):
 
     def build(self, input_shape):
         # Used purely for shape validation.
-        if not isinstance(input_shape[0], tuple):
+        if not isinstance(input_shape[0], (tuple, list)):
             raise ValueError(
                 "A merge layer should be called on a list of inputs. "
                 f"Received: input_shape={input_shape} (not a list of shapes)"

--- a/keras_core/layers/merging/concatenate.py
+++ b/keras_core/layers/merging/concatenate.py
@@ -39,7 +39,7 @@ class Concatenate(Merge):
 
     def build(self, input_shape):
         # Used purely for shape validation.
-        if len(input_shape) < 1 or not isinstance(input_shape[0], tuple):
+        if len(input_shape) < 1 or not isinstance(input_shape[0], (tuple, list):
             raise ValueError(
                 "A `Concatenate` layer should be called on a list of "
                 f"at least 1 input. Received: input_shape={input_shape}"


### PR DESCRIPTION
some of models I saved with Model.save() didn't load `keras_core.saving.load_model()`. e.g., with

```python
import keras_core
import numpy as np

x = keras_core.Input(shape=(10, 3))
y = keras_core.Input(shape=(10, 3))
result = keras_core.layers.Add()([x, y])
model = keras_core.Model([x, y], result)

model.save("model.keras")
loaded_model = keras_core.saving.load_model("model.keras")
```

I got 
```
Traceback (most recent call last):
  File "/private/tmp/b.py", line 10, in <module>
    loaded_model = keras_core.saving.load_model("model.keras")
  File "/Users/freedom/work/keras-core/keras_core/saving/saving_api.py", line 161, in load_model
    return saving_lib.load_model(
  File "/Users/freedom/work/keras-core/keras_core/saving/saving_lib.py", line 155, in load_model
    model = deserialize_keras_object(
  File "/Users/freedom/work/keras-core/keras_core/saving/serialization_lib.py", line 677, in deserialize_keras_object
    instance = cls.from_config(inner_config)
  File "/Users/freedom/work/keras-core/keras_core/models/model.py", line 484, in from_config
    return cls._from_config(config, custom_objects=custom_objects)
  File "/Users/freedom/work/keras-core/keras_core/models/functional.py", line 492, in _from_config
    process_layer(layer_data)
  File "/Users/freedom/work/keras-core/keras_core/models/functional.py", line 476, in process_layer
    layer = serialization_lib.deserialize_keras_object(
  File "/Users/freedom/work/keras-core/keras_core/saving/serialization_lib.py", line 680, in deserialize_keras_object
    instance.build_from_config(build_config)
  File "/Users/freedom/work/keras-core/keras_core/layers/layer.py", line 377, in build_from_config
    self.build(config["input_shape"])
  File "/Users/freedom/work/keras-core/keras_core/layers/merging/base_merge.py", line 67, in build
    raise ValueError(
ValueError: A merge layer should be called on a list of inputs. Received: input_shape=[[None, 10, 3], [None, 10, 3]] (not a list of shapes)

```