### PR TITLE
Only ignore xx_mask arguments for the build shapes dict

### DIFF
--- a/keras_core/layers/layer.py
+++ b/keras_core/layers/layer.py
@@ -1353,7 +1353,7 @@ def get_shapes_dict(call_spec):
     """
     shapes_dict = {}
     for k, v in call_spec.tensor_arguments_dict.items():
-        if k == "mask" or k.startswith("mask_"):
+        if k == "mask" or k.endswith("_mask"):
             # Do not include mask tensors in shapes dict
             continue
         if k == "kwargs" or k == "args":


### PR DESCRIPTION
Silly bug, our mask call args look like `xx_mask` not `mask_xx`, we had the order flipped.