### PR TITLE
Add digitize op for Discretization layer

### DIFF
--- a/keras_core/backend/jax/numpy.py
+++ b/keras_core/backend/jax/numpy.py
@@ -210,7 +210,7 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
 def digitize(x, bins):
     x = convert_to_tensor(x)
     bins = convert_to_tensor(bins)
-    return jnp.digitize(x, bins)
+    return cast(jnp.digitize(x, bins), "int64")
 
 
 def dot(x, y):

--- a/keras_core/backend/jax/numpy.py
+++ b/keras_core/backend/jax/numpy.py
@@ -207,6 +207,12 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
     )
 
 
+def digitize(x, bins):
+    x = convert_to_tensor(x)
+    bins = convert_to_tensor(bins)
+    return jnp.digitize(x, bins)
+
+
 def dot(x, y):
     return jnp.dot(x, y)
 

--- a/keras_core/backend/numpy/numpy.py
+++ b/keras_core/backend/numpy/numpy.py
@@ -199,6 +199,10 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
     )
 
 
+def digitize(x, bins):
+    return np.digitize(x, bins)
+
+
 def dot(x, y):
     return np.dot(x, y)
 

--- a/keras_core/backend/tensorflow/numpy.py
+++ b/keras_core/backend/tensorflow/numpy.py
@@ -213,7 +213,9 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
 def digitize(x, bins):
     x = convert_to_tensor(x)
     bins = list(bins)
-    return tf.raw_ops.Bucketize(input=x, boundaries=bins)
+    return tf.cast(
+        tf.raw_ops.Bucketize(input=x, boundaries=bins), "int64"
+    )
 
 
 def dot(x, y):

--- a/keras_core/backend/tensorflow/numpy.py
+++ b/keras_core/backend/tensorflow/numpy.py
@@ -210,6 +210,12 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
     )
 
 
+def digitize(x, bins):
+    x = convert_to_tensor(x)
+    bins = list(bins)
+    return tf.raw_ops.Bucketize(input=x, boundaries=bins)
+
+
 def dot(x, y):
     return tfnp.dot(x, y)
 

--- a/keras_core/backend/tensorflow/numpy.py
+++ b/keras_core/backend/tensorflow/numpy.py
@@ -213,9 +213,7 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
 def digitize(x, bins):
     x = convert_to_tensor(x)
     bins = list(bins)
-    return tf.cast(
-        tf.raw_ops.Bucketize(input=x, boundaries=bins), "int64"
-    )
+    return tf.cast(tf.raw_ops.Bucketize(input=x, boundaries=bins), "int64")
 
 
 def dot(x, y):

--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -330,7 +330,7 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
 def digitize(x, bins):
     x = convert_to_tensor(x)
     bins = convert_to_tensor(bins)
-    return torch.bucketize(x, bins, right=True)
+    return cast(torch.bucketize(x, bins, right=True), "int32")
 
 
 def dot(x, y):

--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -327,6 +327,12 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
     )
 
 
+def digitize(x, bins):
+    x = convert_to_tensor(x)
+    bins = convert_to_tensor(bins)
+    return torch.bucketize(x, bins, right=True)
+
+
 def dot(x, y):
     x, y = convert_to_tensor(x), convert_to_tensor(y)
     if x.ndim == 0 or y.ndim == 0:

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -1540,17 +1540,22 @@ class Digitize(Operation):
         return backend.numpy.digitize(x, bins)
 
     def compute_output_spec(self, x, bins):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        bins_shape = bins.shape
+        if len(bins_shape) > 1:
+            raise ValueError(
+                "`bins` must be an array of one dimension, but recieved `bins` "
+                f"of shape {bins_shape}."
+            )
+        return KerasTensor(x.shape, dtype="int")
 
 
 @keras_core_export(["keras_core.ops.digitize", "keras_core.ops.numpy.digitize"])
 def digitize(x, bins):
-    """Returns the indices of the bins to which each value in input array
-        belongs.
+    """Returns the indices of the bins to which each value in `x` belongs.
 
     Args:
         x: Input array to be binned.
-        bins: Array of bins. It has to be 1-dimensional and monotonically
+        bins: Array of bins. It has to be one-dimensional and monotonically
             increasing.
 
     Returns:
@@ -1562,7 +1567,7 @@ def digitize(x, bins):
         >>> keras_core.ops.digitize(x, bins)
         array([1, 1, 2, 1])
     """
-    if any_symbolic_tensors((x,)):
+    if any_symbolic_tensors((x, bins)):
         return Digitize().symbolic_call(x, bins)
     return backend.numpy.digitize(x, bins)
 

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -34,6 +34,7 @@ cumsum
 diag
 diagonal
 diff
+digitize
 divide
 dot
 dtype
@@ -1532,6 +1533,38 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
         axis1=axis1,
         axis2=axis2,
     )
+
+
+class Digitize(Operation):
+    def call(self, x, bins):
+        return backend.numpy.digitize(x, bins)
+
+    def compute_output_spec(self, x, bins):
+        return KerasTensor(x.shape, dtype=x.dtype)
+
+
+@keras_core_export(["keras_core.ops.digitize", "keras_core.ops.numpy.digitize"])
+def digitize(x, bins):
+    """Returns the indices of the bins to which each value in input array
+        belongs.
+
+    Args:
+        x: Input array to be binned.
+        bins: Array of bins. It has to be 1-dimensional and monotonically
+            increasing.
+
+    Returns:
+        Output array of indices, of same shape as x.
+
+    Examples:
+        >>> x = x = np.array([0.0, 1.0, 3.0, 1.6])
+        >>> bins = np.array([0.0, 3.0, 4.5, 7.0])
+        >>> keras_core.ops.digitize(x, bins)
+        array([1, 1, 2, 1])
+    """
+    if any_symbolic_tensors((x,)):
+        return Digitize().symbolic_call(x, bins)
+    return backend.numpy.digitize(x, bins)
 
 
 class Dot(Operation):

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -1557,7 +1557,7 @@ def digitize(x, bins):
         Output array of indices, of same shape as x.
 
     Examples:
-        >>> x = x = np.array([0.0, 1.0, 3.0, 1.6])
+        >>> x = np.array([0.0, 1.0, 3.0, 1.6])
         >>> bins = np.array([0.0, 3.0, 4.5, 7.0])
         >>> keras_core.ops.digitize(x, bins)
         array([1, 1, 2, 1])

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -3,8 +3,8 @@ from tensorflow.python.ops.numpy_ops import np_config
 
 from keras_core import backend
 from keras_core import testing
-from keras_core.backend.common.keras_tensor import KerasTensor
 from keras_core.backend.common import standardize_dtype
+from keras_core.backend.common.keras_tensor import KerasTensor
 from keras_core.ops import numpy as knp
 
 # TODO: remove reliance on this (or alternatively, turn it on by default).
@@ -2109,22 +2109,40 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase):
         bins = np.array([0.0, 3.0, 4.5, 7.0])
         self.assertAllClose(knp.digitize(x, bins), np.digitize(x, bins))
         self.assertAllClose(knp.Digitize()(x, bins), np.digitize(x, bins))
-        self.assertTrue( standardize_dtype(knp.digitize(x, bins).dtype) == standardize_dtype("int"))
-        self.assertTrue( standardize_dtype(knp.Digitize()(x, bins).dtype) == standardize_dtype("int"))
+        self.assertTrue(
+            standardize_dtype(knp.digitize(x, bins).dtype)
+            == standardize_dtype("int")
+        )
+        self.assertTrue(
+            standardize_dtype(knp.Digitize()(x, bins).dtype)
+            == standardize_dtype("int")
+        )
 
         x = np.array([0.2, 6.4, 3.0, 1.6])
         bins = np.array([0.0, 1.0, 2.5, 4.0, 10.0])
         self.assertAllClose(knp.digitize(x, bins), np.digitize(x, bins))
         self.assertAllClose(knp.Digitize()(x, bins), np.digitize(x, bins))
-        self.assertTrue( standardize_dtype(knp.digitize(x, bins).dtype) == standardize_dtype("int"))
-        self.assertTrue( standardize_dtype(knp.Digitize()(x, bins).dtype) == standardize_dtype("int"))
-        
+        self.assertTrue(
+            standardize_dtype(knp.digitize(x, bins).dtype)
+            == standardize_dtype("int")
+        )
+        self.assertTrue(
+            standardize_dtype(knp.Digitize()(x, bins).dtype)
+            == standardize_dtype("int")
+        )
+
         x = np.array([1, 4, 10, 15])
         bins = np.array([4, 10, 14, 15])
         self.assertAllClose(knp.digitize(x, bins), np.digitize(x, bins))
         self.assertAllClose(knp.Digitize()(x, bins), np.digitize(x, bins))
-        self.assertTrue( standardize_dtype(knp.digitize(x, bins).dtype) == standardize_dtype("int"))
-        self.assertTrue( standardize_dtype(knp.Digitize()(x, bins).dtype) == standardize_dtype("int"))
+        self.assertTrue(
+            standardize_dtype(knp.digitize(x, bins).dtype)
+            == standardize_dtype("int")
+        )
+        self.assertTrue(
+            standardize_dtype(knp.Digitize()(x, bins).dtype)
+            == standardize_dtype("int")
+        )
 
 
 class NumpyOneInputOpsCorrectnessTest(testing.TestCase):

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -4,6 +4,7 @@ from tensorflow.python.ops.numpy_ops import np_config
 from keras_core import backend
 from keras_core import testing
 from keras_core.backend.common.keras_tensor import KerasTensor
+from keras_core.backend.common import standardize_dtype
 from keras_core.ops import numpy as knp
 
 # TODO: remove reliance on this (or alternatively, turn it on by default).
@@ -664,6 +665,12 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor((2, 3))
         bins = KerasTensor((3,))
         self.assertEqual(knp.digitize(x, bins).shape, (2, 3))
+        self.assertTrue(knp.digitize(x, bins).dtype == standardize_dtype("int"))
+
+        with self.assertRaises(ValueError):
+            x = KerasTensor([2, 3])
+            bins = KerasTensor([2, 3, 4])
+            knp.digitize(x, bins)
 
 
 class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
@@ -2102,6 +2109,22 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase):
         bins = np.array([0.0, 3.0, 4.5, 7.0])
         self.assertAllClose(knp.digitize(x, bins), np.digitize(x, bins))
         self.assertAllClose(knp.Digitize()(x, bins), np.digitize(x, bins))
+        self.assertTrue( standardize_dtype(knp.digitize(x, bins).dtype) == standardize_dtype("int"))
+        self.assertTrue( standardize_dtype(knp.Digitize()(x, bins).dtype) == standardize_dtype("int"))
+
+        x = np.array([0.2, 6.4, 3.0, 1.6])
+        bins = np.array([0.0, 1.0, 2.5, 4.0, 10.0])
+        self.assertAllClose(knp.digitize(x, bins), np.digitize(x, bins))
+        self.assertAllClose(knp.Digitize()(x, bins), np.digitize(x, bins))
+        self.assertTrue( standardize_dtype(knp.digitize(x, bins).dtype) == standardize_dtype("int"))
+        self.assertTrue( standardize_dtype(knp.Digitize()(x, bins).dtype) == standardize_dtype("int"))
+        
+        x = np.array([1, 4, 10, 15])
+        bins = np.array([4, 10, 14, 15])
+        self.assertAllClose(knp.digitize(x, bins), np.digitize(x, bins))
+        self.assertAllClose(knp.Digitize()(x, bins), np.digitize(x, bins))
+        self.assertTrue( standardize_dtype(knp.digitize(x, bins).dtype) == standardize_dtype("int"))
+        self.assertTrue( standardize_dtype(knp.Digitize()(x, bins).dtype) == standardize_dtype("int"))
 
 
 class NumpyOneInputOpsCorrectnessTest(testing.TestCase):

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -660,6 +660,11 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             y = KerasTensor([2, 3, 4])
             knp.logical_xor(x, y)
 
+    def test_digitize(self):
+        x = KerasTensor((2, 3))
+        bins = KerasTensor((3,))
+        self.assertEqual(knp.digitize(x, bins).shape, (2, 3))
+
 
 class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
     def test_mean(self):
@@ -2091,6 +2096,12 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase):
         y = np.array([4, 5, 6])
         self.assertAllClose(knp.where(x > 1, x, y), np.where(x > 1, x, y))
         self.assertAllClose(knp.Where()(x > 1, x, y), np.where(x > 1, x, y))
+
+    def test_digitize(self):
+        x = np.array([0.0, 1.0, 3.0, 1.6])
+        bins = np.array([0.0, 3.0, 4.5, 7.0])
+        self.assertAllClose(knp.digitize(x, bins), np.digitize(x, bins))
+        self.assertAllClose(knp.Digitize()(x, bins), np.digitize(x, bins))
 
 
 class NumpyOneInputOpsCorrectnessTest(testing.TestCase):


### PR DESCRIPTION
This op will help to implement `Discretization` layer.
The output of the op is unified to be like the tensorflow output. and there is somethings to consider:
1- jax and numpy can digitize if the bins are monotonically decreasing but torch and tensorflow can't. torch will return undefined output. And tensorflow will return an error.
2- jax, numpy, and torch has `right` arg but tensorflow hasn't. so I didn't add it