### PR TITLE
Removes ref in Global Average Pool and Elu/Prelu Activations

### DIFF
--- a/keras_core/layers/activations/elu_test.py
+++ b/keras_core/layers/activations/elu_test.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import tensorflow as tf
 
 from keras_core import testing
 from keras_core.layers.activations import elu
@@ -21,11 +20,12 @@ class ELUTest(testing.TestCase):
         )
 
     def test_correctness(self):
+        def np_elu(x, alpha=1.0):
+            return (x > 0) * x + (x <= 0) * alpha * (np.exp(x) - 1)
+
         x = np.random.random((2, 2, 5))
         elu_layer = elu.ELU()
-        tf_elu_layer = tf.keras.layers.ELU()
-        self.assertAllClose(elu_layer(x), tf_elu_layer(x))
+        self.assertAllClose(elu_layer(x), np_elu(x))
 
         elu_layer = elu.ELU(alpha=0.7)
-        tf_elu_layer = tf.keras.layers.ELU(alpha=0.7)
-        self.assertAllClose(elu_layer(x), tf_elu_layer(x))
+        self.assertAllClose(elu_layer(x), np_elu(x, alpha=0.7))

--- a/keras_core/layers/activations/prelu_test.py
+++ b/keras_core/layers/activations/prelu_test.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import tensorflow as tf
 
 from keras_core import testing
 from keras_core.layers.activations import prelu
@@ -22,6 +21,9 @@ class PReLUTest(testing.TestCase):
         )
 
     def test_prelu_correctness(self):
+        def np_prelu(x, alpha):
+            return (x > 0) * x + (x <= 0) * alpha * x
+
         inputs = np.random.randn(2, 10, 5, 3)
         prelu_layer = prelu.PReLU(
             alpha_initializer="glorot_uniform",
@@ -29,18 +31,9 @@ class PReLUTest(testing.TestCase):
             alpha_constraint="non_neg",
             shared_axes=(1, 2),
         )
-        tf_prelu_layer = tf.keras.layers.PReLU(
-            alpha_initializer="glorot_uniform",
-            alpha_regularizer="l1",
-            alpha_constraint="non_neg",
-            shared_axes=(1, 2),
-        )
-
         prelu_layer.build(inputs.shape)
-        tf_prelu_layer.build(inputs.shape)
 
         weights = np.random.random((1, 1, 3))
         prelu_layer.alpha.assign(weights)
-        tf_prelu_layer.alpha.assign(weights)
-
-        self.assertAllClose(prelu_layer(inputs), tf_prelu_layer(inputs))
+        ref_out = np_prelu(inputs, weights)
+        self.assertAllClose(prelu_layer(inputs), ref_out)

--- a/keras_core/layers/pooling/global_average_pooling_test.py
+++ b/keras_core/layers/pooling/global_average_pooling_test.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_core import layers
@@ -95,21 +94,30 @@ class GlobalAveragePoolingCorrectnessTest(
         ("channels_last", False),
         ("channels_last", True),
         ("channels_first", False),
+        ("channels_first", True),
     )
     def test_global_average_pooling1d(self, data_format, keepdims):
-        inputs = np.arange(24, dtype="float32").reshape((2, 3, 4))
+        def np_gap1d(x, data_format, keepdims, mask=None):
+            steps_axis = 1 if data_format == "channels_last" else 2
+            if mask is not None:
+                mask = np.expand_dims(
+                    mask, 2 if data_format == "channels_last" else 1
+                )
+                x *= mask
+                res = np.sum(x, axis=steps_axis) / np.sum(mask, axis=steps_axis)
+            else:
+                res = np.mean(x, axis=steps_axis)
+            if keepdims:
+                res = np.expand_dims(res, axis=steps_axis)
+            return res
 
+        inputs = np.arange(24, dtype="float32").reshape((2, 3, 4))
         layer = layers.GlobalAveragePooling1D(
             data_format=data_format,
             keepdims=keepdims,
         )
-        tf_keras_layer = tf.keras.layers.GlobalAveragePooling1D(
-            data_format=data_format,
-            keepdims=keepdims,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = np_gap1d(inputs, data_format, keepdims)
         self.assertAllClose(outputs, expected)
 
         if data_format == "channels_last":
@@ -117,47 +125,53 @@ class GlobalAveragePoolingCorrectnessTest(
         else:
             mask = np.array([[1, 1, 0, 0], [0, 1, 0, 1]], dtype="int32")
         outputs = layer(inputs, mask)
-        expected = tf_keras_layer(inputs, mask)
+        expected = np_gap1d(inputs, data_format, keepdims, mask)
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
         ("channels_last", False),
         ("channels_last", True),
         ("channels_first", False),
+        ("channels_first", True),
     )
     def test_global_average_pooling2d(self, data_format, keepdims):
-        inputs = np.arange(96, dtype="float32").reshape((2, 3, 4, 4))
+        def np_gap2d(x, data_format, keepdims):
+            steps_axis = [1, 2] if data_format == "channels_last" else [2, 3]
+            res = np.apply_over_axes(np.mean, x, steps_axis)
+            if not keepdims:
+                res = res.squeeze()
+            return res
 
+        inputs = np.arange(96, dtype="float32").reshape((2, 3, 4, 4))
         layer = layers.GlobalAveragePooling2D(
             data_format=data_format,
             keepdims=keepdims,
         )
-        tf_keras_layer = tf.keras.layers.GlobalAveragePooling2D(
-            data_format=data_format,
-            keepdims=keepdims,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = np_gap2d(inputs, data_format, keepdims)
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
         ("channels_last", False),
         ("channels_last", True),
         ("channels_first", False),
+        ("channels_first", True),
     )
     def test_global_average_pooling3d(self, data_format, keepdims):
-        inputs = np.arange(360, dtype="float32").reshape((2, 3, 3, 5, 4))
+        def np_gap3d(x, data_format, keepdims):
+            steps_axis = (
+                [1, 2, 3] if data_format == "channels_last" else [2, 3, 4]
+            )
+            res = np.apply_over_axes(np.mean, x, steps_axis)
+            if not keepdims:
+                res = res.squeeze()
+            return res
 
+        inputs = np.arange(360, dtype="float32").reshape((2, 3, 3, 5, 4))
         layer = layers.GlobalAveragePooling3D(
             data_format=data_format,
             keepdims=keepdims,
         )
-        tf_keras_layer = tf.keras.layers.GlobalAveragePooling3D(
-            data_format=data_format,
-            keepdims=keepdims,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = np_gap3d(inputs, data_format, keepdims)
         self.assertAllClose(outputs, expected)


### PR DESCRIPTION
Replaces `tf.keras` with numpy for expected outputs in Global Average Pooling and Elu/Prelu tests.