### PR TITLE
Small fixes on `image.extract_patches`

### DIFF
--- a/keras_core/ops/image.py
+++ b/keras_core/ops/image.py
@@ -271,6 +271,8 @@ class ExtractPatches(Operation):
         data_format="channels_last",
     ):
         super().__init__()
+        if isinstance(size, int):
+            size = (size, size)
         self.size = size
         self.strides = strides
         self.dilation_rate = dilation_rate
@@ -348,14 +350,14 @@ def extract_patches(
 
     Examples:
 
-    >>> image = np.random.random((1, 20, 20, 3)) # batch of 2 RGB images
+    >>> image = np.random.random((2, 20, 20, 3)).astype("float32") # batch of 2 RGB images
     >>> patches = keras_core.ops.image.extract_patches(image, (5, 5))
     >>> patches.shape
-    (1, 4, 4, 75)
-    >>> image = np.random.random((20, 20, 3)) # batch of 2 RGB images
+    (2, 4, 4, 75)
+    >>> image = np.random.random((20, 20, 3)).astype("float32") # 1 RGB image
     >>> patches = keras_core.ops.image.extract_patches(image, (3, 3), (1, 1))
     >>> patches.shape
-    (4, 4, 75)
+    (18, 18, 27)
     """
     if any_symbolic_tensors((image,)):
         return ExtractPatches(

--- a/keras_core/ops/image.py
+++ b/keras_core/ops/image.py
@@ -350,7 +350,9 @@ def extract_patches(
 
     Examples:
 
-    >>> image = np.random.random((2, 20, 20, 3)).astype("float32") # batch of 2 RGB images
+    >>> image = np.random.random(
+    ...     (2, 20, 20, 3)
+    ... ).astype("float32") # batch of 2 RGB images
     >>> patches = keras_core.ops.image.extract_patches(image, (5, 5))
     >>> patches.shape
     (2, 4, 4, 75)

--- a/keras_core/ops/image_test.py
+++ b/keras_core/ops/image_test.py
@@ -31,6 +31,8 @@ class ImageOpsDynamicShapeTest(testing.TestCase):
         p_h, p_w = 5, 5
         out = kimage.extract_patches(x, (p_h, p_w))
         self.assertEqual(out.shape, (None, 4, 4, 75))
+        out = kimage.extract_patches(x, 5)
+        self.assertEqual(out.shape, (None, 4, 4, 75))
 
 
 class ImageOpsStaticShapeTest(testing.TestCase):
@@ -49,6 +51,8 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor([20, 20, 3])
         p_h, p_w = 5, 5
         out = kimage.extract_patches(x, (p_h, p_w))
+        self.assertEqual(out.shape, (4, 4, 75))
+        out = kimage.extract_patches(x, 5)
         self.assertEqual(out.shape, (4, 4, 75))
 
 
@@ -311,7 +315,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             and dilation_rate > 1
         ):
             pytest.skip(
-                "dilation_rate>1 with strides>1 than not supported with TF"
+                "dilation_rate>1 with strides>1 not supported with TF"
             )
         if data_format == "channels_first":
             image = np.random.uniform(size=(1, 3, 20, 20))

--- a/keras_core/ops/image_test.py
+++ b/keras_core/ops/image_test.py
@@ -314,9 +314,7 @@ class ImageOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             and backend.backend() == "tensorflow"
             and dilation_rate > 1
         ):
-            pytest.skip(
-                "dilation_rate>1 with strides>1 not supported with TF"
-            )
+            pytest.skip("dilation_rate>1 with strides>1 not supported with TF")
         if data_format == "channels_first":
             image = np.random.uniform(size=(1, 3, 20, 20))
         else:


### PR DESCRIPTION
Two small fixes on `extract_patches`:

* Passing argument `size` as an int currently fails for symbolic tensor:
```
>>> x = KerasTensor([None, 20, 20, 3])
>>> keras_core.ops.image.extract_patches(x, size=5)
Traceback (most recent call last):
...
    strides = (self.size[0], self.size[1])
TypeError: 'int' object is not subscriptable
```
Fixed and added unit-test.

* Examples in docstring are failing for me, I have to convert the arrays to "float32" beforehand.
```
>>> image = np.random.random((1, 20, 20, 3)) # batch of 2 RGB images
>>> patches = keras_core.ops.image.extract_patches(image, (5, 5))
Traceback (most recent call last):
...
tensorflow.python.framework.errors_impl.InvalidArgumentError: cannot compute Conv2D as input #1(zero-based) was expected to be a double tensor but is a float tensor [Op:Conv2D] name:
```
I edited the docstring accordingly.