### PR TITLE
Update learning_rate type to float in learning_rate_scheduler's logs

### DIFF
--- a/keras_core/callbacks/learning_rate_scheduler.py
+++ b/keras_core/callbacks/learning_rate_scheduler.py
@@ -76,4 +76,6 @@ class LearningRateScheduler(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
-        logs["learning_rate"] = self.model.optimizer.learning_rate.value
+        logs["learning_rate"] = float(
+            backend.convert_to_numpy(self.model.optimizer.learning_rate)
+        )

--- a/keras_core/callbacks/learning_rate_scheduler_test.py
+++ b/keras_core/callbacks/learning_rate_scheduler_test.py
@@ -107,3 +107,18 @@ class LearningRateSchedulerTest(testing.TestCase):
                 callbacks=[lr_scheduler],
                 epochs=2,
             )
+
+    @pytest.mark.requires_trainable_backend
+    def test_learning_rate_in_history(self):
+        lr_scheduler = callbacks.LearningRateScheduler(lambda step, lr: 0.5)
+
+        history = self.model.fit(
+            self.x_train,
+            self.y_train,
+            callbacks=[lr_scheduler],
+            epochs=1,
+        )
+
+        self.assertTrue("learning_rate" in history.history)
+        self.assertEqual(type(history.history["learning_rate"][0]), float)
+        self.assertEqual(history.history["learning_rate"][0], 0.5)


### PR DESCRIPTION
**Description:**

This merge request updates the `learning_rate` type to `float` in the `learning_rate_scheduler`'s logs for the following reasons:

**Reason 1:**
Currently, when the `learning_rate` is not converted to floats, the history logs show that we are using the same parameter value, resulting in a display like this:

'learning_rate': [Parameter containing:
  tensor(3.9063e-04),
  Parameter containing:
  tensor(3.9063e-04),
  Parameter containing:
  tensor(3.9063e-04),
  ...
  Parameter containing:
  tensor(3.9063e-04)]

This issue occurs we are keeping the parameter type throughout the epochs. Consequently, the parameter type remains the same, but its value changes dynamically as the training progresses. As a result, only the last value is visible, and we lose the history of the learning rate.

**Reason 2:**
The current parameter type is not serializable, which can cause issues when using certain callbacks, such as WandbMetricsLogger callback, which requires serializable data. By updating the `learning_rate` type to `float`, we resolve this serialization issue and ensure smooth integration with such callbacks.

**Proposed Solution:**
By converting the `learning_rate` to floats in the logs, we preserve the entire history of the learning rate, making it easier to track and analyze changes. Additionally, we address the serialization problem, enabling seamless integration with callbacks that require serializable data.

**Impact and Testing:**
These changes do not impact the functionality of the learning rate scheduler itself. The update simply ensures better logging and serialization. I have added a unit test to ensure that we have the learning_rate in history as expected.