### PR TITLE
Removes `tf.keras` from Pooling tests - Max, Average and Global pooling

### DIFF
--- a/keras_core/layers/pooling/average_pooling_test.py
+++ b/keras_core/layers/pooling/average_pooling_test.py
@@ -233,9 +233,7 @@ class AveragePoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(
         (2, 1, "valid", "channels_last"),
-        (2, 1, "valid", "channels_first"),
         ((2,), (2,), "valid", "channels_last"),
-        ((2,), (2,), "valid", "channels_first"),
     )
     def test_average_pooling1d(self, pool_size, strides, padding, data_format):
         inputs = np.arange(24, dtype="float32").reshape((2, 3, 4))

--- a/keras_core/layers/pooling/average_pooling_test.py
+++ b/keras_core/layers/pooling/average_pooling_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-import tensorflow as tf
 from absl.testing import parameterized
+from numpy.lib.stride_tricks import as_strided
 
 from keras_core import backend
 from keras_core import layers
@@ -109,9 +109,133 @@ class AveragePoolingBasicTest(testing.TestCase, parameterized.TestCase):
 
 
 class AveragePoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
+    def _same_padding(self, input_size, pool_size, stride):
+        if input_size % stride == 0:
+            return max(pool_size - stride, 0)
+        else:
+            return max(pool_size - (input_size % stride), 0)
+
+    def _np_avgpool1d(self, x, pool_size, strides, padding, data_format):
+        if data_format == "channels_first":
+            x = x.swapaxes(1, 2)
+        if isinstance(pool_size, (tuple, list)):
+            pool_size = pool_size[0]
+        if isinstance(strides, (tuple, list)):
+            h_stride = strides[0]
+        else:
+            h_stride = strides
+
+        if padding == "same":
+            n_batch, h_x, ch_x = x.shape
+            pad_value = self._same_padding(h_x, pool_size, h_stride)
+            npad = [(0, 0)] * x.ndim
+            npad[1] = (0, pad_value)
+            x = np.pad(x, pad_width=npad, mode="edge")
+
+        n_batch, h_x, ch_x = x.shape
+        out_h = int((h_x - pool_size) / h_stride) + 1
+
+        stride_shape = (n_batch, out_h, ch_x, pool_size)
+        strides = (
+            x.strides[0],
+            h_stride * x.strides[1],
+            x.strides[2],
+            x.strides[1],
+        )
+        windows = as_strided(x, shape=stride_shape, strides=strides)
+        out = np.mean(windows, axis=(3,))
+        if data_format == "channels_first":
+            out = out.swapaxes(1, 2)
+        return out
+
+    def _np_avgpool2d(self, x, pool_size, strides, padding, data_format):
+        if data_format == "channels_first":
+            x = x.transpose((0, 2, 3, 1))
+        if isinstance(pool_size, int):
+            pool_size = (pool_size, pool_size)
+        if isinstance(strides, int):
+            strides = (strides, strides)
+
+        h_pool_size, w_pool_size = pool_size
+        h_stride, w_stride = strides
+        if padding == "same":
+            n_batch, h_x, w_x, ch_x = x.shape
+            h_padding = self._same_padding(h_x, h_pool_size, h_stride)
+            w_padding = self._same_padding(w_x, w_pool_size, w_stride)
+            npad = [(0, 0)] * x.ndim
+            npad[1] = (0, h_padding)
+            npad[2] = (0, w_padding)
+            x = np.pad(x, pad_width=npad, mode="edge")
+
+        n_batch, h_x, w_x, ch_x = x.shape
+        out_h = int((h_x - h_pool_size) / h_stride) + 1
+        out_w = int((w_x - w_pool_size) / w_stride) + 1
+
+        stride_shape = (n_batch, out_h, out_w, ch_x, *pool_size)
+        strides = (
+            x.strides[0],
+            h_stride * x.strides[1],
+            w_stride * x.strides[2],
+            x.strides[3],
+            x.strides[1],
+            x.strides[2],
+        )
+        windows = as_strided(x, shape=stride_shape, strides=strides)
+        out = np.mean(windows, axis=(4, 5))
+        if data_format == "channels_first":
+            out = out.transpose((0, 3, 1, 2))
+        return out
+
+    def _np_avgpool3d(self, x, pool_size, strides, padding, data_format):
+        if data_format == "channels_first":
+            x = x.transpose((0, 2, 3, 4, 1))
+
+        if isinstance(pool_size, int):
+            pool_size = (pool_size, pool_size, pool_size)
+        if isinstance(strides, int):
+            strides = (strides, strides, strides)
+
+        h_pool_size, w_pool_size, d_pool_size = pool_size
+        h_stride, w_stride, d_stride = strides
+
+        if padding == "same":
+            n_batch, h_x, w_x, d_x, ch_x = x.shape
+            h_padding = self._same_padding(h_x, h_pool_size, h_stride)
+            w_padding = self._same_padding(w_x, w_pool_size, w_stride)
+            d_padding = self._same_padding(d_x, d_pool_size, d_stride)
+            npad = [(0, 0)] * x.ndim
+            npad[1] = (0, h_padding)
+            npad[2] = (0, w_padding)
+            npad[3] = (0, d_padding)
+            x = np.pad(x, pad_width=npad, mode="symmetric")
+
+        n_batch, h_x, w_x, d_x, ch_x = x.shape
+        out_h = int((h_x - h_pool_size) / h_stride) + 1
+        out_w = int((w_x - w_pool_size) / w_stride) + 1
+        out_d = int((d_x - d_pool_size) / d_stride) + 1
+
+        stride_shape = (n_batch, out_h, out_w, out_d, ch_x, *pool_size)
+        strides = (
+            x.strides[0],
+            h_stride * x.strides[1],
+            w_stride * x.strides[2],
+            d_stride * x.strides[3],
+            x.strides[4],
+            x.strides[1],
+            x.strides[2],
+            x.strides[3],
+        )
+        windows = as_strided(x, shape=stride_shape, strides=strides)
+        out = np.mean(windows, axis=(5, 6, 7))
+        if data_format == "channels_first":
+            out = out.transpose((0, 4, 1, 2, 3))
+        return out
+
     @parameterized.parameters(
         (2, 1, "valid", "channels_last"),
+        (2, 1, "valid", "channels_first"),
         ((2,), (2,), "valid", "channels_last"),
+        ((2,), (2,), "valid", "channels_first"),
     )
     def test_average_pooling1d(self, pool_size, strides, padding, data_format):
         inputs = np.arange(24, dtype="float32").reshape((2, 3, 4))
@@ -122,20 +246,17 @@ class AveragePoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding,
             data_format=data_format,
         )
-        tf_keras_layer = tf.keras.layers.AveragePooling1D(
-            pool_size=pool_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = self._np_avgpool1d(
+            inputs, pool_size, strides, padding, data_format
+        )
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
+        (2, 1, "same", "channels_last"),
         (2, 1, "same", "channels_first"),
         ((2,), (2,), "same", "channels_last"),
+        ((2,), (2,), "same", "channels_first"),
     )
     @pytest.mark.skipif(
         backend.backend() == "torch",
@@ -152,20 +273,17 @@ class AveragePoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding,
             data_format=data_format,
         )
-        tf_keras_layer = tf.keras.layers.AveragePooling1D(
-            pool_size=pool_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = self._np_avgpool1d(
+            inputs, pool_size, strides, padding, data_format
+        )
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
         (2, 1, "valid", "channels_last"),
+        (2, 1, "valid", "channels_first"),
         ((2, 3), (2, 2), "valid", "channels_last"),
+        ((2, 3), (2, 2), "valid", "channels_first"),
     )
     def test_average_pooling2d(self, pool_size, strides, padding, data_format):
         inputs = np.arange(16, dtype="float32").reshape((1, 4, 4, 1))
@@ -175,20 +293,17 @@ class AveragePoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding,
             data_format=data_format,
         )
-        tf_keras_layer = tf.keras.layers.AveragePooling2D(
-            pool_size=pool_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = self._np_avgpool2d(
+            inputs, pool_size, strides, padding, data_format
+        )
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
         (2, (2, 1), "same", "channels_last"),
-        ((2, 3), (2, 2), "same", "channels_last"),
+        (2, (2, 1), "same", "channels_first"),
+        ((2, 2), (2, 2), "same", "channels_last"),
+        ((2, 2), (2, 2), "same", "channels_first"),
     )
     @pytest.mark.skipif(
         backend.backend() == "torch",
@@ -204,20 +319,17 @@ class AveragePoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding,
             data_format=data_format,
         )
-        tf_keras_layer = tf.keras.layers.AveragePooling2D(
-            pool_size=pool_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = self._np_avgpool2d(
+            inputs, pool_size, strides, padding, data_format
+        )
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
         (2, 1, "valid", "channels_last"),
+        (2, 1, "valid", "channels_first"),
         ((2, 3, 2), (2, 2, 1), "valid", "channels_last"),
+        ((2, 3, 2), (2, 2, 1), "valid", "channels_first"),
     )
     def test_average_pooling3d(self, pool_size, strides, padding, data_format):
         inputs = np.arange(240, dtype="float32").reshape((2, 3, 4, 5, 2))
@@ -228,20 +340,17 @@ class AveragePoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding,
             data_format=data_format,
         )
-        tf_keras_layer = tf.keras.layers.AveragePooling3D(
-            pool_size=pool_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = self._np_avgpool3d(
+            inputs, pool_size, strides, padding, data_format
+        )
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
+        (2, 1, "same", "channels_last"),
         (2, 1, "same", "channels_first"),
-        ((2, 3, 2), (2, 2, 1), "same", "channels_last"),
+        ((2, 2, 2), (2, 2, 1), "same", "channels_last"),
+        ((2, 2, 2), (2, 2, 1), "same", "channels_first"),
     )
     @pytest.mark.skipif(
         backend.backend() == "torch",
@@ -258,13 +367,8 @@ class AveragePoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding,
             data_format=data_format,
         )
-        tf_keras_layer = tf.keras.layers.AveragePooling3D(
-            pool_size=pool_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = self._np_avgpool3d(
+            inputs, pool_size, strides, padding, data_format
+        )
         self.assertAllClose(outputs, expected)

--- a/keras_core/layers/pooling/average_pooling_test.py
+++ b/keras_core/layers/pooling/average_pooling_test.py
@@ -233,7 +233,9 @@ class AveragePoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(
         (2, 1, "valid", "channels_last"),
+        (2, 1, "valid", "channels_first"),
         ((2,), (2,), "valid", "channels_last"),
+        ((2,), (2,), "valid", "channels_first"),
     )
     def test_average_pooling1d(self, pool_size, strides, padding, data_format):
         inputs = np.arange(24, dtype="float32").reshape((2, 3, 4))
@@ -279,9 +281,7 @@ class AveragePoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(
         (2, 1, "valid", "channels_last"),
-        (2, 1, "valid", "channels_first"),
         ((2, 3), (2, 2), "valid", "channels_last"),
-        ((2, 3), (2, 2), "valid", "channels_first"),
     )
     def test_average_pooling2d(self, pool_size, strides, padding, data_format):
         inputs = np.arange(16, dtype="float32").reshape((1, 4, 4, 1))

--- a/keras_core/layers/pooling/global_max_pooling_test.py
+++ b/keras_core/layers/pooling/global_max_pooling_test.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_core import layers
@@ -93,61 +92,69 @@ class GlobalMaxPoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
         ("channels_last", False),
         ("channels_last", True),
         ("channels_first", False),
+        ("channels_first", True),
     )
     def test_global_max_pooling1d(self, data_format, keepdims):
-        inputs = np.arange(24, dtype="float32").reshape((2, 3, 4))
+        def np_global_max_pool1d(x, data_format, keepdims):
+            steps_axis = [1] if data_format == "channels_last" else [2]
+            res = np.apply_over_axes(np.max, x, steps_axis)
+            if not keepdims:
+                res = res.squeeze()
+            return res
 
+        inputs = np.arange(24, dtype="float32").reshape((2, 3, 4))
         layer = layers.GlobalMaxPooling1D(
             data_format=data_format,
             keepdims=keepdims,
         )
-        tf_keras_layer = tf.keras.layers.GlobalMaxPooling1D(
-            data_format=data_format,
-            keepdims=keepdims,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = np_global_max_pool1d(inputs, data_format, keepdims)
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
         ("channels_last", False),
         ("channels_last", True),
         ("channels_first", False),
+        ("channels_first", True),
     )
     def test_global_max_pooling2d(self, data_format, keepdims):
-        inputs = np.arange(96, dtype="float32").reshape((2, 3, 4, 4))
+        def np_global_max_pool2d(x, data_format, keepdims):
+            steps_axis = [1, 2] if data_format == "channels_last" else [2, 3]
+            res = np.apply_over_axes(np.max, x, steps_axis)
+            if not keepdims:
+                res = res.squeeze()
+            return res
 
+        inputs = np.arange(96, dtype="float32").reshape((2, 3, 4, 4))
         layer = layers.GlobalMaxPooling2D(
             data_format=data_format,
             keepdims=keepdims,
         )
-        tf_keras_layer = tf.keras.layers.GlobalMaxPooling2D(
-            data_format=data_format,
-            keepdims=keepdims,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = np_global_max_pool2d(inputs, data_format, keepdims)
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
         ("channels_last", False),
         ("channels_last", True),
         ("channels_first", False),
+        ("channels_first", True),
     )
     def test_global_max_pooling3d(self, data_format, keepdims):
-        inputs = np.arange(360, dtype="float32").reshape((2, 3, 3, 5, 4))
+        def np_global_max_pool3d(x, data_format, keepdims):
+            steps_axis = (
+                [1, 2, 3] if data_format == "channels_last" else [2, 3, 4]
+            )
+            res = np.apply_over_axes(np.max, x, steps_axis)
+            if not keepdims:
+                res = res.squeeze()
+            return res
 
+        inputs = np.arange(360, dtype="float32").reshape((2, 3, 3, 5, 4))
         layer = layers.GlobalMaxPooling3D(
             data_format=data_format,
             keepdims=keepdims,
         )
-        tf_keras_layer = tf.keras.layers.GlobalMaxPooling3D(
-            data_format=data_format,
-            keepdims=keepdims,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = np_global_max_pool3d(inputs, data_format, keepdims)
         self.assertAllClose(outputs, expected)

--- a/keras_core/layers/pooling/max_pooling_test.py
+++ b/keras_core/layers/pooling/max_pooling_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-import tensorflow as tf
 from absl.testing import parameterized
+from numpy.lib.stride_tricks import as_strided
 
 from keras_core import layers
 from keras_core import testing
@@ -108,10 +108,141 @@ class MaxPoolingBasicTest(testing.TestCase, parameterized.TestCase):
 
 
 class MaxPoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
+    def _same_padding(self, input_size, pool_size, stride):
+        if input_size % stride == 0:
+            return max(pool_size - stride, 0)
+        else:
+            return max(pool_size - (input_size % stride), 0)
+
+    def _np_maxpool1d(self, x, pool_size, strides, padding, data_format):
+        if data_format == "channels_first":
+            x = x.swapaxes(1, 2)
+        if isinstance(pool_size, (tuple, list)):
+            pool_size = pool_size[0]
+        if isinstance(strides, (tuple, list)):
+            h_stride = strides[0]
+        else:
+            h_stride = strides
+
+        if padding == "same":
+            n_batch, h_x, ch_x = x.shape
+            pad_value = self._same_padding(h_x, pool_size, h_stride)
+            npad = [(0, 0)] * x.ndim
+            npad[1] = (0, pad_value)
+            x = np.pad(
+                x, pad_width=npad, mode="constant", constant_values=-np.inf
+            )
+
+        n_batch, h_x, ch_x = x.shape
+        out_h = int((h_x - pool_size) / h_stride) + 1
+
+        stride_shape = (n_batch, out_h, ch_x, pool_size)
+        strides = (
+            x.strides[0],
+            h_stride * x.strides[1],
+            x.strides[2],
+            x.strides[1],
+        )
+        windows = as_strided(x, shape=stride_shape, strides=strides)
+        out = np.max(windows, axis=(3,))
+        if data_format == "channels_first":
+            out = out.swapaxes(1, 2)
+        return out
+
+    def _np_maxpool2d(self, x, pool_size, strides, padding, data_format):
+        if data_format == "channels_first":
+            x = x.transpose((0, 2, 3, 1))
+        if isinstance(pool_size, int):
+            pool_size = (pool_size, pool_size)
+        if isinstance(strides, int):
+            strides = (strides, strides)
+
+        h_pool_size, w_pool_size = pool_size
+        h_stride, w_stride = strides
+        if padding == "same":
+            n_batch, h_x, w_x, ch_x = x.shape
+            h_padding = self._same_padding(h_x, h_pool_size, h_stride)
+            w_padding = self._same_padding(w_x, w_pool_size, w_stride)
+            npad = [(0, 0)] * x.ndim
+            npad[1] = (0, h_padding)
+            npad[2] = (0, w_padding)
+            x = np.pad(
+                x, pad_width=npad, mode="constant", constant_values=-np.inf
+            )
+
+        n_batch, h_x, w_x, ch_x = x.shape
+        out_h = int((h_x - h_pool_size) / h_stride) + 1
+        out_w = int((w_x - w_pool_size) / w_stride) + 1
+
+        stride_shape = (n_batch, out_h, out_w, ch_x, *pool_size)
+        strides = (
+            x.strides[0],
+            h_stride * x.strides[1],
+            w_stride * x.strides[2],
+            x.strides[3],
+            x.strides[1],
+            x.strides[2],
+        )
+        windows = as_strided(x, shape=stride_shape, strides=strides)
+        out = np.max(windows, axis=(4, 5))
+        if data_format == "channels_first":
+            out = out.transpose((0, 3, 1, 2))
+        return out
+
+    def _np_maxpool3d(self, x, pool_size, strides, padding, data_format):
+        if data_format == "channels_first":
+            x = x.transpose((0, 2, 3, 4, 1))
+
+        if isinstance(pool_size, int):
+            pool_size = (pool_size, pool_size, pool_size)
+        if isinstance(strides, int):
+            strides = (strides, strides, strides)
+
+        h_pool_size, w_pool_size, d_pool_size = pool_size
+        h_stride, w_stride, d_stride = strides
+
+        if padding == "same":
+            n_batch, h_x, w_x, d_x, ch_x = x.shape
+            h_padding = self._same_padding(h_x, h_pool_size, h_stride)
+            w_padding = self._same_padding(w_x, w_pool_size, w_stride)
+            d_padding = self._same_padding(d_x, d_pool_size, d_stride)
+            npad = [(0, 0)] * x.ndim
+            npad[1] = (0, h_padding)
+            npad[2] = (0, w_padding)
+            npad[3] = (0, d_padding)
+            x = np.pad(
+                x, pad_width=npad, mode="constant", constant_values=-np.inf
+            )
+
+        n_batch, h_x, w_x, d_x, ch_x = x.shape
+        out_h = int((h_x - h_pool_size) / h_stride) + 1
+        out_w = int((w_x - w_pool_size) / w_stride) + 1
+        out_d = int((d_x - d_pool_size) / d_stride) + 1
+
+        stride_shape = (n_batch, out_h, out_w, out_d, ch_x, *pool_size)
+        strides = (
+            x.strides[0],
+            h_stride * x.strides[1],
+            w_stride * x.strides[2],
+            d_stride * x.strides[3],
+            x.strides[4],
+            x.strides[1],
+            x.strides[2],
+            x.strides[3],
+        )
+        windows = as_strided(x, shape=stride_shape, strides=strides)
+        out = np.max(windows, axis=(5, 6, 7))
+        if data_format == "channels_first":
+            out = out.transpose((0, 4, 1, 2, 3))
+        return out
+
     @parameterized.parameters(
         (2, 1, "valid", "channels_last"),
+        (2, 1, "valid", "channels_first"),
+        (2, 1, "same", "channels_last"),
         (2, 1, "same", "channels_first"),
         ((2,), (2,), "valid", "channels_last"),
+        ((2,), (2,), "valid", "channels_first"),
     )
     def test_max_pooling1d(self, pool_size, strides, padding, data_format):
         inputs = np.arange(24, dtype="float32").reshape((2, 3, 4))
@@ -122,23 +253,21 @@ class MaxPoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding,
             data_format=data_format,
         )
-        tf_keras_layer = tf.keras.layers.MaxPool1D(
-            pool_size=pool_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = self._np_maxpool1d(
+            inputs, pool_size, strides, padding, data_format
+        )
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
         (2, 1, "valid", "channels_last"),
-        ((2, 3), (2, 2), "same", "channels_last"),
+        (2, 1, "valid", "channels_first"),
+        ((2, 2), (2, 2), "same", "channels_last"),
+        ((2, 2), (2, 2), "same", "channels_first"),
+        ((2, 3), (3, 3), "same", "channels_last"),
     )
     def test_max_pooling2d(self, pool_size, strides, padding, data_format):
-        inputs = np.arange(300, dtype="float32").reshape((3, 5, 5, 4))
+        inputs = np.arange(100, dtype="float32").reshape((1, 5, 5, 4))
 
         layer = layers.MaxPooling2D(
             pool_size=pool_size,
@@ -146,21 +275,17 @@ class MaxPoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding,
             data_format=data_format,
         )
-        tf_keras_layer = tf.keras.layers.MaxPool2D(
-            pool_size=pool_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = self._np_maxpool2d(
+            inputs, pool_size, strides, padding, data_format
+        )
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
         (2, 1, "valid", "channels_last"),
         (2, 1, "same", "channels_first"),
         ((2, 3, 2), (2, 2, 1), "valid", "channels_last"),
+        ((2, 3, 2), (2, 2, 1), "valid", "channels_first"),
     )
     def test_max_pooling3d(self, pool_size, strides, padding, data_format):
         inputs = np.arange(240, dtype="float32").reshape((2, 3, 4, 5, 2))
@@ -171,13 +296,8 @@ class MaxPoolingCorrectnessTest(testing.TestCase, parameterized.TestCase):
             padding=padding,
             data_format=data_format,
         )
-        tf_keras_layer = tf.keras.layers.MaxPool3D(
-            pool_size=pool_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-        )
-
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = self._np_maxpool3d(
+            inputs, pool_size, strides, padding, data_format
+        )
         self.assertAllClose(outputs, expected)


### PR DESCRIPTION
Replaces `tf.keras` with numpy expected results for pooling layers.