### PR TITLE
Add a segment_max op

### DIFF
--- a/keras_core/backend/jax/math.py
+++ b/keras_core/backend/jax/math.py
@@ -12,6 +12,7 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
         data, segment_ids, num_segments, indices_are_sorted=sorted
     )
 
+
 def segment_max(data, segment_ids, num_segments=None, sorted=False):
     if num_segments is None:
         raise ValueError(

--- a/keras_core/backend/jax/math.py
+++ b/keras_core/backend/jax/math.py
@@ -12,6 +12,16 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
         data, segment_ids, num_segments, indices_are_sorted=sorted
     )
 
+def segment_max(data, segment_ids, num_segments=None, sorted=False):
+    if num_segments is None:
+        raise ValueError(
+            "Argument `num_segments` must be set when using the JAX backend. "
+            "Received: num_segments=None"
+        )
+    return jax.ops.segment_max(
+        data, segment_ids, num_segments, indices_are_sorted=sorted
+    )
+
 
 def top_k(x, k, sorted=True):
     # Jax does not supported `sorted`, but in the case where `sorted=False`,

--- a/keras_core/backend/numpy/math.py
+++ b/keras_core/backend/numpy/math.py
@@ -28,6 +28,33 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
     return result
 
 
+def segment_max(data, segment_ids, num_segments=None, sorted=False):
+    if num_segments is None:
+        num_segments = np.amax(segment_ids) + 1
+
+    valid_indices = segment_ids >= 0  # Ignore segment_ids that are -1
+    valid_data = data[valid_indices]
+    valid_segment_ids = segment_ids[valid_indices]
+
+    data_shape = list(valid_data.shape)
+    data_shape[
+        0
+    ] = num_segments  # Replace first dimension (which corresponds to segments)
+
+    if sorted:
+        result = np.zeros(data_shape, dtype=valid_data.dtype)
+        np.maximum.at(result, valid_segment_ids, valid_data)
+    else:
+        sort_indices = np.argsort(valid_segment_ids)
+        sorted_segment_ids = valid_segment_ids[sort_indices]
+        sorted_data = valid_data[sort_indices]
+
+        result = np.zeros(data_shape, dtype=valid_data.dtype)
+        np.maximum.at(result, sorted_segment_ids, sorted_data)
+
+    return result
+
+
 def top_k(x, k, sorted=False):
     sorted_indices = np.argsort(x, axis=-1)[..., ::-1]
     sorted_values = np.sort(x, axis=-1)[..., ::-1]

--- a/keras_core/backend/tensorflow/math.py
+++ b/keras_core/backend/tensorflow/math.py
@@ -11,6 +11,16 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
         return tf.math.unsorted_segment_sum(data, segment_ids, num_segments)
 
 
+def segment_max(data, segment_ids, num_segments=None, sorted=False):
+    if sorted:
+        return tf.math.segment_max(data, segment_ids)
+    else:
+        if num_segments is None:
+            unique_segment_ids, _ = tf.unique(segment_ids)
+            num_segments = tf.shape(unique_segment_ids)[0]
+        return tf.math.unsorted_segment_max(data, segment_ids, num_segments)
+
+
 def top_k(x, k, sorted=True):
     return tf.math.top_k(x, k, sorted=sorted)
 

--- a/keras_core/backend/torch/math.py
+++ b/keras_core/backend/torch/math.py
@@ -48,8 +48,8 @@ def segment_max(data, segment_ids, num_segments=None, **kwargs):
     num_repeats = torch.prod(
         torch.tensor(data.shape[1:], device=get_device())
     ).long()
-    # To use `scatter_reduce` in torch, we need to replicate `segment_ids` into the
-    # shape of `data`.
+    # To use `scatter_reduce` in torch, we need to replicate `segment_ids` into
+    # the shape of `data`.
     segment_ids = (
         segment_ids.repeat_interleave(num_repeats)
         .view(*data.shape)

--- a/keras_core/backend/torch/math.py
+++ b/keras_core/backend/torch/math.py
@@ -42,6 +42,47 @@ def segment_sum(data, segment_ids, num_segments=None, **kwargs):
     return result.type(data.dtype)
 
 
+def segment_max(data, segment_ids, num_segments=None, **kwargs):
+    print(data.shape)
+    print(segment_ids.shape)
+    data = convert_to_tensor(data)
+    segment_ids = convert_to_tensor(segment_ids)
+    num_repeats = torch.prod(
+        torch.tensor(data.shape[1:], device=get_device())
+    ).long()
+    # To use `scatter_add` in torch, we need to replicate `segment_ids` into the
+    # shape of `data`.
+    segment_ids = (
+        segment_ids.repeat_interleave(num_repeats)
+        .view(*data.shape)
+        .type(torch.int64)
+    )
+    num_segments = num_segments or len(torch.unique(segment_ids))
+
+    # .scatter_add does not support -1 in the indices.
+    # Add all out-of-bound indices value to an extra dimension after
+    # num_segments, which is removed before returning the result.
+
+    # Replacing the out-of-bound indices.
+    segment_ids = torch.where(segment_ids >= 0, segment_ids, num_segments)
+    segment_ids = torch.where(
+        segment_ids < num_segments, segment_ids, num_segments
+    )
+
+    # Add one more dimension to the result shape with the "+1".
+    shape = (num_segments + 1,) + tuple(data.shape[1:])
+    print(shape)
+
+    result = torch.zeros(*shape, device=get_device()).scatter_reduce(
+        0, segment_ids, data.float(), "amax"
+    )
+
+    # Removing the extra dimension.
+    result = result[:-1, ...]
+
+    return result.type(data.dtype)
+
+
 def top_k(x, k, sorted=True):
     x = convert_to_tensor(x)
     return torch.topk(x, k, sorted=sorted)

--- a/keras_core/backend/torch/math.py
+++ b/keras_core/backend/torch/math.py
@@ -43,8 +43,6 @@ def segment_sum(data, segment_ids, num_segments=None, **kwargs):
 
 
 def segment_max(data, segment_ids, num_segments=None, **kwargs):
-    print(data.shape)
-    print(segment_ids.shape)
     data = convert_to_tensor(data)
     segment_ids = convert_to_tensor(segment_ids)
     num_repeats = torch.prod(
@@ -71,7 +69,6 @@ def segment_max(data, segment_ids, num_segments=None, **kwargs):
 
     # Add one more dimension to the result shape with the "+1".
     shape = (num_segments + 1,) + tuple(data.shape[1:])
-    print(shape)
 
     result = torch.zeros(*shape, device=get_device()).scatter_reduce(
         0, segment_ids, data.float(), "amax"

--- a/keras_core/backend/torch/math.py
+++ b/keras_core/backend/torch/math.py
@@ -48,7 +48,7 @@ def segment_max(data, segment_ids, num_segments=None, **kwargs):
     num_repeats = torch.prod(
         torch.tensor(data.shape[1:], device=get_device())
     ).long()
-    # To use `scatter_add` in torch, we need to replicate `segment_ids` into the
+    # To use `scatter_reduce` in torch, we need to replicate `segment_ids` into the
     # shape of `data`.
     segment_ids = (
         segment_ids.repeat_interleave(num_repeats)
@@ -57,7 +57,7 @@ def segment_max(data, segment_ids, num_segments=None, **kwargs):
     )
     num_segments = num_segments or len(torch.unique(segment_ids))
 
-    # .scatter_add does not support -1 in the indices.
+    # .scatter_reduce does not support -1 in the indices.
     # Add all out-of-bound indices value to an extra dimension after
     # num_segments, which is removed before returning the result.
 

--- a/keras_core/ops/math.py
+++ b/keras_core/ops/math.py
@@ -60,6 +60,58 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
     )
 
 
+class SegmentMax(Operation):
+    def __init__(self, num_segments=None, sorted=False):
+        super().__init__()
+        self.num_segments = num_segments
+        self.sorted = sorted
+
+    def compute_output_spec(self, data, segment_ids):
+        num_segments = self.num_segments
+        output_shape = (num_segments,) + tuple(data.shape[1:])
+        return KerasTensor(shape=output_shape, dtype=data.dtype)
+
+    def call(self, data, segment_ids):
+        return backend.math.segment_max(
+            data,
+            segment_ids,
+            num_segments=self.num_segments,
+            sorted=self.sorted,
+        )
+
+
+@keras_core_export("keras_core.ops.segment_max")
+def segment_max(data, segment_ids, num_segments=None, sorted=False):
+    """Computes the max of segments in a tensor.
+
+    Args:
+        data: Input tensor.
+        segment_ids: A 1-D tensor containing segment indices for each
+            element in `data`.
+        num_segments: An integer representing the total number of
+            segments. If not specified, it is inferred from the maximum
+            value in `segment_ids`.
+        sorted: A boolean indicating whether `segment_ids` is sorted.
+            Default is `False`.
+
+    Returns:
+        A tensor containing the max of segments, where each element
+        represents the max of the corresponding segment in `data`.
+
+    Example:
+
+    >>> data = keras_core.ops.convert_to_tensor([1, 2, 3, 4, 5, 6])
+    >>> segment_ids = keras_core.ops.convert_to_tensor([0, 1, 0, 1, 0, 1])
+    >>> segment_max(data, segment_ids)
+    array([9 12], shape=(2,), dtype=int32)
+    """
+    if any_symbolic_tensors((data,)):
+        return SegmentSum(num_segments, sorted).symbolic_call(data, segment_ids)
+    return backend.math.segment_max(
+        data, segment_ids, num_segments=num_segments, sorted=sorted
+    )
+
+
 class TopK(Operation):
     def __init__(self, k, sorted=False):
         super().__init__()

--- a/keras_core/ops/math_test.py
+++ b/keras_core/ops/math_test.py
@@ -20,6 +20,17 @@ class MathOpsDynamicShapeTest(testing.TestCase):
         outputs = kmath.segment_sum(data, segment_ids, num_segments=5)
         self.assertEqual(outputs.shape, (5, 4))
 
+    def test_segment_max(self):
+        data = KerasTensor((None, 4), dtype="float32")
+        segment_ids = KerasTensor((10,), dtype="int32")
+        outputs = kmath.segment_max(data, segment_ids)
+        self.assertEqual(outputs.shape, (None, 4))
+
+        data = KerasTensor((None, 4), dtype="float32")
+        segment_ids = KerasTensor((10,), dtype="int32")
+        outputs = kmath.segment_max(data, segment_ids, num_segments=5)
+        self.assertEqual(outputs.shape, (5, 4))
+
     def test_top_k(self):
         x = KerasTensor((None, 2, 3))
         values, indices = kmath.top_k(x, k=1)
@@ -70,6 +81,22 @@ class MathOpsStaticShapeTest(testing.TestCase):
         data = KerasTensor((10, 4), dtype="float32")
         segment_ids = KerasTensor((10,), dtype="int32")
         outputs = kmath.segment_sum(data, segment_ids, num_segments=5)
+        self.assertEqual(outputs.shape, (5, 4))
+
+    @pytest.mark.skipif(
+        backend.backend() == "jax",
+        reason="JAX does not support `num_segments=None`.",
+    )
+    def test_segment_max(self):
+        data = KerasTensor((10, 4), dtype="float32")
+        segment_ids = KerasTensor((10,), dtype="int32")
+        outputs = kmath.segment_max(data, segment_ids)
+        self.assertEqual(outputs.shape, (None, 4))
+
+    def test_segment_max_explicit_num_segments(self):
+        data = KerasTensor((10, 4), dtype="float32")
+        segment_ids = KerasTensor((10,), dtype="int32")
+        outputs = kmath.segment_max(data, segment_ids, num_segments=5)
         self.assertEqual(outputs.shape, (5, 4))
 
     def test_topk(self):
@@ -146,6 +173,53 @@ class MathOpsCorrectnessTest(testing.TestCase):
         outputs = kmath.segment_sum(data, segment_ids, num_segments=4)
         expected = tf.math.unsorted_segment_sum(
             data, segment_ids, num_segments=4
+        )
+        self.assertAllClose(outputs, expected)
+
+    @pytest.mark.skipif(
+        backend.backend() == "jax",
+        reason="JAX does not support `num_segments=None`.",
+    )
+    def test_segment_max(self):
+        # Test 1D case.
+        data = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.float32)
+        segment_ids = np.array([0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int32)
+        outputs = kmath.segment_max(data, segment_ids)
+        expected = tf.math.segment_max(data, segment_ids)
+        self.assertAllClose(outputs, expected)
+
+        # Test N-D case.
+        data = np.random.rand(9, 3, 3)
+        segment_ids = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int32)
+        outputs = kmath.segment_max(data, segment_ids)
+        expected = tf.math.segment_max(data, segment_ids)
+        self.assertAllClose(outputs, expected)
+
+    def test_segment_max_explicit_num_segments(self):
+        # Test 1D case.
+        data = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.float32)
+        segment_ids = np.array([0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int32)
+        outputs = kmath.segment_max(data, segment_ids, num_segments=3)
+        expected = tf.math.unsorted_segment_max(
+            data, segment_ids, num_segments=3
+        )
+        self.assertAllClose(outputs, expected)
+
+        # Test 1D with -1 case.
+        data = np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.float32)
+        segment_ids = np.array([0, 0, 1, 1, -1, 2, 2, -1], dtype=np.int32)
+        outputs = kmath.segment_max(data, segment_ids, num_segments=3)
+        expected = tf.math.unsorted_segment_max(
+            data, segment_ids, num_segments=3
+        )
+        self.assertAllClose(outputs, expected)
+
+        # Test N-D case.
+        data = np.random.rand(9, 3, 3)
+        segment_ids = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int32)
+        outputs = kmath.segment_max(data, segment_ids, num_segments=3)
+        expected = tf.math.unsorted_segment_max(
+            data, segment_ids, num_segments=3
         )
         self.assertAllClose(outputs, expected)
 


### PR DESCRIPTION
This op is a sibling of `segment_sum` which is useful in box decoding for a handful of 2D and 3D object detection models (and I would imagine instance segmentation models as well, although I have yet to encounter that particular use case)