### PR TITLE
Remove `self.support_jit = False` in RandomFlip

### DIFF
--- a/keras_core/layers/preprocessing/random_flip.py
+++ b/keras_core/layers/preprocessing/random_flip.py
@@ -48,21 +48,33 @@ class RandomFlip(TFDataLayer):
         self._allow_non_tensor_positional_args = True
 
     def _randomly_flip_inputs(self, inputs):
+        unbatched = len(inputs.shape) == 3
+        if unbatched:
+            inputs = self.backend.numpy.expand_dims(inputs, axis=0)
+        batch_size = self.backend.shape(inputs)[0]
         flipped_outputs = inputs
         seed_generator = self._get_seed_generator(self.backend._backend)
         if self.mode == HORIZONTAL or self.mode == HORIZONTAL_AND_VERTICAL:
-            flipped_outputs = self.backend.cond(
-                self.backend.random.uniform(shape=(), seed=seed_generator)
+            flipped_outputs = self.backend.numpy.where(
+                self.backend.random.uniform(
+                    shape=(batch_size,), seed=seed_generator
+                )
                 <= 0.5,
-                lambda: self.backend.numpy.flip(flipped_outputs, axis=-2),
-                lambda: flipped_outputs,
+                self.backend.numpy.flip(flipped_outputs, axis=-2),
+                flipped_outputs,
             )
         if self.mode == VERTICAL or self.mode == HORIZONTAL_AND_VERTICAL:
-            flipped_outputs = self.backend.cond(
-                self.backend.random.uniform(shape=(), seed=seed_generator)
+            flipped_outputs = self.backend.numpy.where(
+                self.backend.random.uniform(
+                    shape=(batch_size,), seed=seed_generator
+                )
                 <= 0.5,
-                lambda: self.backend.numpy.flip(flipped_outputs, axis=-3),
-                lambda: flipped_outputs,
+                self.backend.numpy.flip(flipped_outputs, axis=-3),
+                flipped_outputs,
+            )
+        if unbatched:
+            flipped_outputs = self.backend.numpy.squeeze(
+                flipped_outputs, axis=0
             )
         return flipped_outputs
 

--- a/keras_core/layers/preprocessing/random_flip.py
+++ b/keras_core/layers/preprocessing/random_flip.py
@@ -44,7 +44,6 @@ class RandomFlip(TFDataLayer):
         self.seed = seed
         self.generator = SeedGenerator(seed)
         self.mode = mode
-        self.supports_jit = False
         self._convert_input_args = False
         self._allow_non_tensor_positional_args = True
 

--- a/keras_core/layers/preprocessing/random_flip_test.py
+++ b/keras_core/layers/preprocessing/random_flip_test.py
@@ -67,6 +67,28 @@ class RandomFlipTest(testing.TestCase, parameterized.TestCase):
             run_training_check=False,
         )
 
+    def test_support_jit(self):
+        if backend.backend() not in ("tensorflow", "jax"):
+            self.skipTest(
+                "only tensorflow and jax support jit compilation for RandomFlip"
+            )
+        input_data = np.random.random(size=(2, 4, 4, 3)) * 255
+        layer = layers.RandomFlip()
+        if backend.backend() == "jax":
+            import jax
+
+            @jax.jit
+            def call(input_data):
+                return layer.call(input_data)
+
+        elif backend.backend() == "tensorflow":
+
+            @tf.function(jit_compile=True)
+            def call(input_data):
+                return layer.call(input_data)
+
+        call(input_data)
+
     def test_tf_data_compatibility(self):
         layer = layers.RandomFlip("vertical", seed=42)
         input_data = np.array([[[2, 3, 4]], [[5, 6, 7]]])

--- a/keras_core/layers/preprocessing/random_flip_test.py
+++ b/keras_core/layers/preprocessing/random_flip_test.py
@@ -12,8 +12,15 @@ from keras_core import utils
 
 class MockedRandomFlip(layers.RandomFlip):
     def call(self, inputs, training=True):
+        unbatched = len(inputs.shape) == 3
+        batch_size = 1 if unbatched else self.backend.shape(inputs)[0]
+        mocked_value = self.backend.numpy.full(
+            (batch_size,), 0.1, dtype="float32"
+        )
         with unittest.mock.patch.object(
-            self.backend.random, "uniform", return_value=0.1
+            self.backend.random,
+            "uniform",
+            return_value=mocked_value,
         ):
             out = super().call(inputs, training=training)
         return out
@@ -26,6 +33,7 @@ class RandomFlipTest(testing.TestCase, parameterized.TestCase):
         ("random_flip_both", "horizontal_and_vertical"),
     )
     def test_random_flip(self, mode):
+        run_training_check = False if backend.backend() == "numpy" else True
         self.run_layer_test(
             layers.RandomFlip,
             init_kwargs={
@@ -34,10 +42,11 @@ class RandomFlipTest(testing.TestCase, parameterized.TestCase):
             input_shape=(2, 3, 4),
             expected_output_shape=(2, 3, 4),
             supports_masking=False,
-            run_training_check=False,
+            run_training_check=run_training_check,
         )
 
     def test_random_flip_horizontal(self):
+        run_training_check = False if backend.backend() == "numpy" else True
         utils.set_random_seed(0)
         self.run_layer_test(
             MockedRandomFlip,
@@ -48,10 +57,11 @@ class RandomFlipTest(testing.TestCase, parameterized.TestCase):
             input_data=np.asarray([[[2, 3, 4], [5, 6, 7]]]),
             expected_output=backend.convert_to_tensor([[[5, 6, 7], [2, 3, 4]]]),
             supports_masking=False,
-            run_training_check=False,
+            run_training_check=run_training_check,
         )
 
     def test_random_flip_vertical(self):
+        run_training_check = False if backend.backend() == "numpy" else True
         utils.set_random_seed(0)
         self.run_layer_test(
             MockedRandomFlip,
@@ -64,30 +74,8 @@ class RandomFlipTest(testing.TestCase, parameterized.TestCase):
                 [[[5, 6, 7]], [[2, 3, 4]]]
             ),
             supports_masking=False,
-            run_training_check=False,
+            run_training_check=run_training_check,
         )
-
-    def test_support_jit(self):
-        if backend.backend() not in ("tensorflow", "jax"):
-            self.skipTest(
-                "only tensorflow and jax support jit compilation for RandomFlip"
-            )
-        input_data = np.random.random(size=(2, 4, 4, 3)) * 255
-        layer = layers.RandomFlip()
-        if backend.backend() == "jax":
-            import jax
-
-            @jax.jit
-            def call(input_data):
-                return layer.call(input_data)
-
-        elif backend.backend() == "tensorflow":
-
-            @tf.function(jit_compile=True)
-            def call(input_data):
-                return layer.call(input_data)
-
-        call(input_data)
 
     def test_tf_data_compatibility(self):
         layer = layers.RandomFlip("vertical", seed=42)


### PR DESCRIPTION
I'm pretty sure that RandomFlip is jittable and `self.support_jit = False` should be removed.

This PR has added a test for this: `test_support_jit`

A script to test the jit functionality:

```python
import os

os.environ["KERAS_BACKEND"] = "tensorflow"  # "jax", "torch" and "numpy"

import numpy as np
import keras_core as keras

x = np.random.random(size=(2, 128, 128, 3)) * 255
layer = keras.layers.RandomFlip()

if keras.backend.backend() == "tensorflow":
    import tensorflow as tf

    @tf.function(jit_compile=True)
    def get_output(x):
        return layer.call(x)

elif keras.backend.backend() == "jax":
    import jax

    @jax.jit
    def get_output(x):
        return layer.call(x)

else:

    def get_output(x):
        return layer(x)


y = get_output(x)
print("succeed!")

```