### PR TITLE
Make ner transformers work again

### DIFF
--- a/examples/keras_io/tensorflow/nlp/ner_transformers.py
+++ b/examples/keras_io/tensorflow/nlp/ner_transformers.py
@@ -271,7 +271,7 @@ class CustomNonPaddingTokenLoss(keras.losses.Loss):
 
     def call(self, y_true, y_pred):
         loss_fn = keras.losses.SparseCategoricalCrossentropy(
-            from_logits=True, reduction=keras.losses.Reduction.NONE
+            from_logits=True, reduction=None
         )
         loss = loss_fn(y_true, y_pred)
         mask = keras.backend.cast((y_true > 0), dtype="float32")

--- a/keras_core/layers/attention/multi_head_attention.py
+++ b/keras_core/layers/attention/multi_head_attention.py
@@ -4,7 +4,6 @@ import string
 
 import numpy as np
 
-from keras_core import backend
 from keras_core import constraints
 from keras_core import initializers
 from keras_core import ops

--- a/keras_core/layers/attention/multi_head_attention.py
+++ b/keras_core/layers/attention/multi_head_attention.py
@@ -314,9 +314,7 @@ class MultiHeadAttention(Layer):
         )
         self._softmax = Softmax(axis=norm_axes)
         self._dropout_layer = Dropout(rate=self._dropout)
-        self._inverse_sqrt_key_dim = backend.convert_to_tensor(
-            1.0 / math.sqrt(float(self._key_dim))
-        )
+        self._inverse_sqrt_key_dim = 1.0 / math.sqrt(float(self._key_dim))
 
     def _masked_softmax(self, attention_scores, attention_mask=None):
         # Normalize the attention scores to probabilities.


### PR DESCRIPTION
1. 489237f  breaks this example,  don't use tensor in MHA `__init__()`, ed2a726
2. keras.losses.Reduction.NONE  is no longer there, replace it with `None`