### PR TITLE
Convert to tensor for jax ops.numpy.transpose

### DIFF
--- a/keras_core/backend/jax/numpy.py
+++ b/keras_core/backend/jax/numpy.py
@@ -582,6 +582,7 @@ def squeeze(x, axis=None):
 
 
 def transpose(x, axes=None):
+    x = convert_to_tensor(x)
     return jnp.transpose(x, axes=axes)
 
 


### PR DESCRIPTION
Another spot we need this when passing a variable.