### PR TITLE
Update the softmax default to axis=-1

### DIFF
--- a/keras_core/backend/jax/nn.py
+++ b/keras_core/backend/jax/nn.py
@@ -83,7 +83,7 @@ def gelu(x, approximate=True):
     return jnn.gelu(x, approximate)
 
 
-def softmax(x, axis=None):
+def softmax(x, axis=-1):
     x = convert_to_tensor(x)
     return jnn.softmax(x, axis=axis)
 

--- a/keras_core/backend/tensorflow/nn.py
+++ b/keras_core/backend/tensorflow/nn.py
@@ -74,26 +74,27 @@ def gelu(x, approximate=True):
     return tf.nn.gelu(x, approximate)
 
 
-def softmax(x, axis=None):
+def softmax(x, axis=-1):
     logits = x
     if axis is None:
         # Unlike numpy, tf will handle axis=None as axis=-1.
         # We need this workaround for the reduction on every dim.
-        logits_exp = tf.exp(logits)
-        output = logits_exp / tf.reduce_sum(logits_exp, keepdims=True)
+        output = tf.reshape(x, [-1])
+        output = tf.nn.softmax(output, axis=-1)
+        output = tf.reshape(output, tf.shape(x))
     else:
         output = tf.nn.softmax(x, axis=axis)
     output._keras_logits = logits
     return output
 
 
-def log_softmax(x, axis=None):
+def log_softmax(x, axis=-1):
     if axis is None:
         # Unlike numpy, tf will handle axis=None as axis=-1.
         # We need this workaround for the reduction on every dim.
-        logits = x
-        logits_exp = tf.exp(logits)
-        return logits - tf.math.log(tf.reduce_sum(logits_exp, keepdims=True))
+        output = tf.reshape(x, [-1])
+        output = tf.nn.log_softmax(output, axis=-1)
+        return tf.reshape(output, tf.shape(x))
     return tf.nn.log_softmax(x, axis=axis)
 
 

--- a/keras_core/backend/torch/nn.py
+++ b/keras_core/backend/torch/nn.py
@@ -89,24 +89,26 @@ def gelu(x, approximate=True):
     return tnn.gelu(x)
 
 
-def softmax(x, axis=None):
-    logits = convert_to_tensor(x)
+def softmax(x, axis=-1):
+    x = convert_to_tensor(x)
     if axis is None:
         # Unlike numpy, PyTorch will handle axis=None as axis=-1.
         # We need this workaround for the reduction on every dim.
-        logits_exp = torch.exp(logits)
-        return logits_exp / torch.sum(logits_exp)
-    return tnn.softmax(logits, dim=axis)
+        output = torch.reshape(x, [-1])
+        output = tnn.softmax(output, dim=-1)
+        return torch.reshape(output, x.shape)
+    return tnn.softmax(x, dim=axis)
 
 
-def log_softmax(x, axis=None):
-    logits = convert_to_tensor(x)
+def log_softmax(x, axis=-1):
+    x = convert_to_tensor(x)
     if axis is None:
         # Unlike numpy, PyTorch will handle axis=None as axis=-1.
         # We need this workaround for the reduction on every dim.
-        logits_exp = torch.exp(logits)
-        return logits - torch.log(torch.sum(logits_exp))
-    return tnn.log_softmax(logits, dim=axis)
+        output = torch.reshape(x, [-1])
+        output = tnn.log_softmax(output, dim=-1)
+        return torch.reshape(output, x.shape)
+    return tnn.log_softmax(x, dim=axis)
 
 
 def _compute_padding_length(

--- a/keras_core/ops/nn.py
+++ b/keras_core/ops/nn.py
@@ -443,9 +443,9 @@ def gelu(x, approximate=True):
 
 
 class Softmax(Operation):
-    def __init__(self, axis=None):
+    def __init__(self, axis=-1):
         super().__init__()
-        self.axis = axis if axis is not None else -1
+        self.axis = axis
 
     def call(self, x):
         return backend.nn.softmax(x, axis=self.axis)
@@ -455,16 +455,16 @@ class Softmax(Operation):
 
 
 @keras_core_export(["keras_core.ops.softmax", "keras_core.ops.nn.softmax"])
-def softmax(x, axis=None):
+def softmax(x, axis=-1):
     if any_symbolic_tensors((x,)):
         return Softmax(axis).symbolic_call(x)
     return backend.nn.softmax(x, axis=axis)
 
 
 class LogSoftmax(Operation):
-    def __init__(self, axis=None):
+    def __init__(self, axis=-1):
         super().__init__()
-        self.axis = axis if axis is not None else -1
+        self.axis = axis
 
     def call(self, x):
         return backend.nn.log_softmax(x, axis=self.axis)
@@ -479,7 +479,7 @@ class LogSoftmax(Operation):
         "keras_core.ops.nn.log_softmax",
     ]
 )
-def log_softmax(x, axis=None):
+def log_softmax(x, axis=-1):
     if any_symbolic_tensors((x,)):
         return LogSoftmax(axis).symbolic_call(x)
     return backend.nn.log_softmax(x, axis=axis)

--- a/keras_core/ops/nn_test.py
+++ b/keras_core/ops/nn_test.py
@@ -688,7 +688,7 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
     def test_softmax(self):
         x = np.array([[1, 2, 3], [1, 2, 3]], dtype=np.float32)
         self.assertAllClose(
-            knn.softmax(x),
+            knn.softmax(x, axis=None),  # Reduce on all axes.
             [[0.045015, 0.122364, 0.33262], [0.045015, 0.122364, 0.33262]],
         )
         self.assertAllClose(
@@ -702,11 +702,18 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
                 [0.09003057, 0.24472848, 0.66524094],
             ],
         )
+        self.assertAllClose(
+            knn.softmax(x),  # Default axis should be -1.
+            [
+                [0.09003057, 0.24472848, 0.66524094],
+                [0.09003057, 0.24472848, 0.66524094],
+            ],
+        )
 
     def test_log_softmax(self):
         x = np.array([[1, 2, 3], [1, 2, 3]], dtype=np.float32)
         self.assertAllClose(
-            knn.log_softmax(x),
+            knn.log_softmax(x, axis=None),  # Reduce on all axes.
             [
                 [-3.100753, -2.100753, -1.100753],
                 [-3.100753, -2.100753, -1.100753],
@@ -721,6 +728,13 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         )
         self.assertAllClose(
             knn.log_softmax(x, axis=-1),
+            [
+                [-2.407606, -1.407606, -0.407606],
+                [-2.407606, -1.407606, -0.407606],
+            ],
+        )
+        self.assertAllClose(
+            knn.log_softmax(x),  # Default axis should be -1.
             [
                 [-2.407606, -1.407606, -0.407606],
                 [-2.407606, -1.407606, -0.407606],


### PR DESCRIPTION
Essentially we are going to adopt the jax approach for softmax:

- The `axis` default is `-1` (aligns with tf/torch default behavior).
- Passing `axis=None` explicitly mean a reduction on all axes, which fits with jax and all numpy reduction ops.

This should be least surprising overall to users.

Also, let's `reshape` to get the `None` behavior we want in torch/tf, rather then compute the reduction ourselves, so we can be sure our numerics are the same close to zero.