### PR TITLE
Random Flip for batched inputs

### DIFF
--- a/keras_core/layers/preprocessing/random_flip.py
+++ b/keras_core/layers/preprocessing/random_flip.py
@@ -57,7 +57,7 @@ class RandomFlip(TFDataLayer):
         if self.mode == HORIZONTAL or self.mode == HORIZONTAL_AND_VERTICAL:
             flipped_outputs = self.backend.numpy.where(
                 self.backend.random.uniform(
-                    shape=(batch_size,), seed=seed_generator
+                    shape=(batch_size, 1, 1, 1), seed=seed_generator
                 )
                 <= 0.5,
                 self.backend.numpy.flip(flipped_outputs, axis=-2),
@@ -66,7 +66,7 @@ class RandomFlip(TFDataLayer):
         if self.mode == VERTICAL or self.mode == HORIZONTAL_AND_VERTICAL:
             flipped_outputs = self.backend.numpy.where(
                 self.backend.random.uniform(
-                    shape=(batch_size,), seed=seed_generator
+                    shape=(batch_size, 1, 1, 1), seed=seed_generator
                 )
                 <= 0.5,
                 self.backend.numpy.flip(flipped_outputs, axis=-3),


### PR DESCRIPTION
Random Flip seems to fail for batched inputs.

For instance:
```
>>> (x_train, y_train), (x_test, y_test) = keras_core.datasets.cifar10.load_data()
>>> keras_core.layers.RandomFlip(mode="horizontal")(x_train[1]) # Works
>>> keras_core.layers.RandomFlip(mode="horizontal")(x_train) # Fails
InvalidArgumentError                      Traceback (most recent call last)
...
{{function_node __wrapped__SelectV2_device_/job:localhost/replica:0/task:0/device:CPU:0}} condition [50000], then [50000,32,32,3], and else [50000,32,32,3] must be broadcastable [Op:SelectV2] name:
```

This is due to some shape broadcasting gone wrong, which this PR should fix. Added unit-test as well.