### PR TITLE
Remove duplicated swish implementation

### DIFF
--- a/keras_core/backend/numpy/nn.py
+++ b/keras_core/backend/numpy/nn.py
@@ -40,10 +40,6 @@ def silu(x):
     return x * (1.0 / (1.0 + np.exp(-x)))
 
 
-def swish(x):
-    return x * (1.0 / (1.0 + np.exp(-x)))
-
-
 def log_sigmoid(x):
     return np.log(1.0 / (1.0 + np.exp(-x)))
 

--- a/keras_core/ops/nn.py
+++ b/keras_core/ops/nn.py
@@ -186,9 +186,10 @@ class Silu(Operation):
         return KerasTensor(x.shape, dtype=x.dtype)
 
 
-@keras_core_export(["keras_core.ops.silu", "keras_core.ops.nn.silu"])
+@keras_core_export(["keras_core.ops.silu", "keras_core.ops.nn.silu",
+                    "keras_core.ops.swish", "keras_core.ops.nn.swish"])
 def silu(x):
-    """Sigmoid-weighted linear unit activation function.
+    """Sigmoid-weighted linear unit (or swish) activation function.
 
     It is defined as `f(x) = x * sigmoid(x)`.
 
@@ -209,21 +210,6 @@ def silu(x):
     if any_symbolic_tensors((x,)):
         return Silu().symbolic_call(x)
     return backend.nn.silu(x)
-
-
-class Swish(Operation):
-    def call(self, x):
-        return backend.nn.swish(x)
-
-    def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
-
-
-@keras_core_export(["keras_core.ops.swish", "keras_core.ops.nn.swish"])
-def swish(x):
-    if any_symbolic_tensors((x,)):
-        return Swish().symbolic_call(x)
-    return backend.nn.swish(x)
 
 
 class LogSigmoid(Operation):

--- a/keras_core/ops/nn_test.py
+++ b/keras_core/ops/nn_test.py
@@ -34,10 +34,6 @@ class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.silu(x).shape, (None, 2, 3))
 
-    def test_swish(self):
-        x = KerasTensor([None, 2, 3])
-        self.assertEqual(knn.swish(x).shape, (None, 2, 3))
-
     def test_log_sigmoid(self):
         x = KerasTensor([None, 2, 3])
         self.assertEqual(knn.log_sigmoid(x).shape, (None, 2, 3))


### PR DESCRIPTION
Removes duplicated `swish` implementation from `ops.nn.py` as it is already consolidated under `silu`.

Discussed in #695 