### PR TITLE
Fix typo in WhileLoop docstring in core.py

### DIFF
--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -230,7 +230,7 @@ def while_loop(
     loop_vars,
     maximum_iterations=None,
 ):
-    """While loop implemetation.
+    """While loop implementation.
 
     Args:
         cond: A callable that represents the termination condition of the loop.


### PR DESCRIPTION
**Summary**
This fixes a small typo in the `WhileLoop` docstring in core.py

**Changes**
- In `WhileLoop` docstring, fix "implemetation" to "implementation"

**Location** 
https://github.com/keras-team/keras-core/blob/main/keras_core/ops/core.py#L233



**Note**: I know it's a very simple change :) , but this is my first pull request ever, and I am still learning how to use GitHub. I love this project; it's very future-proof. I am aiming to be a helpful and active contributor. 