### PR TITLE
Update Seed Generator

### DIFF
--- a/keras_core/backend/jax/random.py
+++ b/keras_core/backend/jax/random.py
@@ -1,5 +1,7 @@
 import jax
 
+import random as python_random
+
 from keras_core.backend.config import floatx
 from keras_core.random.seed_generator import SeedGenerator
 from keras_core.random.seed_generator import draw_seed
@@ -13,7 +15,8 @@ def jax_draw_seed(seed):
 
 
 def make_default_seed():
-    return None, jax.random.PRNGKey(42)
+    random_seed = python_random.randint(1, int(1e9))
+    return None, jax.random.PRNGKey(seed=random_seed)
 
 
 def make_initial_seed(seed):
@@ -28,8 +31,10 @@ def make_initial_seed(seed):
     return None, jax.random.PRNGKey(seed=seed)
 
 
-def get_next_state(seed):
-    return jax.random.split(seed, 2)
+def get_next_seed_state(seed):
+    # JAX complains about the PRNG dtype if we don't cast it
+    # TODO: Figure out the underlying problem
+    return jax.random.split(jax.numpy.array(seed, jax.numpy.uint32), 2)
 
 
 def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):

--- a/keras_core/backend/jax/random.py
+++ b/keras_core/backend/jax/random.py
@@ -3,14 +3,33 @@ import jax
 from keras_core.backend.config import floatx
 from keras_core.random.seed_generator import SeedGenerator
 from keras_core.random.seed_generator import draw_seed
-from keras_core.random.seed_generator import make_default_seed
 
 
 def jax_draw_seed(seed):
-    if isinstance(seed, jax.Array):
-        return seed
+    if isinstance(seed, SeedGenerator):
+        return seed.next()
     else:
         return draw_seed(seed)
+
+
+def make_default_seed():
+    return None, jax.random.PRNGKey(42)
+
+
+def make_initial_seed(seed):
+    if isinstance(seed, (tuple, list, jax.Array)):
+        raise ValueError(
+            f"Initial seed should be a scalar value. Received seed={seed}."
+        )
+    if seed < 0:
+        raise ValueError(
+            f"Seed should be a non-negative number. Received seed={seed}."
+        )
+    return None, jax.random.PRNGKey(seed=seed)
+
+
+def get_next_state(seed):
+    return jax.random.split(seed, 2)
 
 
 def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):

--- a/keras_core/backend/jax/random.py
+++ b/keras_core/backend/jax/random.py
@@ -1,6 +1,6 @@
-import jax
-
 import random as python_random
+
+import jax
 
 from keras_core.backend.config import floatx
 from keras_core.random.seed_generator import SeedGenerator

--- a/keras_core/backend/tensorflow/random.py
+++ b/keras_core/backend/tensorflow/random.py
@@ -1,3 +1,5 @@
+import random as python_random
+
 import tensorflow as tf
 
 from keras_core.backend.common import standardize_dtype
@@ -14,7 +16,8 @@ def tf_draw_seed(seed):
 
 
 def make_default_seed():
-    rng = tf.random.Generator.from_seed(42)
+    random_seed = python_random.randint(1, int(1e9))
+    rng = tf.random.Generator.from_seed(random_seed)
     seed = tf.cast(rng.make_seeds(2)[0], tf.int32)
     return rng, seed
 
@@ -33,7 +36,7 @@ def make_initial_seed(seed):
     return rng, seed
 
 
-def get_next_state(seed):
+def get_next_seed_state(seed):
     return tf.random.split(seed, 2)
 
 

--- a/keras_core/backend/torch/random.py
+++ b/keras_core/backend/torch/random.py
@@ -1,3 +1,5 @@
+import random as python_random
+
 import torch
 import torch.nn.functional as tnn
 
@@ -25,7 +27,8 @@ def make_default_seed():
         return None
 
     torch_seed_gen = torch.Generator(device=get_device())
-    torch_seed_gen.manual_seed(42)
+    random_seed = python_random.randint(1, int(1e9))
+    torch_seed_gen.manual_seed(random_seed)
     return torch_seed_gen, torch_seed_gen.get_state()
 
 
@@ -45,6 +48,10 @@ def make_initial_seed(seed):
     torch_seed_gen = torch.Generator(device=get_device())
     torch_seed_gen.manual_seed(seed)
     return torch_seed_gen, torch_seed_gen.get_state()
+
+
+def get_next_seed_state(rng):
+    return rng, rng.get_state()
 
 
 def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):

--- a/keras_core/random/seed_generator.py
+++ b/keras_core/random/seed_generator.py
@@ -82,23 +82,22 @@ class SeedGenerator:
             return seed_sub_state
 
 
-def global_seed_generator(seed):
+def global_seed_generator():
     gen = global_state.get_global_attribute("global_seed_generator")
-    if gen is None:
-        gen = global_state.set_global_attribute("global_seed_generator", seed)
-    return gen
+    if gen is not None:
+        return gen.next()
+    else:
+        rng = SeedGenerator(seed=None)
+        global_state.set_global_attribute("global_seed_generator", rng)
+        return rng.next()
 
 
 def draw_seed(seed):
     if seed is None:
-        gen = global_state.get_global_attribute("global_seed_generator")
-        if gen is None:
-            rng = SeedGenerator(seed)
-            return global_seed_generator(rng)
-        else:
-            return gen.next()
+        return global_seed_generator()
     else:
-        return SeedGenerator(seed).next()
+        rng, seed = backend.random.make_initial_seed(seed)
+        return rng if backend.backend() == "torch" else seed
 
 
 @keras_core_export("keras_core.random.global_rng_state")


### PR DESCRIPTION
This PR is an attempt to fix #650 A few notable things:

1. Right now, I have kept `42` as the default seed so that everyone can test it easily on their side with the same setup. Will replace it with a random number once PR is approved
2. `torch` is a pain to work with when it comes to random generation. Why? Because it consumes and updates the state of the generator implicitly. Had it followed the same algo as TF and JAX, we could have avoided a couple of `if-else` conditions
3. I have tested the workflow on my end with all the backends with random ops, and layers. It works flawlessly! I will update the tests later on.

Here is an overview of how the seed generation works now:

## Random ops

### Scenario 1: No seed value is provided

```python
samples = ops.random.randint(shape=(1,), minval=0, maxval=10)
```
1. Once this random op is called, it will call the `draw_seed(...)` function.
2. It will check if we already have a global seed generator. If yes, then we will use call the `next(...)` method to get the next state of the global generator and draw samples from this updated rng state
3. If there is no global seed generator yet, It will create an instance of `SeedGenerator()` with `seed=None`, which will initialize the seed state with `42`, and will set the global seed generator to this instance
4. Subsequent calls of unseeded random ops will use the next state of this global seed generator


### Scenario 2: seed value is provided

```python
samples = ops.random.randint(shape=(1,), minval=0, maxval=10, seed=1)
```
~1. Once this random op is called, it will call the `draw_seed(...)` function.~
~2. If the seed is an `int`, it will create a `SeedGenerator` instance by calling the `make_initial_seed(...)` function.~
~3. Or you can instantiate `SeedGenerator` and pass to it.~
~4. The function then will use the seed value produced by calling the `next(..)` method in `draw_seed(...)` function~

1. Once this random op is called, it will call the `draw_seed(...)` function.
2. The `draw_seed()` function will call the `make_initial_seed(seed)` function that expects an integer argument. Only integer arguments are supported to make the behavior consistent across backends. 
3. This is a `stateless` call, meaning if you call the function with the same seed, you will get the same results everytime.

---

## Layers

### Scenario 1: No seed value is provided

1. It will check if a global seed generator is there. If yes, will draw seed by calling `next(...)`
2. If no global seed generator is present, it will create one with `42` as the initial state. And it will then draw seed from this global seed generator on subsequent calls.

### Scenario 2: Seed value is provided

Will instantiate a `SeedGenerator`, and subsequent calls will draw seed from this generator.

**Note:** The `SeedGenerator` class now depends on the backend specific state updates of the rng. In case of `TF` and `JAX` we will split the state at every call while in torch the state is consumed implicitly. The `next()` method in the `SeedGenerator` is now fully deterministic and depends on the algos used by the backend for managing state of the rng

Though I don't think I have missed anything in testing this on my end, it will be good if someone can confirm the same on their end. cc: @fchollet @martin-gorner @GallagherCommaJack 