### PR TITLE
Fix erroneous SegmentSum call in SegmentMax class

### DIFF
--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -230,7 +230,7 @@ def while_loop(
     loop_vars,
     maximum_iterations=None,
 ):
-    """While loop implemetation.
+    """While loop implementation.
 
     Args:
         cond: A callable that represents the termination condition of the loop.

--- a/keras_core/ops/math.py
+++ b/keras_core/ops/math.py
@@ -106,7 +106,7 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     array([9 12], shape=(2,), dtype=int32)
     """
     if any_symbolic_tensors((data,)):
-        return SegmentSum(num_segments, sorted).symbolic_call(data, segment_ids)
+        return SegmentMax(num_segments, sorted).symbolic_call(data, segment_ids)
     return backend.math.segment_max(
         data, segment_ids, num_segments=num_segments, sorted=sorted
     )


### PR DESCRIPTION
This pull request rectifies an oversight in the SegmentMax class.

It seems to me that the symbolic_call method was mistakenly invoking SegmentSum instead of performing the max operation.