### PR TITLE
Fix RandomCrop with TF backend

### DIFF
--- a/keras_core/layers/preprocessing/random_crop.py
+++ b/keras_core/layers/preprocessing/random_crop.py
@@ -66,7 +66,7 @@ class RandomCrop(TFDataLayer):
 
     def call(self, inputs, training=True):
         inputs = self.backend.cast(inputs, self.compute_dtype)
-        input_shape = self.backend.shape(inputs)
+        input_shape = inputs.shape
         is_batched = len(input_shape) > 3
         if not is_batched:
             inputs = self.backend.numpy.expand_dims(inputs, axis=0)


### PR DESCRIPTION
`RandomCrop` fails when fitting a model, with Tensorflow backend. For instance:

```
input = keras_core.Input(shape=(32, 32, 3))
x = keras_core.layers.RandomCrop(height=25, width=25)(input)
x = keras_core.layers.GlobalAveragePooling2D(data_format="channels_last")(x)
output = keras_core.layers.Dense(1)(x)

model = keras_core.Model(input, output)

model.compile(loss="categorical_crossentropy")

(x_train, y_train), (x_test, y_test) = keras_core.datasets.cifar10.load_data()
model.fit(x_train, y_train)
```

Returns (with my TF version is `2.13.0`):
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 11
      8 model.compile(loss="categorical_crossentropy")
     10 (x_train, y_train), (x_test, y_test) = keras_core.datasets.cifar10.load_data()
---> 11 model.fit(x_train, y_train)

File ~/Documents/private/dev_projects/keras-core/keras_core/utils/traceback_utils.py:123, in filter_traceback.<locals>.error_handler(*args, **kwargs)
    120     filtered_tb = _process_traceback_frames(e.__traceback__)
    121     # To get the full stack trace, call:
    122     # `keras_core.config.disable_traceback_filtering()`
--> 123     raise e.with_traceback(filtered_tb) from None
    124 finally:
    125     del filtered_tb

File ~/Documents/private/dev_projects/keras-core/keras_core/utils/traceback_utils.py:123, in filter_traceback.<locals>.error_handler(*args, **kwargs)
    120     filtered_tb = _process_traceback_frames(e.__traceback__)
    121     # To get the full stack trace, call:
    122     # `keras_core.config.disable_traceback_filtering()`
--> 123     raise e.with_traceback(filtered_tb) from None
    124 finally:
    125     del filtered_tb

TypeError: Exception encountered when calling RandomCrop.call().

len is not well defined for a symbolic Tensor (functional_3/random_crop_1/Shape:0). Please call `x.shape` rather than `len(x)` for shape information.

Arguments received by RandomCrop.call():
  • inputs=tf.Tensor(shape=(None, 32, 32, 3), dtype=float32)
  • training=True
```

This is because `keras_core.ops.shape` returns a Tensorflow tensor (when using TF as backend), on which we can't take the length. Instead, `.shape` returns a tuple.

Not entirely sure how to write a test for that, as calls to `RandomCrop` outside of `.fit` or `.predict` run fine.