### PR TITLE
Fix Issue in SegmentMax's Symbolic Call in keras_core/ops/math.py

### DIFF
--- a/keras_core/ops/math.py
+++ b/keras_core/ops/math.py
@@ -106,7 +106,7 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     array([9 12], shape=(2,), dtype=int32)
     """
     if any_symbolic_tensors((data,)):
-        return SegmentSum(num_segments, sorted).symbolic_call(data, segment_ids)
+        return SegmentMax(num_segments, sorted).symbolic_call(data, segment_ids)
     return backend.math.segment_max(
         data, segment_ids, num_segments=num_segments, sorted=sorted
     )


### PR DESCRIPTION
**Background**
The current implementation of the segment_max function in keras_core.ops.math has an error when dealing with symbolic tensors. Specifically, when checking for symbolic tensors and attempting to use the SegmentMax class's symbolic call method, it erroneously calls SegmentSum instead of SegmentMax.

**Changes**
Updated the segment_max function's symbolic tensor handling to call the correct SegmentMax class's symbolic_call method.

**Impact:**
Fixing this ensures that the segment_max function behaves correctly for symbolic tensors and avoids incorrect computations
