### PR TITLE
Only compute mean once in layernorm

### DIFF
--- a/keras_core/layers/normalization/layer_normalization.py
+++ b/keras_core/layers/normalization/layer_normalization.py
@@ -198,7 +198,10 @@ class LayerNormalization(Layer):
 
         # Calculate the mean and variance last axis (layer activations).
         mean = ops.mean(inputs, axis=self.axis, keepdims=True)
-        variance = ops.var(inputs, axis=self.axis, keepdims=True)
+        # Don't use ops.var, as that would re-compute the mean from scratch.
+        variance = ops.mean(
+            ops.power(inputs - mean, 2), axis=self.axis, keepdims=True
+        )
 
         scale, offset = _broadcast(self.gamma), _broadcast(self.beta)
 

--- a/keras_core/layers/normalization/layer_normalization_test.py
+++ b/keras_core/layers/normalization/layer_normalization_test.py
@@ -85,3 +85,11 @@ class LayerNormalizationTest(testing.TestCase):
 
         self.assertAllClose(ops.mean(out), 0.0, atol=1e-1)
         self.assertAllClose(ops.std(out), 1.0, atol=1e-1)
+
+    def test_output(self):
+        layer = layers.LayerNormalization(
+            dtype="float32", beta_initializer="ones", gamma_initializer="ones",
+        )
+        inputs = np.arange(5).astype("float32")[None, :]
+        out = layer(inputs)
+        self.assertAllClose(out, [[-0.41386, 0.29307, 1., 1.70693, 2.41386]])


### PR DESCRIPTION
Small think I just noticed, the `tf.keras` layernorm was using `tf.nn.moments` to compute mean and variance together.

However, we are computing them separately with numpy here, meaning that we were actually computing the mean of the inputs twice. Should be more efficient to reuse the computed mean to compute the variance.