### PR TITLE
Always return a tuple from ops.shape

### DIFF
--- a/keras_core/backend/tensorflow/core.py
+++ b/keras_core/backend/tensorflow/core.py
@@ -87,7 +87,23 @@ def is_tensor(x):
 
 
 def shape(x):
-    return tf.shape(x)
+    """Always return a tuple shape.
+
+    `tf.shape` will return a `tf.Tensor`, which differs from the tuple return
+    type on the torch and jax backends. We write our own method instead which
+    always returns a tuple, with integer values when the shape is known, and
+    tensor values when the shape is unknown (this is tf specific, as dynamic
+    shapes do not apply in other backends).
+    """
+    x = tf.convert_to_tensor(x)
+    dynamic = tf.shape(x)
+    if x.shape == tf.TensorShape(None):
+        raise ValueError(
+            "All tensors passed to `ops.shape` must have a statically known "
+            f"rank. Received: x={x} with unknown rank."
+        )
+    static = x.shape.as_list()
+    return tuple(dynamic[i] if s is None else s for i, s in enumerate(static))
 
 
 def cast(x, dtype):

--- a/keras_core/ops/core.py
+++ b/keras_core/ops/core.py
@@ -402,6 +402,10 @@ def unstack(x, num=None, axis=0):
 def shape(x):
     """Gets the shape of the tensor input.
 
+    Note: On the tensorflow backend, when `x` is a `tf.Tensor` with dynamic
+    shape, dimensions which are dynamic in the context of a compiled function
+    will have a `tf.Tensor` value instead of a static integer value.
+
     Args:
         x: A tensor. This function will try to access the `shape` attribute of
             the input tensor.


### PR DESCRIPTION
This was already true in all contexts except when called on `tf.Tensor`s on the Tensorflow backend. In this case, we were returning a 1-D `tf.Tensor`.

This was leading to some weird incongruencies, e.g.
```python
# On Jax.
ops.shape(np.ones((1, 2))) + (3,)
> (1, 2, 3)

# On TensorFlow.
ops.shape(np.ones((1, 2))) + (3,)
> tf.Tensor([4, 5])
```