### PR TITLE
Fix incorrect return value in map_graph() in /ops/function.py

### DIFF
--- a/keras_core/ops/function.py
+++ b/keras_core/ops/function.py
@@ -289,7 +289,7 @@ def map_graph(inputs, outputs):
                 f'The name "{name}" is used {all_names.count(name)} '
                 "times in the model. All operation names should be unique."
             )
-    return network_nodes, nodes_by_depth, operations, operations_by_depth
+    return nodes, nodes_by_depth, operations, operations_by_depth
 
 
 def _build_map(outputs):


### PR DESCRIPTION
This fixes the mismatch between the declared and actual return values in map_graph() in /ops/function.py

The map_graph() function currently returns:

`(**network_nodes**, nodes_by_depth, operations, operations_by_depth) `



But in the Function.__init__ and map_graph() docstring it is declared to return:

`(**nodes**, nodes_by_depth, operations, operations_by_depth)`

