### PR TITLE
Fix wrong return value in map_graph()

### DIFF
--- a/keras_core/ops/function.py
+++ b/keras_core/ops/function.py
@@ -289,7 +289,7 @@ def map_graph(inputs, outputs):
                 f'The name "{name}" is used {all_names.count(name)} '
                 "times in the model. All operation names should be unique."
             )
-    return network_nodes, nodes_by_depth, operations, operations_by_depth
+    return nodes, nodes_by_depth, operations, operations_by_depth
 
 
 def _build_map(outputs):


### PR DESCRIPTION
There is a mismatch between the declared and actual return [values ](https://github.com/keras-team/keras-core/blob/main/keras_core/ops/function.py#L292)for the `map_graph()` function located in `/ops/function.py`.

Currently, `map_graph()` returns:
- **network_nodes**
- nodes_by_depth
- operations
- operations_by_depth

However, both the [`Function.__init__` ](https://github.com/keras-team/keras-core/blob/main/keras_core/ops/function.py#L54)and the [ `map_graph()` docstring ](https://github.com/keras-team/keras-core/blob/main/keras_core/ops/function.py#L183)indicate that it should return:
- **nodes**
- nodes_by_depth
- operations
- operations_by_depth


`network_nodes` appears to be an internal temporary variable not used outside of `map_graph()`, while `nodes` is required as a key property of the `Function` class.


To resolve this discrepancy, we should either:
1. Modify the function's output to match its documentation and  `Function.__init__`, or 
2. Update the documentation and `Function.__init__` to be consistent with the function's current behavior.

I'm leaning towards adjusting the function's return value. If that's not feasible, I'll submit another PR to update the docstring and `Function.__init__`. 

I would appreciate any feedback or suggestions on this matter. Thank you.

