### PR TITLE
Remove the redundant rsqrt function +  Fix map_graph docstring

### DIFF
--- a/keras_core/ops/function.py
+++ b/keras_core/ops/function.py
@@ -180,7 +180,7 @@ def map_graph(inputs, outputs):
 
     Returns:
         A tuple `(nodes, nodes_by_depth, operations, operations_by_depth)`.
-        - network_nodes : dict mapping the unique node keys to the Node instances.
+        - network_nodes:dict mapping the unique node keys to the Node instances
         - nodes_by_depth: dict mapping ints (depth) to lists of node instances.
         - operations: list of Operation instances.
         - operations_by_depth: dict mapping ints (depth) to lists of Operation

--- a/keras_core/ops/function.py
+++ b/keras_core/ops/function.py
@@ -180,7 +180,7 @@ def map_graph(inputs, outputs):
 
     Returns:
         A tuple `(nodes, nodes_by_depth, operations, operations_by_depth)`.
-        - nodes: list of Node instances.
+        - network_nodes : dict mapping the unique node keys to the Node instances.
         - nodes_by_depth: dict mapping ints (depth) to lists of node instances.
         - operations: list of Operation instances.
         - operations_by_depth: dict mapping ints (depth) to lists of Operation

--- a/keras_core/ops/math.py
+++ b/keras_core/ops/math.py
@@ -481,34 +481,3 @@ def rsqrt(x):
         return Rsqrt().symbolic_call(x)
     x = backend.convert_to_tensor(x)
     return backend.math.rsqrt(x)
-
-
-class Rsqrt(Operation):
-    """Computes reciprocal of square root of x element-wise.
-
-    Args:
-        x: input tensor
-
-    Returns:
-        A tensor with the same type as `x`.
-
-    Example:
-
-    >>> x = keras_core.ops.convert_to_tensor([2., 3., -2.])
-    >>> rsqrt(x)
-    """
-
-    def call(self, x):
-        x = backend.convert_to_tensor(x)
-        return backend.math.rsqrt(x)
-
-    def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
-
-
-@keras_core_export("keras_core.ops.rsqrt")
-def rsqrt(x):
-    if any_symbolic_tensors((x,)):
-        return Rsqrt().symbolic_call(x)
-    x = backend.convert_to_tensor(x)
-    return backend.math.rsqrt(x)


### PR DESCRIPTION
Fixes the docstring for map_graph(), which inaccurately describes network_nodes