### PR TITLE
Replace `tf.keras` with numpy  for conv2d and conv3d tests

### DIFF
--- a/keras_core/layers/convolutional/conv_test.py
+++ b/keras_core/layers/convolutional/conv_test.py
@@ -1,8 +1,5 @@
-import math
-
 import numpy as np
 import pytest
-import tensorflow as tf
 from absl.testing import parameterized
 from numpy.lib.stride_tricks import as_strided
 
@@ -249,11 +246,11 @@ class ConvBasicTest(testing.TestCase, parameterized.TestCase):
 
 class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
     def _same_padding(self, input_size, kernel_size, stride):
-        # P = ((S-1)*W-S+K)/2, with K = kernel size, S = stride, W = input size
-        padding = int(
-            math.ceil(((stride - 1) * input_size - stride + kernel_size) / 2)
-        )
-        return padding
+        if input_size % stride == 0:
+            padding = max(kernel_size - stride, 0)
+        else:
+            padding = max(kernel_size - (input_size % stride), 0)
+        return padding // 2, padding - padding // 2
 
     def _np_conv1d(
         self,
@@ -292,9 +289,9 @@ class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
             h_pad = self._same_padding(h_x, kernel_size, h_stride)
             npad = [(0, 0)] * x.ndim
             if padding == "causal":
-                npad[1] = (h_pad * 2, 0)
+                npad[1] = (h_pad[0] + h_pad[1], 0)
             else:
-                npad[1] = (h_pad, h_pad)
+                npad[1] = h_pad
             x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
 
         n_batch, h_x, _ = x.shape
@@ -325,7 +322,192 @@ class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
                 ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
             ]
             out_grps.append(x_strided @ kernel_weights_grp + bias_weights_grp)
-        return np.concatenate(out_grps, axis=-1)
+        out = np.concatenate(out_grps, axis=-1)
+        if data_format == "channels_first":
+            out = out.swapaxes(1, 2)
+        return out
+
+    def _np_conv2d(
+        self,
+        x,
+        kernel_weights,
+        bias_weights,
+        strides,
+        padding,
+        data_format,
+        dilation_rate,
+        groups,
+    ):
+        if data_format == "channels_first":
+            x = x.transpose((0, 2, 3, 1))
+        if isinstance(strides, (tuple, list)):
+            h_stride, w_stride = strides
+        else:
+            h_stride = strides
+            w_stride = strides
+        if isinstance(dilation_rate, (tuple, list)):
+            h_dilation, w_dilation = dilation_rate
+        else:
+            h_dilation = dilation_rate
+            w_dilation = dilation_rate
+        h_kernel, w_kernel, ch_in, ch_out = kernel_weights.shape
+
+        if h_dilation > 1 or w_dilation > 1:
+            new_h_kernel = h_kernel + (h_dilation - 1) * (h_kernel - 1)
+            new_w_kernel = w_kernel + (w_dilation - 1) * (w_kernel - 1)
+            new_kenel_size_tuple = (new_h_kernel, new_w_kernel)
+            new_kernel_weights = np.zeros(
+                (*new_kenel_size_tuple, ch_in, ch_out),
+                dtype=kernel_weights.dtype,
+            )
+            new_kernel_weights[::h_dilation, ::w_dilation] = kernel_weights
+            kernel_weights = new_kernel_weights
+            h_kernel, w_kernel = kernel_weights.shape[:2]
+
+        if padding == "same":
+            n_batch, h_x, w_x, _ = x.shape
+            h_pad = self._same_padding(h_x, h_kernel, h_stride)
+            w_pad = self._same_padding(w_x, w_kernel, w_stride)
+            npad = [(0, 0)] * x.ndim
+            npad[1] = h_pad
+            npad[2] = w_pad
+            x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
+
+        n_batch, h_x, w_x, _ = x.shape
+        h_out = int((h_x - h_kernel) / h_stride) + 1
+        w_out = int((w_x - w_kernel) / w_stride) + 1
+
+        out_grps = []
+        for grp in range(1, groups + 1):
+            x_in = x[..., (grp - 1) * ch_in : grp * ch_in]
+            stride_shape = (n_batch, h_out, w_out, h_kernel, w_kernel, ch_in)
+            strides = (
+                x_in.strides[0],
+                h_stride * x_in.strides[1],
+                w_stride * x_in.strides[2],
+                x_in.strides[1],
+                x_in.strides[2],
+                x_in.strides[3],
+            )
+            inner_dim = h_kernel * w_kernel * ch_in
+            x_strided = as_strided(
+                x_in, shape=stride_shape, strides=strides
+            ).reshape(-1, inner_dim)
+            ch_out_groups = ch_out // groups
+            kernel_weights_grp = kernel_weights[
+                ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
+            ].reshape(-1, ch_out_groups)
+            bias_weights_grp = bias_weights[
+                ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
+            ]
+            out_grps.append(x_strided @ kernel_weights_grp + bias_weights_grp)
+        out = np.concatenate(out_grps, axis=-1).reshape(
+            n_batch, h_out, w_out, ch_out
+        )
+        if data_format == "channels_first":
+            out = out.transpose((0, 3, 1, 2))
+        return out
+
+    def _np_conv3d(
+        self,
+        x,
+        kernel_weights,
+        bias_weights,
+        strides,
+        padding,
+        data_format,
+        dilation_rate,
+        groups,
+    ):
+        if data_format == "channels_first":
+            x = x.transpose((0, 2, 3, 4, 1))
+        if isinstance(strides, (tuple, list)):
+            h_stride, w_stride, d_stride = strides
+        else:
+            h_stride = strides
+            w_stride = strides
+            d_stride = strides
+        if isinstance(dilation_rate, (tuple, list)):
+            h_dilation, w_dilation, d_dilation = dilation_rate
+        else:
+            h_dilation = dilation_rate
+            w_dilation = dilation_rate
+            d_dilation = dilation_rate
+
+        h_kernel, w_kernel, d_kernel, ch_in, ch_out = kernel_weights.shape
+
+        if h_dilation > 1 or w_dilation > 1 or d_dilation > 1:
+            new_h_kernel = h_kernel + (h_dilation - 1) * (h_kernel - 1)
+            new_w_kernel = w_kernel + (w_dilation - 1) * (w_kernel - 1)
+            new_d_kernel = d_kernel + (d_dilation - 1) * (d_kernel - 1)
+            new_kenel_size_tuple = (new_h_kernel, new_w_kernel, new_d_kernel)
+            new_kernel_weights = np.zeros(
+                (*new_kenel_size_tuple, ch_in, ch_out),
+                dtype=kernel_weights.dtype,
+            )
+            new_kernel_weights[
+                ::h_dilation, ::w_dilation, ::d_dilation
+            ] = kernel_weights
+            kernel_weights = new_kernel_weights
+            h_kernel, w_kernel, d_kernel = kernel_weights.shape[:3]
+
+        if padding == "same":
+            n_batch, h_x, w_x, d_x, _ = x.shape
+            h_pad = self._same_padding(h_x, h_kernel, h_stride)
+            w_pad = self._same_padding(w_x, w_kernel, w_stride)
+            d_pad = self._same_padding(d_x, d_kernel, d_stride)
+            npad = [(0, 0)] * x.ndim
+            npad[1] = h_pad
+            npad[2] = w_pad
+            npad[3] = d_pad
+            x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
+
+        n_batch, h_x, w_x, d_x, _ = x.shape
+        h_out = int((h_x - h_kernel) / h_stride) + 1
+        w_out = int((w_x - w_kernel) / w_stride) + 1
+        d_out = int((d_x - d_kernel) / d_stride) + 1
+
+        out_grps = []
+        for grp in range(1, groups + 1):
+            x_in = x[..., (grp - 1) * ch_in : grp * ch_in]
+            stride_shape = (
+                n_batch,
+                h_out,
+                w_out,
+                d_out,
+                h_kernel,
+                w_kernel,
+                d_kernel,
+                ch_in,
+            )
+            strides = (
+                x_in.strides[0],
+                h_stride * x_in.strides[1],
+                w_stride * x_in.strides[2],
+                d_stride * x_in.strides[3],
+                x_in.strides[1],
+                x_in.strides[2],
+                x_in.strides[3],
+                x_in.strides[4],
+            )
+            inner_dim = h_kernel * w_kernel * d_kernel * ch_in
+            x_strided = as_strided(
+                x_in, shape=stride_shape, strides=strides
+            ).reshape(-1, inner_dim)
+            ch_out_groups = ch_out // groups
+            kernel_weights_grp = kernel_weights[
+                ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
+            ].reshape(-1, ch_out_groups)
+            bias_weights_grp = bias_weights[
+                ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
+            ]
+            out_grps.append(x_strided @ kernel_weights_grp + bias_weights_grp)
+        out = np.concatenate(out_grps, axis=-1).reshape(
+            n_batch, h_out, w_out, d_out, ch_out
+        )
+        if data_format == "channels_first":
+            out = out.transpose((0, 4, 1, 2, 3))
+        return out
 
     @parameterized.parameters(
         {
@@ -361,6 +543,15 @@ class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
             "strides": (2,),
             "padding": "valid",
             "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 2,
+        },
+        {
+            "filters": 6,
+            "kernel_size": (2,),
+            "strides": (2,),
+            "padding": "valid",
+            "data_format": "channels_first",
             "dilation_rate": 1,
             "groups": 2,
         },
@@ -437,10 +628,28 @@ class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
         },
         {
             "filters": 6,
+            "kernel_size": 2,
+            "strides": 1,
+            "padding": "same",
+            "data_format": "channels_last",
+            "dilation_rate": (2, 3),
+            "groups": 2,
+        },
+        {
+            "filters": 6,
             "kernel_size": (4, 3),
             "strides": (2, 1),
             "padding": "valid",
             "data_format": "channels_last",
+            "dilation_rate": (1, 1),
+            "groups": 2,
+        },
+        {
+            "filters": 6,
+            "kernel_size": (4, 3),
+            "strides": (2, 1),
+            "padding": "valid",
+            "data_format": "channels_first",
             "dilation_rate": (1, 1),
             "groups": 2,
         },
@@ -464,31 +673,27 @@ class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
             dilation_rate=dilation_rate,
             groups=groups,
         )
-        tf_keras_layer = tf.keras.layers.Conv2D(
-            filters=filters,
-            kernel_size=kernel_size,
+
+        inputs = np.random.normal(size=[2, 8, 8, 4])
+        layer.build(input_shape=inputs.shape)
+
+        kernel_shape = layer.kernel.shape
+        kernel_weights = np.random.normal(size=kernel_shape)
+        bias_weights = np.random.normal(size=(filters,))
+        layer.kernel.assign(kernel_weights)
+        layer.bias.assign(bias_weights)
+
+        outputs = layer(inputs)
+        expected = self._np_conv2d(
+            inputs,
+            kernel_weights,
+            bias_weights,
             strides=strides,
             padding=padding,
             data_format=data_format,
             dilation_rate=dilation_rate,
             groups=groups,
         )
-
-        inputs = np.random.normal(size=[2, 8, 8, 4])
-        layer.build(input_shape=inputs.shape)
-        tf_keras_layer.build(input_shape=inputs.shape)
-
-        kernel_shape = layer.kernel.shape
-        kernel_weights = np.random.normal(size=kernel_shape)
-        bias_weights = np.random.normal(size=(filters,))
-        layer.kernel.assign(kernel_weights)
-        tf_keras_layer.kernel.assign(kernel_weights)
-
-        layer.bias.assign(bias_weights)
-        tf_keras_layer.bias.assign(bias_weights)
-
-        outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
         self.assertAllClose(outputs, expected, rtol=5e-4)
 
     @parameterized.parameters(
@@ -512,10 +717,28 @@ class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
         },
         {
             "filters": 6,
+            "kernel_size": 2,
+            "strides": 1,
+            "padding": "same",
+            "data_format": "channels_last",
+            "dilation_rate": (2, 3, 4),
+            "groups": 2,
+        },
+        {
+            "filters": 6,
             "kernel_size": (2, 2, 3),
             "strides": (2, 1, 2),
             "padding": "valid",
             "data_format": "channels_last",
+            "dilation_rate": (1, 1, 1),
+            "groups": 2,
+        },
+        {
+            "filters": 6,
+            "kernel_size": (2, 2, 3),
+            "strides": (2, 1, 2),
+            "padding": "valid",
+            "data_format": "channels_first",
             "dilation_rate": (1, 1, 1),
             "groups": 2,
         },
@@ -539,29 +762,25 @@ class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
             dilation_rate=dilation_rate,
             groups=groups,
         )
-        tf_keras_layer = tf.keras.layers.Conv3D(
-            filters=filters,
-            kernel_size=kernel_size,
+
+        inputs = np.random.normal(size=[2, 8, 8, 8, 4])
+        layer.build(input_shape=inputs.shape)
+
+        kernel_shape = layer.kernel.shape
+        kernel_weights = np.random.normal(size=kernel_shape)
+        bias_weights = np.random.normal(size=(filters,))
+        layer.kernel.assign(kernel_weights)
+        layer.bias.assign(bias_weights)
+
+        outputs = layer(inputs)
+        expected = self._np_conv3d(
+            inputs,
+            kernel_weights,
+            bias_weights,
             strides=strides,
             padding=padding,
             data_format=data_format,
             dilation_rate=dilation_rate,
             groups=groups,
         )
-
-        inputs = np.random.normal(size=[2, 8, 8, 8, 4])
-        layer.build(input_shape=inputs.shape)
-        tf_keras_layer.build(input_shape=inputs.shape)
-
-        kernel_shape = layer.kernel.shape
-        kernel_weights = np.random.normal(size=kernel_shape)
-        bias_weights = np.random.normal(size=(filters,))
-        layer.kernel.assign(kernel_weights)
-        tf_keras_layer.kernel.assign(kernel_weights)
-
-        layer.bias.assign(bias_weights)
-        tf_keras_layer.bias.assign(bias_weights)
-        outputs = layer(inputs)
-
-        expected = tf_keras_layer(inputs)
         self.assertAllClose(outputs, expected, rtol=5e-4)

--- a/keras_core/layers/convolutional/conv_transpose_test.py
+++ b/keras_core/layers/convolutional/conv_transpose_test.py
@@ -323,7 +323,7 @@ class ConvTransposeCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
         outputs = layer(inputs)
         expected = tf_keras_layer(inputs)
-        self.assertAllClose(outputs, expected)
+        self.assertAllClose(outputs, expected, atol=1e-5)
 
     @parameterized.parameters(
         {
@@ -407,7 +407,7 @@ class ConvTransposeCorrectnessTest(testing.TestCase, parameterized.TestCase):
 
         outputs = layer(inputs)
         expected = tf_keras_layer(inputs)
-        self.assertAllClose(outputs, expected)
+        self.assertAllClose(outputs, expected, atol=1e-5)
 
     @parameterized.parameters(
         {

--- a/keras_core/utils/numerical_utils_test.py
+++ b/keras_core/utils/numerical_utils_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_core import backend
@@ -56,22 +55,20 @@ class TestNumericalUtils(testing.TestCase, parameterized.TestCase):
 
     @parameterized.parameters([1, 2, 3])
     def test_normalize(self, order):
-        xnp = np.random.random((3, 3))
         xb = backend.random.uniform((3, 3), seed=1337)
+        xnp = backend.convert_to_numpy(xb)
+
+        # Expected result
+        l2 = np.atleast_1d(np.linalg.norm(xnp, order, axis=-1))
+        l2[l2 == 0] = 1
+        expected = xnp / np.expand_dims(l2, axis=-1)
 
         # Test NumPy
         out = numerical_utils.normalize(xnp, axis=-1, order=order)
         self.assertTrue(isinstance(out, np.ndarray))
-        self.assertAllClose(
-            tf.keras.utils.normalize(xnp, axis=-1, order=order), out
-        )
+        self.assertAllClose(out, expected)
 
         # Test backend
         out = numerical_utils.normalize(xb, axis=-1, order=order)
         self.assertTrue(backend.is_tensor(out))
-        self.assertAllClose(
-            tf.keras.utils.normalize(
-                backend.convert_to_numpy(xb), axis=-1, order=order
-            ),
-            backend.convert_to_numpy(out),
-        )
+        self.assertAllClose(backend.convert_to_numpy(out), expected)


### PR DESCRIPTION
* Replaces `tf.keras` with numpy reference implementation
* Adds test for `channel_first` and changing dilation rates.
* Replaces `tf.keras` in `numerical_utils_test.py`