### PR TITLE
Add `irfft` and `istft`

### DIFF
--- a/keras_core/backend/jax/math.py
+++ b/keras_core/backend/jax/math.py
@@ -78,18 +78,31 @@ def extract_sequences(x, sequence_length, sequence_stride):
 
 def overlap_sequences(x, sequence_stride):
     # Ref: https://github.com/google/jax/blob/main/jax/_src/scipy/signal.py
-    *batch_shape, nframes, segment_len = x.shape
+    *batch_shape, num_sequences, sequence_length = x.shape
+    if sequence_stride > sequence_length:
+        raise ValueError(
+            "`sequence_stride` must equal or less than x.shape[-1]. "
+            f"Received: sequence_stride={sequence_stride}, "
+            f"x.shape[-1]={sequence_length}"
+        )
+    if sequence_stride < (sequence_length / num_sequences):
+        raise ValueError(
+            "`sequence_stride` must equal or greater than "
+            "x.shape[-1] / x.shape[-2]. "
+            f"Received: sequence_stride={sequence_stride}, "
+            f"x.shape[-1]={sequence_length}, x.shape[-2]={num_sequences}"
+        )
     flat_batchsize = math.prod(batch_shape)
-    x = jnp.reshape(x, (flat_batchsize, nframes, segment_len))
-    output_size = sequence_stride * (nframes - 1) + segment_len
-    nstep_per_segment = 1 + (segment_len - 1) // sequence_stride
+    x = jnp.reshape(x, (flat_batchsize, num_sequences, sequence_length))
+    output_size = sequence_stride * (num_sequences - 1) + sequence_length
+    nstep_per_segment = 1 + (sequence_length - 1) // sequence_stride
     # Here, we use shorter notation for axes.
-    # B: batch_size, N: nframes, S: nstep_per_segment,
-    # T: segment_len divided by S
+    # B: batch_size, N: num_sequences, S: nstep_per_segment,
+    # T: sequence_length divided by S
     padded_segment_len = nstep_per_segment * sequence_stride
-    x = jnp.pad(x, ((0, 0), (0, 0), (0, padded_segment_len - segment_len)))
+    x = jnp.pad(x, ((0, 0), (0, 0), (0, padded_segment_len - sequence_length)))
     x = jnp.reshape(
-        x, (flat_batchsize, nframes, nstep_per_segment, sequence_stride)
+        x, (flat_batchsize, num_sequences, nstep_per_segment, sequence_stride)
     )
     # For obtaining shifted signals, this routine reinterprets flattened array
     # with a shrinked axis.  With appropriate truncation/ padding, this
@@ -97,7 +110,7 @@ def overlap_sequences(x, sequence_stride):
     # of the current row.
     # See implementation of `overlap_and_add` in Tensorflow for details.
     x = jnp.transpose(x, (0, 2, 1, 3))  # x: (B, S, N, T)
-    x = jnp.pad(x, ((0, 0), (0, 0), (0, nframes), (0, 0)))
+    x = jnp.pad(x, ((0, 0), (0, 0), (0, num_sequences), (0, 0)))
     # x: (B, S, N*2, T)
     shrinked = x.shape[2] - 1
     x = jnp.reshape(x, (flat_batchsize, -1))
@@ -209,12 +222,20 @@ def stft(
 
 
 def istft(
-    x, sequence_length, sequence_stride, fft_length, window="hann", center=True
+    x,
+    sequence_length,
+    sequence_stride,
+    fft_length,
+    length=None,
+    window="hann",
+    center=True,
 ):
     # ref:
     # torch: aten/src/ATen/native/SpectralOps.cpp
     # tf: tf.signal.inverse_stft_window_fn
     x = irfft(x, fft_length)
+
+    expected_output_len = fft_length + sequence_stride * (x.shape[-2] - 1)
 
     if window is not None:
         if isinstance(window, str):
@@ -248,9 +269,14 @@ def istft(
 
     x = overlap_sequences(x, sequence_stride)
 
-    if center:
-        x[..., fft_length // 2 : -(fft_length // 2)]
-    return x
+    start = 0 if center is False else fft_length // 2
+    if length is not None:
+        end = start + length
+    elif center is True:
+        end = -(fft_length // 2)
+    else:
+        end = expected_output_len
+    return x[..., start:end]
 
 
 def rsqrt(x):

--- a/keras_core/backend/jax/math.py
+++ b/keras_core/backend/jax/math.py
@@ -208,5 +208,50 @@ def stft(
     return rfft(x, fft_length)
 
 
+def istft(
+    x, sequence_length, sequence_stride, fft_length, window="hann", center=True
+):
+    # ref:
+    # torch: aten/src/ATen/native/SpectralOps.cpp
+    # tf: tf.signal.inverse_stft_window_fn
+    x = irfft(x, fft_length)
+
+    if window is not None:
+        if isinstance(window, str):
+            win = convert_to_tensor(
+                scipy.signal.get_window(window, sequence_length), dtype=x.dtype
+            )
+        else:
+            win = convert_to_tensor(window, dtype=x.dtype)
+        if len(win.shape) != 1 or win.shape[-1] != sequence_length:
+            raise ValueError(
+                "The shape of `window` must be equal to [sequence_length]."
+                f"Received: window shape={win.shape}"
+            )
+        l_pad = (fft_length - sequence_length) // 2
+        r_pad = fft_length - sequence_length - l_pad
+        win = jnp.pad(win, [[l_pad, r_pad]])
+
+        # square and sum
+        _sequence_length = sequence_length + l_pad + r_pad
+        denom = jnp.square(win)
+        overlaps = -(-_sequence_length // sequence_stride)
+        denom = jnp.pad(
+            denom, [(0, overlaps * sequence_stride - _sequence_length)]
+        )
+        denom = jnp.reshape(denom, [overlaps, sequence_stride])
+        denom = jnp.sum(denom, 0, keepdims=True)
+        denom = jnp.tile(denom, [overlaps, 1])
+        denom = jnp.reshape(denom, [overlaps * sequence_stride])
+        win = jnp.divide(win, denom[:_sequence_length])
+        x = jnp.multiply(x, win)
+
+    x = overlap_sequences(x, sequence_stride)
+
+    if center:
+        x[..., fft_length // 2 : -(fft_length // 2)]
+    return x
+
+
 def rsqrt(x):
     return jax.lax.rsqrt(x)

--- a/keras_core/backend/jax/math.py
+++ b/keras_core/backend/jax/math.py
@@ -76,53 +76,6 @@ def extract_sequences(x, sequence_length, sequence_stride):
     return jnp.reshape(x, (*batch_shape, *x.shape[-2:]))
 
 
-def _overlap_sequences(x, sequence_stride):
-    # Ref: https://github.com/google/jax/blob/main/jax/_src/scipy/signal.py
-    *batch_shape, num_sequences, sequence_length = x.shape
-    if sequence_stride > sequence_length:
-        raise ValueError(
-            "`sequence_stride` must equal or less than x.shape[-1]. "
-            f"Received: sequence_stride={sequence_stride}, "
-            f"x.shape[-1]={sequence_length}"
-        )
-    if sequence_stride < (sequence_length / num_sequences):
-        raise ValueError(
-            "`sequence_stride` must equal or greater than "
-            "x.shape[-1] / x.shape[-2]. "
-            f"Received: sequence_stride={sequence_stride}, "
-            f"x.shape[-1]={sequence_length}, x.shape[-2]={num_sequences}"
-        )
-    flat_batchsize = math.prod(batch_shape)
-    x = jnp.reshape(x, (flat_batchsize, num_sequences, sequence_length))
-    output_size = sequence_stride * (num_sequences - 1) + sequence_length
-    nstep_per_segment = 1 + (sequence_length - 1) // sequence_stride
-    # Here, we use shorter notation for axes.
-    # B: batch_size, N: num_sequences, S: nstep_per_segment,
-    # T: sequence_length divided by S
-    padded_segment_len = nstep_per_segment * sequence_stride
-    x = jnp.pad(x, ((0, 0), (0, 0), (0, padded_segment_len - sequence_length)))
-    x = jnp.reshape(
-        x, (flat_batchsize, num_sequences, nstep_per_segment, sequence_stride)
-    )
-    # For obtaining shifted signals, this routine reinterprets flattened array
-    # with a shrinked axis.  With appropriate truncation/ padding, this
-    # operation pushes the last padded elements of the previous row to the head
-    # of the current row.
-    # See implementation of `overlap_and_add` in Tensorflow for details.
-    x = jnp.transpose(x, (0, 2, 1, 3))  # x: (B, S, N, T)
-    x = jnp.pad(x, ((0, 0), (0, 0), (0, num_sequences), (0, 0)))
-    # x: (B, S, N*2, T)
-    shrinked = x.shape[2] - 1
-    x = jnp.reshape(x, (flat_batchsize, -1))
-    x = x[:, : (nstep_per_segment * shrinked * sequence_stride)]
-    x = jnp.reshape(
-        x, (flat_batchsize, nstep_per_segment, shrinked * sequence_stride)
-    )
-    # Finally, sum shifted segments, and truncate results to the output_size.
-    x = jnp.sum(x, axis=1)[:, :output_size]
-    return jnp.reshape(x, tuple(batch_shape) + (-1,))
-
-
 def _get_complex_tensor_from_tuple(x):
     if not isinstance(x, (tuple, list)) or len(x) != 2:
         raise ValueError(
@@ -193,6 +146,7 @@ def stft(
                 "If a string is passed to `window`, it must be one of "
                 f'`"hann"`, `"hamming"`. Received: window={window}'
             )
+    x = convert_to_tensor(x)
 
     if center:
         pad_width = [(0, 0) for _ in range(len(x.shape))]
@@ -244,44 +198,43 @@ def istft(
     window="hann",
     center=True,
 ):
-    # ref:
-    # torch: aten/src/ATen/native/SpectralOps.cpp
-    # tf: tf.signal.inverse_stft_window_fn
-    x = irfft(x, fft_length)
+    x = _get_complex_tensor_from_tuple(x)
+    dtype = jnp.real(x).dtype
 
     expected_output_len = fft_length + sequence_stride * (x.shape[-2] - 1)
+    l_pad = (fft_length - sequence_length) // 2
+    r_pad = fft_length - sequence_length - l_pad
 
     if window is not None:
         if isinstance(window, str):
             win = convert_to_tensor(
-                scipy.signal.get_window(window, sequence_length), dtype=x.dtype
+                scipy.signal.get_window(window, sequence_length), dtype=dtype
             )
         else:
-            win = convert_to_tensor(window, dtype=x.dtype)
+            win = convert_to_tensor(window, dtype=dtype)
         if len(win.shape) != 1 or win.shape[-1] != sequence_length:
             raise ValueError(
                 "The shape of `window` must be equal to [sequence_length]."
                 f"Received: window shape={win.shape}"
             )
-        l_pad = (fft_length - sequence_length) // 2
-        r_pad = fft_length - sequence_length - l_pad
         win = jnp.pad(win, [[l_pad, r_pad]])
+    else:
+        win = jnp.ones((sequence_length + l_pad + r_pad), dtype=dtype)
 
-        # square and sum
-        _sequence_length = sequence_length + l_pad + r_pad
-        denom = jnp.square(win)
-        overlaps = -(-_sequence_length // sequence_stride)
-        denom = jnp.pad(
-            denom, [(0, overlaps * sequence_stride - _sequence_length)]
-        )
-        denom = jnp.reshape(denom, [overlaps, sequence_stride])
-        denom = jnp.sum(denom, 0, keepdims=True)
-        denom = jnp.tile(denom, [overlaps, 1])
-        denom = jnp.reshape(denom, [overlaps * sequence_stride])
-        win = jnp.divide(win, denom[:_sequence_length])
-        x = jnp.multiply(x, win)
+    x = jax.scipy.signal.istft(
+        x,
+        fs=1.0,
+        window=win,
+        nperseg=(sequence_length + l_pad + r_pad),
+        noverlap=(sequence_length + l_pad + r_pad - sequence_stride),
+        nfft=fft_length,
+        boundary=False,
+        time_axis=-2,
+        freq_axis=-1,
+    )[-1]
 
-    x = _overlap_sequences(x, sequence_stride)
+    # scale
+    x = x / win.sum() if window is not None else x / sequence_stride
 
     start = 0 if center is False else fft_length // 2
     if length is not None:

--- a/keras_core/backend/numpy/math.py
+++ b/keras_core/backend/numpy/math.py
@@ -200,12 +200,19 @@ def fft2(x):
 
 def rfft(x, fft_length=None):
     complex_output = np.fft.rfft(x, n=fft_length, axis=-1, norm="backward")
-    return np.real(complex_output), np.imag(complex_output)
+    # numpy always outputs complex128, so we need to recast the dtype
+    return (
+        np.real(complex_output).astype(x.dtype),
+        np.imag(complex_output).astype(x.dtype),
+    )
 
 
 def irfft(x, fft_length=None):
     complex_input = _get_complex_tensor_from_tuple(x)
-    return np.fft.irfft(complex_input, n=fft_length, axis=-1, norm="backward")
+    # numpy always outputs float64, so we need to recast the dtype
+    return np.fft.irfft(
+        complex_input, n=fft_length, axis=-1, norm="backward"
+    ).astype(x[0].dtype)
 
 
 def stft(
@@ -233,6 +240,7 @@ def stft(
         pad_width = [(0, 0) for _ in range(len(x.shape))]
         pad_width[-1] = (fft_length // 2, fft_length // 2)
         x = np.pad(x, pad_width, mode="reflect")
+
     x = extract_sequences(x, fft_length, sequence_stride)
 
     if window is not None:

--- a/keras_core/backend/numpy/math.py
+++ b/keras_core/backend/numpy/math.py
@@ -128,18 +128,30 @@ def extract_sequences(x, sequence_length, sequence_stride):
 
 def overlap_sequences(x, sequence_stride):
     # Ref: https://github.com/google/jax/blob/main/jax/_src/scipy/signal.py
-    *batch_shape, nframes, segment_len = x.shape
+    *batch_shape, num_sequences, sequence_length = x.shape
+    if sequence_stride > sequence_length:
+        raise ValueError(
+            "`sequence_stride` must not larger than x.shape[-1]. "
+            f"Received: sequence_stride={sequence_stride}, "
+            f"x.shape[-1]={sequence_length}"
+        )
+    if sequence_stride < (sequence_length / num_sequences):
+        raise ValueError(
+            "`sequence_stride` must not less than x.shape[-1] / x.shape[-2]. "
+            f"Received: sequence_stride={sequence_stride}, "
+            f"x.shape[-1]={sequence_length}, x.shape[-2]={num_sequences}"
+        )
     flat_batchsize = math.prod(batch_shape)
-    x = np.reshape(x, (flat_batchsize, nframes, segment_len))
-    output_size = sequence_stride * (nframes - 1) + segment_len
-    nstep_per_segment = 1 + (segment_len - 1) // sequence_stride
+    x = np.reshape(x, (flat_batchsize, num_sequences, sequence_length))
+    output_size = sequence_stride * (num_sequences - 1) + sequence_length
+    nstep_per_segment = 1 + (sequence_length - 1) // sequence_stride
     # Here, we use shorter notation for axes.
     # B: batch_size, N: nframes, S: nstep_per_segment,
     # T: segment_len divided by S
     padded_segment_len = nstep_per_segment * sequence_stride
-    x = np.pad(x, ((0, 0), (0, 0), (0, padded_segment_len - segment_len)))
+    x = np.pad(x, ((0, 0), (0, 0), (0, padded_segment_len - sequence_length)))
     x = np.reshape(
-        x, (flat_batchsize, nframes, nstep_per_segment, sequence_stride)
+        x, (flat_batchsize, num_sequences, nstep_per_segment, sequence_stride)
     )
     # For obtaining shifted signals, this routine reinterprets flattened array
     # with a shrinked axis.  With appropriate truncation/ padding, this
@@ -147,7 +159,7 @@ def overlap_sequences(x, sequence_stride):
     # of the current row.
     # See implementation of `overlap_and_add` in Tensorflow for details.
     x = x.transpose((0, 2, 1, 3))  # x: (B, S, N, T)
-    x = np.pad(x, ((0, 0), (0, 0), (0, nframes), (0, 0)))
+    x = np.pad(x, ((0, 0), (0, 0), (0, num_sequences), (0, 0)))
     # x: (B, S, N*2, T)
     shrinked = x.shape[2] - 1
     x = np.reshape(x, (flat_batchsize, -1))
@@ -264,12 +276,20 @@ def stft(
 
 
 def istft(
-    x, sequence_length, sequence_stride, fft_length, window="hann", center=True
+    x,
+    sequence_length,
+    sequence_stride,
+    fft_length,
+    length=None,
+    window="hann",
+    center=True,
 ):
     # ref:
     # torch: aten/src/ATen/native/SpectralOps.cpp
     # tf: tf.signal.inverse_stft_window_fn
     x = irfft(x, fft_length)
+
+    expected_output_len = fft_length + sequence_stride * (x.shape[-2] - 1)
 
     if window is not None:
         if isinstance(window, str):
@@ -303,6 +323,11 @@ def istft(
 
     x = overlap_sequences(x, sequence_stride)
 
-    if center:
-        x[..., fft_length // 2 : -(fft_length // 2)]
-    return x
+    start = 0 if center is False else fft_length // 2
+    if length is not None:
+        end = start + length
+    elif center:
+        end = -(fft_length // 2)
+    else:
+        end = expected_output_len
+    return x[..., start:end]

--- a/keras_core/backend/tensorflow/math.py
+++ b/keras_core/backend/tensorflow/math.py
@@ -142,7 +142,6 @@ def stft(
     l_pad = (fft_length - sequence_length) // 2
     r_pad = fft_length - sequence_length - l_pad
 
-    win = None
     if window is not None:
         if isinstance(window, str):
             if window == "hann":
@@ -164,6 +163,9 @@ def stft(
 
         def win(frame_step, dtype):
             return win_array
+
+    else:
+        win = None
 
     result = tf.signal.stft(
         x,

--- a/keras_core/backend/tensorflow/math.py
+++ b/keras_core/backend/tensorflow/math.py
@@ -170,5 +170,55 @@ def stft(
     return rfft(x, fft_length)
 
 
+def istft(
+    x, sequence_length, sequence_stride, fft_length, window="hann", center=True
+):
+    # ref:
+    # torch: aten/src/ATen/native/SpectralOps.cpp
+    # tf: tf.signal.inverse_stft_window_fn
+    x = irfft(x, fft_length)
+
+    if window is not None:
+        if isinstance(window, str):
+            if window == "hann":
+                win = tf.signal.hann_window(
+                    sequence_length, periodic=True, dtype=x.dtype
+                )
+            else:
+                win = tf.signal.hamming_window(
+                    sequence_length, periodic=True, dtype=x.dtype
+                )
+        else:
+            win = convert_to_tensor(window, dtype=x.dtype)
+        if len(win.shape) != 1 or win.shape[-1] != sequence_length:
+            raise ValueError(
+                "The shape of `window` must be equal to [sequence_length]."
+                f"Received: window shape={win.shape}"
+            )
+        l_pad = (fft_length - sequence_length) // 2
+        r_pad = fft_length - sequence_length - l_pad
+        win = tf.pad(win, [[l_pad, r_pad]])
+
+        # square and sum
+        _sequence_length = sequence_length + l_pad + r_pad
+        denom = tf.square(win)
+        overlaps = -(-_sequence_length // sequence_stride)
+        denom = tf.pad(
+            denom, [(0, overlaps * sequence_stride - _sequence_length)]
+        )
+        denom = tf.reshape(denom, [overlaps, sequence_stride])
+        denom = tf.reduce_sum(denom, 0, keepdims=True)
+        denom = tf.tile(denom, [overlaps, 1])
+        denom = tf.reshape(denom, [overlaps * sequence_stride])
+        win = tf.divide(win, denom[:_sequence_length])
+        x = tf.multiply(x, win)
+
+    x = overlap_sequences(x, sequence_stride)
+
+    if center:
+        x[..., fft_length // 2 : -(fft_length // 2)]
+    return x
+
+
 def rsqrt(x):
     return tf.math.rsqrt(x)

--- a/keras_core/backend/torch/math.py
+++ b/keras_core/backend/torch/math.py
@@ -135,7 +135,7 @@ def extract_sequences(x, sequence_length, sequence_stride):
 def overlap_sequences(x, sequence_stride):
     # Ref: https://github.com/google/jax/blob/main/jax/_src/scipy/signal.py
     x = convert_to_tensor(x)
-    *batch_shape, num_sequences, sequence_length = x.size()
+    *batch_shape, num_sequences, sequence_length = x.shape
     if sequence_stride > sequence_length:
         raise ValueError(
             "`sequence_stride` must equal or less than x.shape[-1]. "


### PR DESCRIPTION
Similar to #717 
This PR mainly implements `istft`. This allows us to reconstruct sequences from the frequency domain.

Notes: some clean up (e.g. `a` to `x`, `jax.numpy` to `jnp`) included, I can revert it if it is not necessary

```bash
# output
# lr means librosa's output
# needs `center=True` to get reasonable result
ori. vs. lr RMSE: 3.663534e-09
ori. vs. np RMSE: 4.223074e-09
ori. vs. jax RMSE: 8.257622e-09
ori. vs. tf RMSE: 1.0522875e-08
ori. vs. torch RMSE: 8.910108e-09
```

Reconstructed results:
![output](https://github.com/keras-team/keras-core/assets/20734616/f166f889-980f-496f-ab30-b8c17f462f02)



A standalone script:
(needs `pip install librosa matplotlib`)

```python
import jax
import librosa as lr
import matplotlib.pyplot as plt
import numpy as np
import tensorflow as tf

from keras_core.backend.jax.math import istft as jax_istft
from keras_core.backend.numpy.math import istft as np_istft
from keras_core.backend.tensorflow.math import istft as tf_istft
from keras_core.backend.torch.math import istft as torch_istft

# load waveform from librosa
waveform, samplerate = lr.load(lr.util.example("trumpet"))
waveform = waveform.astype(np.float32)
n = len(waveform)

# produce stft output from librosa with random parameters
sequence_length = 234
sequence_stride = 123
fft_length = 567
length = n
center = True

lr_stfts = lr.core.stft(
    waveform,
    hop_length=sequence_stride,
    win_length=sequence_length,
    n_fft=fft_length,
    center=center,
)
lr_stfts = np.transpose(lr_stfts)
real_out, imag_out = np.real(lr_stfts), np.imag(lr_stfts)

# reference istft output from librosa
lr_out = lr.core.istft(
    np.transpose(lr_stfts),
    hop_length=sequence_stride,
    win_length=sequence_length,
    n_fft=fft_length,
    length=length,
    center=center,
)
lr_rmse = np.sqrt(np.mean((lr_out - waveform) ** 2))
print("ori. vs. lr RMSE:", lr_rmse)

# compute istft with keras-core
arguments = {
    "sequence_length": sequence_length,
    "sequence_stride": sequence_stride,
    "fft_length": fft_length,
    "length": length,
    "center": center,
}
np_out = np_istft((real_out, imag_out), **arguments)
tf_out = tf.function(tf_istft, jit_compile=True)(
    (real_out, imag_out), **arguments
).numpy()
torch_out = torch_istft((real_out, imag_out), **arguments).numpy()
jax_out = jax.jit(lambda x: jax_istft(x, **arguments))((real_out, imag_out))
jax_out = np.array(jax_out)

# RMSE between all backends and librosa
np_rmse = np.sqrt(np.mean((np_out - waveform) ** 2))
print("ori. vs. np RMSE:", np_rmse)
jax_rmse = np.sqrt(np.mean((jax_out - waveform) ** 2))
print("ori. vs. jax RMSE:", jax_rmse)
tf_rmse = np.sqrt(np.mean((tf_out - waveform) ** 2))
print("ori. vs. tf RMSE:", tf_rmse)
torch_rmse = np.sqrt(np.mean((torch_out - waveform) ** 2))
print("ori. vs. torch RMSE:", torch_rmse)

# visaulization
fig, ax_dict = plt.subplot_mosaic(
    [["A", "LR", "B", "C", "D", "E"]], figsize=(30, 6)
)
ax_dict["A"].set_title("Original Waveform")
ax_dict["A"].plot(waveform)
ax_dict["LR"].set_title("Librosa")
ax_dict["LR"].plot(lr_out)
ax_dict["B"].set_title("NumPy")
ax_dict["B"].plot(np_out)
ax_dict["C"].set_title("JAX")
ax_dict["C"].plot(jax_out)
ax_dict["D"].set_title("TensorFlow")
ax_dict["D"].plot(tf_out)
ax_dict["E"].set_title("Torch")
ax_dict["E"].plot(torch_out)
plt.tight_layout()
plt.savefig("output.png")

```
