### PR TITLE
Fixed uniqueness bug and bits->bytes

### DIFF
--- a/keras_core/utils/summary_utils.py
+++ b/keras_core/utils/summary_utils.py
@@ -30,15 +30,14 @@ def weight_memory_size(weights):
     Returns:
         The total memory size (in Bytes) of the weights.
     """
-    unique_weights_ids = set(id(w) for w in weights)
-    unique_weights = [w for w in weights if id(w) in unique_weights_ids]
+    unique_weights = {id(w): w for w in weights}.values()
     total_memory_size = 0
     for w in unique_weights:
         weight_shape = math.prod(w.shape)
         dtype = backend.standardize_dtype(w.dtype)
         per_param_size = dtype_utils.dtype_size(dtype)
         total_memory_size += weight_shape * per_param_size
-    return total_memory_size
+    return total_memory_size / 8
 
 
 def readable_memory_size(weight_memory_size):


### PR DESCRIPTION
This fixes two issues:
1. The original unique-ifying code did nothing. This is fixed.
2. The return values are now in bytes, consistent with the documentation and usage elsewhere in keras-core.