### PR TITLE
An attempt to add MPS device to torch backend

### DIFF
--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -13,7 +13,9 @@ from keras_core.backend.common.stateless_scope import StatelessScope
 from keras_core.utils.nest import pack_sequence_as
 
 DYNAMIC_SHAPES_OK = True
-# The operator 'aten::_foreach_mul_.Scalar' is not currently implemented for the MPS device, check https://github.com/pytorch/pytorch/issues/77764.
+# Some operators such as 'aten::_foreach_mul_.Scalar'
+# are not currently implemented for the MPS device.
+# check https://github.com/pytorch/pytorch/issues/77764.
 if (
     torch.backends.mps.is_available()
     and os.getenv("PYTORCH_ENABLE_MPS_FALLBACK") == "1"

--- a/keras_core/backend/torch/core.py
+++ b/keras_core/backend/torch/core.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 
 import numpy as np
 import torch
@@ -12,7 +13,16 @@ from keras_core.backend.common.stateless_scope import StatelessScope
 from keras_core.utils.nest import pack_sequence_as
 
 DYNAMIC_SHAPES_OK = True
-DEFAULT_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+# The operator 'aten::_foreach_mul_.Scalar' is not currently implemented for the MPS device, check https://github.com/pytorch/pytorch/issues/77764.
+if (
+    torch.backends.mps.is_available()
+    and os.getenv("PYTORCH_ENABLE_MPS_FALLBACK") == "1"
+):
+    DEFAULT_DEVICE = "mps"
+elif torch.cuda.is_available():
+    DEFAULT_DEVICE = "cuda"
+else:
+    DEFAULT_DEVICE = "cpu"
 
 TORCH_DTYPES = {
     "float16": torch.float16,
@@ -145,7 +155,7 @@ def convert_to_numpy(x):
             if x.requires_grad:
                 x = x.detach()
             # Tensor has to be moved to CPU before converting to numpy.
-            if x.is_cuda:
+            if x.is_cuda or x.is_mps:
                 x = x.cpu()
         return np.array(x)
 


### PR DESCRIPTION
I attempted to incorporate MPS device and have already conducted testing across various models, datasets, and optimizers. However, I've encountered two current challenges:

1- There are certain performance issues present compared to CPU, even when excluding Keras Core from the equation, and using torch only
2- Some operators are not supported on MPS, and a temporary workaround involves setting PYTORCH_ENABLE_MPS_FALLBACK, though this does come at the cost of reduced speed.