### PR TITLE
Fix bug + Add Tests + Enhance docstrings (shape_equal)

### DIFF
--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -226,8 +226,8 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         True
         >>> shape_equal((32, 64, 128), (32, 63, 127), axis=(1, 2))
         True
-        >>> shape_equal((32, 64, 128), (32, 63, 127), axis=1)
-        False
+        >>> shape_equal((32, 64, 128), (32, 63, 127), axis=[1,2])
+        True
         >>> shape_equal((32, 64), (32, 64, 128))
         False
     """

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -203,14 +203,14 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         shape1: A list or tuple of integers for first shape to be compared.
         shape2: A list or tuple of integers for second shape to be compared.
         axis: An integer, list, or tuple of integers (optional):
-            Axes to ignore during comparison. Default is 'None'.
-        allow_none (bool, optional): If 'True', allows 'None' in a shape
+            Axes to ignore during comparison. Default is `None`.
+        allow_none (bool, optional): If `True`, allows `None` in a shape
             to match any value in the corresponding position of the other shape.
-            Default is 'True'.
+            Default is `True`.
 
     Returns:
-        bool: 'True' if shapes are considered equal based on the criteria,
-        'False' otherwise.
+        bool: `True` if shapes are considered equal based on the criteria,
+        `False` otherwise.
 
     Examples:
 

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -202,7 +202,7 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
     Args:
         shape1: A list or tuple of integers for first shape to be compared.
         shape2: A list or tuple of integers for second shape to be compared.
-        axis: A list or tuple of integers (optional):
+        axis: An integer, list, or tuple of integers (optional):
             Axes to ignore during comparison.Default is None.
         allow_none (bool, optional): If True, allows None in a shape to match
             any value in the corresponding position of the other shape.
@@ -222,23 +222,45 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         True
         >>> shape_equal((32, 64, None), (32, 64, 128), allow_none=False)
         False
-        >>> shape_equal((32, 64, 128), (32, 63, 128), axis=[1])
+        >>> shape_equal((32, 64, 128), (32, 63, 128), axis=1)
         True
         >>> shape_equal((32, 64, 128), (32, 63, 127), axis=(1, 2))
         True
-        >>> shape_equal((32, 64, 128), (32, 63, 127), axis=[1])
+        >>> shape_equal((32, 64, 128), (32, 63, 127), axis=1)
         False
         >>> shape_equal((32, 64), (32, 64, 128))
         False
     """
+    def shape_equal(shape1, shape2, axis=None, allow_none=True):
+    """ 
+    Check if two shapes are equal.
+
+    Args:
+        shape1: A list or tuple of integers for the first shape to be compared.
+        shape2: A list or tuple of integers for the second shape to be compared.
+        axis: An integer, list, or tuple of integers (optional):
+            Axes to ignore during comparison. Default is None.
+        allow_none (bool, optional): If True, allows None in a shape to match
+            any value in the corresponding position of the other shape.
+            Default is True.
+
+    Returns:
+        bool: True if shapes are considered equal based on the criteria,
+        False otherwise.
+    """
     if len(shape1) != len(shape2):
         return False
+
     shape1 = list(shape1)
     shape2 = list(shape2)
+
     if axis is not None:
+        if isinstance(axis, int):
+            axis = [axis]
         for ax in axis:
             shape1[ax] = -1
             shape2[ax] = -1
+
     if allow_none:
         for i in range(len(shape1)):
             if shape1[i] is None:
@@ -247,7 +269,6 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
                 shape2[i] = shape1[i]
 
     return shape1 == shape2
-
 
 class Absolute(Operation):
     def call(self, x):

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -240,7 +240,6 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
     """
     # Check if both shapes are None, in which case they are considered equal.
     if shape1 is None and shape2 is None:
-        print("Both shapes are None.")
         return True
     # If one of the shapes is None and the other isn't, they are not equal.
     if (shape1 is None and shape2 is not None) or (

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -203,7 +203,7 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
     Args:
         shape1: A list or tuple of integers for first shape to be compared.
         shape2: A list or tuple of integers for second shape to be compared.
-        axis: integer or list or tuple of integers (optional):
+        axis: A list or tuple of integers (optional):
             Axes to ignore during comparison.Default is None.
         allow_none (bool, optional): If True, allows None in a shape to match
             any value in the corresponding position of the other shape.
@@ -227,11 +227,11 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         False
 
         # Ignoring specific axes with the axis parameter
-        >>> shape_equal((32, 64, 128), (32, 63, 128), axis=1)
+        >>> shape_equal((32, 64, 128), (32, 63, 128), axis=[1])
         True
         >>> shape_equal((32, 64, 128), (32, 63, 127), axis=(1, 2))
         True
-        >>> shape_equal((32, 64, 128), (32, 63, 127), axis=1)
+        >>> shape_equal((32, 64, 128), (32, 63, 127), axis=[1])
         False
 
         # Comparing shapes of different lengths

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -201,10 +201,10 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
     allow None as a wildcard.
 
     Args:
-        shape1: A list or tuple of integers representing the first shape to be compared.
-        shape2: A list or tuple of integers representing the second shape to be compared.
-        axis: integer or list or tuple of integers (optional): Axes to ignore during comparison.
-            Default is None.
+        shape1: A list or tuple of integers for first shape to be compared.
+        shape2: A list or tuple of integers for second shape to be compared.
+        axis: integer or list or tuple of integers (optional):
+            Axes to ignore during comparison.Default is None.
         allow_none (bool, optional): If True, allows None in a shape to match
             any value in the corresponding position of the other shape.
             Default is True.

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -201,9 +201,9 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
     allow None as a wildcard.
 
     Args:
-        shape1 (list or tuple): First shape.
-        shape2 (list or tuple): Second shape.
-        axis (int, list, or tuple, optional): Axes to ignore during comparison.
+        shape1: A list or tuple of integers representing the first shape to be compared.
+        shape2: A list or tuple of integers representing the second shape to be compared.
+        axis: integer or list or tuple of integers (optional): Axes to ignore during comparison.
             Default is None.
         allow_none (bool, optional): If True, allows None in a shape to match
             any value in the corresponding position of the other shape.

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -197,39 +197,39 @@ def broadcast_shapes(shape1, shape2):
 
 
 def shape_equal(shape1, shape2, axis=None, allow_none=True):
-    """Check if two shapes are equal
+    """Check if two shapes are equal.
 
     Args:
         shape1: A list or tuple of integers for first shape to be compared.
         shape2: A list or tuple of integers for second shape to be compared.
         axis: An integer, list, or tuple of integers (optional):
-            Axes to ignore during comparison.Default is None.
-        allow_none (bool, optional): If True, allows None in a shape to match
+            Axes to ignore during comparison. Default is 'None'.
+        allow_none (bool, optional): If 'True', allows 'None' in a shape to match
             any value in the corresponding position of the other shape.
-            Default is True.
+            Default is 'True'.
 
     Returns:
-        bool: True if shapes are considered equal based on the criteria,
-        False otherwise.
+        bool: 'True' if shapes are considered equal based on the criteria,
+        'False' otherwise.
 
     Examples:
 
-        >>> shape_equal((32, 64, 128), (32, 64, 128))
-        True
-        >>> shape_equal((32, 64, 128), (32, 64, 127))
-        False
-        >>> shape_equal((32, 64, None), (32, 64, 128), allow_none=True)
-        True
-        >>> shape_equal((32, 64, None), (32, 64, 128), allow_none=False)
-        False
-        >>> shape_equal((32, 64, 128), (32, 63, 128), axis=1)
-        True
-        >>> shape_equal((32, 64, 128), (32, 63, 127), axis=(1, 2))
-        True
-        >>> shape_equal((32, 64, 128), (32, 63, 127), axis=[1,2])
-        True
-        >>> shape_equal((32, 64), (32, 64, 128))
-        False
+    >>> shape_equal((32, 64, 128), (32, 64, 128))
+    True
+    >>> shape_equal((32, 64, 128), (32, 64, 127))
+    False
+    >>> shape_equal((32, 64, None), (32, 64, 128), allow_none=True)
+    True
+    >>> shape_equal((32, 64, None), (32, 64, 128), allow_none=False)
+    False
+    >>> shape_equal((32, 64, 128), (32, 63, 128), axis=1)
+    True
+    >>> shape_equal((32, 64, 128), (32, 63, 127), axis=(1, 2))
+    True
+    >>> shape_equal((32, 64, 128), (32, 63, 127), axis=[1,2])
+    True
+    >>> shape_equal((32, 64), (32, 64, 128))
+    False
     """
     if len(shape1) != len(shape2):
         return False

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -197,8 +197,7 @@ def broadcast_shapes(shape1, shape2):
 
 
 def shape_equal(shape1, shape2, axis=None, allow_none=True):
-    """Check if two shapes are equal, with options to ignore certain axes and to
-    allow None as a wildcard.
+    """Check if two shapes are equal
 
     Args:
         shape1: A list or tuple of integers for first shape to be compared.
@@ -214,27 +213,21 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         False otherwise.
 
     Examples:
-        # Basic equality check
+
         >>> shape_equal((32, 64, 128), (32, 64, 128))
         True
         >>> shape_equal((32, 64, 128), (32, 64, 127))
         False
-
-        # Using allow_none option
         >>> shape_equal((32, 64, None), (32, 64, 128), allow_none=True)
         True
         >>> shape_equal((32, 64, None), (32, 64, 128), allow_none=False)
         False
-
-        # Ignoring specific axes with the axis parameter
         >>> shape_equal((32, 64, 128), (32, 63, 128), axis=[1])
         True
         >>> shape_equal((32, 64, 128), (32, 63, 127), axis=(1, 2))
         True
         >>> shape_equal((32, 64, 128), (32, 63, 127), axis=[1])
         False
-
-        # Comparing shapes of different lengths
         >>> shape_equal((32, 64), (32, 64, 128))
         False
     """

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -275,9 +275,10 @@ def absolute(x):
         An array containing the absolute value of each element in `x`.
 
     Example:
+
     >>> x = keras_core.ops.convert_to_tensor([-1.2, 1.2])
     >>> keras_core.ops.absolute(x)
-    array([1.2 1.2], shape=(2,), dtype=float32)
+    array([1.2, 1.2], dtype=float32)
     """
     if any_symbolic_tensors((x,)):
         return Absolute().symbolic_call(x)

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -204,8 +204,8 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         shape2: A list or tuple of integers for second shape to be compared.
         axis: An integer, list, or tuple of integers (optional):
             Axes to ignore during comparison. Default is 'None'.
-        allow_none (bool, optional): If 'True', allows 'None' in a shape to match
-            any value in the corresponding position of the other shape.
+        allow_none (bool, optional): If 'True', allows 'None' in a shape
+            to match any value in the corresponding position of the other shape.
             Default is 'True'.
 
     Returns:

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -238,48 +238,22 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         >>> shape_equal((32, 64), (32, 64, 128))
         False
     """
-    # Check if both shapes are None, in which case they are considered equal.
-    if shape1 is None and shape2 is None:
-        return True
-    # If one of the shapes is None and the other isn't, they are not equal.
-    if (shape1 is None and shape2 is not None) or (
-        shape1 is not None and shape2 is None
-    ):
+    if len(shape1) != len(shape2):
         return False
-    # Convert shapes to lists for easier manipulation.
     shape1 = list(shape1)
     shape2 = list(shape2)
-
-    # Handle the axis parameter. If provided, it specifies the axes that should be ignored during comparison.
     if axis is not None:
-        # If only a single axis is provided as an integer, convert it to a list.
-        if isinstance(axis, int):
-            axis = [axis]
-        # Check if the provided axis/axes exist in both shapes.
-        if any(ax >= len(shape1) or ax >= len(shape2) for ax in axis):
-            return False
-        # Ignore the specified axes by setting their values to -1 in both shapes.
         for ax in axis:
             shape1[ax] = -1
             shape2[ax] = -1
-    # If the shapes have different lengths, they aren't equal.
-    if len(shape1) != len(shape2):
-        return False
-    # The allow_none parameter lets None in one shape match any value in the other.
     if allow_none:
-        for s1, s2 in zip(
-            shape1, shape2
-        ):  # Use zip to safely iterate over both lists in parallel.
-            # Replace None with the corresponding value from the other shape.
-            if s1 is None:
-                s1 = s2
-            if s2 is None:
-                s2 = s1
-            # If after possible replacement the dimensions are still not the same, the shapes are not equal.
-            if s1 != s2:
-                return False
-    # If all conditions have passed, the shapes are considered equal.
-    return True
+        for i in range(len(shape1)):
+            if shape1[i] is None:
+                shape1[i] = shape2[i]
+            if shape2[i] is None:
+                shape2[i] = shape1[i]
+
+    return shape1 == shape2
 
 
 class Absolute(Operation):

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -231,23 +231,6 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         >>> shape_equal((32, 64), (32, 64, 128))
         False
     """
-    def shape_equal(shape1, shape2, axis=None, allow_none=True):
-    """ 
-    Check if two shapes are equal.
-
-    Args:
-        shape1: A list or tuple of integers for the first shape to be compared.
-        shape2: A list or tuple of integers for the second shape to be compared.
-        axis: An integer, list, or tuple of integers (optional):
-            Axes to ignore during comparison. Default is None.
-        allow_none (bool, optional): If True, allows None in a shape to match
-            any value in the corresponding position of the other shape.
-            Default is True.
-
-    Returns:
-        bool: True if shapes are considered equal based on the criteria,
-        False otherwise.
-    """
     if len(shape1) != len(shape2):
         return False
 
@@ -269,6 +252,7 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
                 shape2[i] = shape1[i]
 
     return shape1 == shape2
+
 
 class Absolute(Operation):
     def call(self, x):

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -238,28 +238,55 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         >>> shape_equal((32, 64), (32, 64, 128))
         False
     """
+    # Check if both shapes are None, in which case they are considered equal.
+    if shape1 is None and shape2 is None:
+        print("Both shapes are None.")
+        return True
+    # If one of the shapes is None and the other isn't, they are not equal.
+    if (shape1 is None and shape2 is not None) or (
+        shape1 is not None and shape2 is None
+    ):
+        return False
+    # Convert shapes to lists for easier manipulation.
     shape1 = list(shape1)
     shape2 = list(shape2)
 
+    # Handle the axis parameter. If provided, it specifies the axes that should be ignored during comparison.
     if axis is not None:
+        # If only a single axis is provided as an integer, convert it to a list.
         if isinstance(axis, int):
             axis = [axis]
+        # Check if axis is a valid list/tuple of integers.
         elif not isinstance(axis, (list, tuple)) or not all(
             isinstance(ax, int) for ax in axis
         ):
             raise ValueError("axis must be an int or list/tuple of ints")
+        # Check if the provided axis/axes exist in both shapes.
+        if any(ax >= len(shape1) or ax >= len(shape2) for ax in axis):
+            return False
+        # Ignore the specified axes by setting their values to -1 in both shapes.
         for ax in axis:
             shape1[ax] = -1
             shape2[ax] = -1
-
+    # If the shapes have different lengths, they aren't equal.
+    if len(shape1) != len(shape2):
+        return False
+    # The allow_none parameter lets None in one shape match any value in the other.
     if allow_none:
-        for i in range(len(shape1)):
-            if shape1[i] is None:
-                shape1[i] = shape2[i]
-            if shape2[i] is None:
-                shape2[i] = shape1[i]
+        for s1, s2 in zip(
+            shape1, shape2
+        ):  # Use zip to safely iterate over both lists in parallel.
+            # Replace None with the corresponding value from the other shape.
+            if s1 is None:
+                s1 = s2
+            if s2 is None:
+                s2 = s1
+            # If after possible replacement the dimensions are still not the same, the shapes are not equal.
+            if s1 != s2:
+                return False
+    # If all conditions have passed, the shapes are considered equal.
+    return True
 
-    return shape1 == shape2
 
 class Absolute(Operation):
     def call(self, x):

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -197,24 +197,61 @@ def broadcast_shapes(shape1, shape2):
 
 
 def shape_equal(shape1, shape2, axis=None, allow_none=True):
-    """Check if two shapes are equal.
+    """Check if two shapes are equal, with options to ignore certain axes and to
+    allow None as a wildcard.
 
     Args:
-        shape1: A tuple or list of integers.
-        shape2: A tuple or list of integers.
-        axis: int or list/tuple of ints, defaults to `None`. If specified, the
-            shape check will ignore the axes specified by `axis`.
-        allow_none: bool, defaults to `True`. If `True`, `None` in the shape
-            will match any value.
+        shape1 (list or tuple): First shape.
+        shape2 (list or tuple): Second shape.
+        axis (int, list, or tuple, optional): Axes to ignore during comparison.
+            Default is None.
+        allow_none (bool, optional): If True, allows None in a shape to match
+            any value in the corresponding position of the other shape.
+            Default is True.
+
+    Returns:
+        bool: True if shapes are considered equal based on the criteria,
+        False otherwise.
+
+    Examples:
+        # Basic equality check
+        >>> shape_equal((32, 64, 128), (32, 64, 128))
+        True
+        >>> shape_equal((32, 64, 128), (32, 64, 127))
+        False
+
+        # Using allow_none option
+        >>> shape_equal((32, 64, None), (32, 64, 128), allow_none=True)
+        True
+        >>> shape_equal((32, 64, None), (32, 64, 128), allow_none=False)
+        False
+
+        # Ignoring specific axes with the axis parameter
+        >>> shape_equal((32, 64, 128), (32, 63, 128), axis=1)
+        True
+        >>> shape_equal((32, 64, 128), (32, 63, 127), axis=(1, 2))
+        True
+        >>> shape_equal((32, 64, 128), (32, 63, 127), axis=1)
+        False
+
+        # Comparing shapes of different lengths
+        >>> shape_equal((32, 64), (32, 64, 128))
+        False
     """
-    if len(shape1) != len(shape2):
-        return False
     shape1 = list(shape1)
     shape2 = list(shape2)
+    
     if axis is not None:
+        if isinstance(axis, int):
+            axis = [axis]
+        elif not isinstance(axis, (list, tuple)) or not all(
+            isinstance(ax, int) for ax in axis
+        ):
+            raise ValueError("axis must be an int or list/tuple of ints")
         for ax in axis:
             shape1[ax] = -1
             shape2[ax] = -1
+
     if allow_none:
         for i in range(len(shape1)):
             if shape1[i] is None:
@@ -223,7 +260,6 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
                 shape2[i] = shape1[i]
 
     return shape1 == shape2
-
 
 class Absolute(Operation):
     def call(self, x):

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -255,11 +255,6 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         # If only a single axis is provided as an integer, convert it to a list.
         if isinstance(axis, int):
             axis = [axis]
-        # Check if axis is a valid list/tuple of integers.
-        elif not isinstance(axis, (list, tuple)) or not all(
-            isinstance(ax, int) for ax in axis
-        ):
-            raise ValueError("axis must be an int or list/tuple of ints")
         # Check if the provided axis/axes exist in both shapes.
         if any(ax >= len(shape1) or ax >= len(shape2) for ax in axis):
             return False

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -240,7 +240,7 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
     """
     shape1 = list(shape1)
     shape2 = list(shape2)
-    
+
     if axis is not None:
         if isinstance(axis, int):
             axis = [axis]

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -320,7 +320,7 @@ def add(x1, x2):
     >>> x1 = keras_core.ops.convert_to_tensor([1, 4])
     >>> x2 = keras_core.ops.convert_to_tensor([5, 6])
     >>> keras_core.ops.add(x1, x2)
-    array([ 6 10], shape=(2,), dtype=int32)
+    array([6, 10], dtype=int32)
 
     `keras_core.ops.add` also broadcasts shapes:
     >>> x1 = keras_core.ops.convert_to_tensor(

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -276,10 +276,10 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         self.assertFalse(knp.shape_equal(x, y))
 
     def test_shape_equal_ignore_axes(self):
-        x = KerasTensor([3, 4, 5])
-        y = KerasTensor([3, 6, 5])
+        x = KerasTensor([3, 4, 5]).shape
+        y = KerasTensor([3, 6, 5]).shape
         self.assertTrue(knp.shape_equal(x, y, axis=1))
-        y = KerasTensor([3, 6, 7])
+        y = KerasTensor([3, 6, 7]).shape
         self.assertTrue(knp.shape_equal(x, y, axis=(1, 2)))
         self.assertFalse(knp.shape_equal(x, y, axis=1))
 

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -257,6 +257,31 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         y = KerasTensor((2, None))
         self.assertEqual(knp.logical_xor(x, y).shape, (2, 3))
 
+    def test_shape_equal_basic_equality(self):
+        x = KerasTensor([3, 4])
+        y = KerasTensor([3, 4])
+        self.assertTrue(knp.shape_equal(x, y))
+        y = KerasTensor([3, 5])
+        self.assertFalse(knp.shape_equal(x, y))
+
+    def test_shape_equal_allow_none(self):
+       x = KerasTensor([3, 4, None])
+       y = KerasTensor([3, 4, 5])
+       self.assertTrue(knp.shape_equal(x, y, allow_none=True))
+       self.assertFalse(knp.shape_equal(x, y, allow_none=False))
+
+    def test_shape_equal_ignore_axes(self):
+       x = KerasTensor([3, 4, 5])
+       y = KerasTensor([3, 6, 5])
+       self.assertTrue(knp.shape_equal(x, y, axis=1))
+       y = KerasTensor([3, 6, 7])
+       self.assertTrue(knp.shape_equal(x, y, axis=(1, 2)))
+       self.assertFalse(knp.shape_equal(x, y, axis=1))
+
+    def test_shape_equal_different_shape_lengths(self):
+       x = KerasTensor([3, 4])
+       y = KerasTensor([3, 4, 5])
+       self.assertFalse(knp.shape_equal(x, y))
 
 class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
     def test_add(self):

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -275,6 +275,14 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         y = KerasTensor([3, 4, 5]).shape
         self.assertFalse(knp.shape_equal(x, y))
 
+    def test_shape_equal_ignore_axes(self):
+        x = KerasTensor([3, 4, 5])
+        y = KerasTensor([3, 6, 5])
+        self.assertTrue(knp.shape_equal(x, y, axis=1))
+        y = KerasTensor([3, 6, 7])
+        self.assertTrue(knp.shape_equal(x, y, axis=(1, 2)))
+        self.assertFalse(knp.shape_equal(x, y, axis=1))
+
 
 class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
     def test_add(self):

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -265,23 +265,24 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         self.assertFalse(knp.shape_equal(x, y))
 
     def test_shape_equal_allow_none(self):
-       x = KerasTensor([3, 4, None])
-       y = KerasTensor([3, 4, 5])
-       self.assertTrue(knp.shape_equal(x, y, allow_none=True))
-       self.assertFalse(knp.shape_equal(x, y, allow_none=False))
+        x = KerasTensor([3, 4, None])
+        y = KerasTensor([3, 4, 5])
+        self.assertTrue(knp.shape_equal(x, y, allow_none=True))
+        self.assertFalse(knp.shape_equal(x, y, allow_none=False))
 
     def test_shape_equal_ignore_axes(self):
-       x = KerasTensor([3, 4, 5])
-       y = KerasTensor([3, 6, 5])
-       self.assertTrue(knp.shape_equal(x, y, axis=1))
-       y = KerasTensor([3, 6, 7])
-       self.assertTrue(knp.shape_equal(x, y, axis=(1, 2)))
-       self.assertFalse(knp.shape_equal(x, y, axis=1))
+        x = KerasTensor([3, 4, 5])
+        y = KerasTensor([3, 6, 5])
+        self.assertTrue(knp.shape_equal(x, y, axis=1))
+        y = KerasTensor([3, 6, 7])
+        self.assertTrue(knp.shape_equal(x, y, axis=(1, 2)))
+        self.assertFalse(knp.shape_equal(x, y, axis=1))
 
     def test_shape_equal_different_shape_lengths(self):
-       x = KerasTensor([3, 4])
-       y = KerasTensor([3, 4, 5])
-       self.assertFalse(knp.shape_equal(x, y))
+        x = KerasTensor([3, 4])
+        y = KerasTensor([3, 4, 5])
+        self.assertFalse(knp.shape_equal(x, y))
+
 
 class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
     def test_add(self):

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -258,29 +258,29 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.logical_xor(x, y).shape, (2, 3))
 
     def test_shape_equal_basic_equality(self):
-        x = KerasTensor([3, 4])
-        y = KerasTensor([3, 4])
+        x = KerasTensor([3, 4]).shape
+        y = KerasTensor([3, 4]).shape
         self.assertTrue(knp.shape_equal(x, y))
-        y = KerasTensor([3, 5])
+        y = KerasTensor([3, 5]).shape
         self.assertFalse(knp.shape_equal(x, y))
 
     def test_shape_equal_allow_none(self):
-        x = KerasTensor([3, 4, None])
-        y = KerasTensor([3, 4, 5])
+        x = KerasTensor([3, 4, None]).shape
+        y = KerasTensor([3, 4, 5]).shape
         self.assertTrue(knp.shape_equal(x, y, allow_none=True))
         self.assertFalse(knp.shape_equal(x, y, allow_none=False))
 
     def test_shape_equal_ignore_axes(self):
-        x = KerasTensor([3, 4, 5])
-        y = KerasTensor([3, 6, 5])
+        x = KerasTensor([3, 4, 5]).shape
+        y = KerasTensor([3, 6, 5]).shape
         self.assertTrue(knp.shape_equal(x, y, axis=1))
-        y = KerasTensor([3, 6, 7])
+        y = KerasTensor([3, 6, 7]).shape
         self.assertTrue(knp.shape_equal(x, y, axis=(1, 2)))
         self.assertFalse(knp.shape_equal(x, y, axis=1))
 
     def test_shape_equal_different_shape_lengths(self):
-        x = KerasTensor([3, 4])
-        y = KerasTensor([3, 4, 5])
+        x = KerasTensor([3, 4]).shape
+        y = KerasTensor([3, 4, 5]).shape
         self.assertFalse(knp.shape_equal(x, y))
 
 

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -270,14 +270,6 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         self.assertTrue(knp.shape_equal(x, y, allow_none=True))
         self.assertFalse(knp.shape_equal(x, y, allow_none=False))
 
-    def test_shape_equal_ignore_axes(self):
-        x = KerasTensor([3, 4, 5]).shape
-        y = KerasTensor([3, 6, 5]).shape
-        self.assertTrue(knp.shape_equal(x, y, axis=1))
-        y = KerasTensor([3, 6, 7]).shape
-        self.assertTrue(knp.shape_equal(x, y, axis=(1, 2)))
-        self.assertFalse(knp.shape_equal(x, y, axis=1))
-
     def test_shape_equal_different_shape_lengths(self):
         x = KerasTensor([3, 4]).shape
         y = KerasTensor([3, 4, 5]).shape


### PR DESCRIPTION
**Bug Fix:**

In `shape_equal `function, using `axis=1` resulted in the `error: TypeError: 'int' object is not iterable.`
but  `axis=[1] `worked correctly.

After hours of trying  :)  the issue has been resolved, and now an integer, list, or tuple of integers  work as expected and documented.


**Improved Docstrings:**
The documentation for the shape_equal function has been enhanced. It now provides a more in-depth description and includes illustrative examples.

**Additional Tests:**

A new set of tests has been added to ensure the proper functionality of the `shape_equal `function.
Why do we need tests for the `shape_equal` function? Because there are 7 other functions depend on it:

1. Append ( )
2. Average ( )
3. Concatenate ( )
4. Hstack ( )
5. Stack ( )
6. Tensordot ( )
7. Vstack () 


Please share your feedback, thank you for the guidance, I am learning so much :) 
