### PR TITLE
Remove `tf.keras` from depthwise and separable conv tests

### DIFF
--- a/keras_core/layers/convolutional/conv_test.py
+++ b/keras_core/layers/convolutional/conv_test.py
@@ -7,6 +7,269 @@ from keras_core import layers
 from keras_core import testing
 
 
+def _same_padding(input_size, kernel_size, stride):
+    if input_size % stride == 0:
+        padding = max(kernel_size - stride, 0)
+    else:
+        padding = max(kernel_size - (input_size % stride), 0)
+    return padding // 2, padding - padding // 2
+
+
+def np_conv1d(
+    x,
+    kernel_weights,
+    bias_weights,
+    strides,
+    padding,
+    data_format,
+    dilation_rate,
+    groups,
+):
+    if data_format == "channels_first":
+        x = x.swapaxes(1, 2)
+    if isinstance(strides, (tuple, list)):
+        h_stride = strides[0]
+    else:
+        h_stride = strides
+    if isinstance(dilation_rate, (tuple, list)):
+        dilation_rate = dilation_rate[0]
+    kernel_size, ch_in, ch_out = kernel_weights.shape
+
+    if dilation_rate > 1:
+        new_kernel_size = kernel_size + (dilation_rate - 1) * (kernel_size - 1)
+        new_kernel_weights = np.zeros(
+            (new_kernel_size, ch_in, ch_out), dtype=kernel_weights.dtype
+        )
+        new_kernel_weights[::dilation_rate] = kernel_weights
+        kernel_weights = new_kernel_weights
+        kernel_size = kernel_weights.shape[0]
+
+    if padding != "valid":
+        n_batch, h_x, _ = x.shape
+        h_pad = _same_padding(h_x, kernel_size, h_stride)
+        npad = [(0, 0)] * x.ndim
+        if padding == "causal":
+            npad[1] = (h_pad[0] + h_pad[1], 0)
+        else:
+            npad[1] = h_pad
+        x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
+
+    n_batch, h_x, _ = x.shape
+    h_out = int((h_x - kernel_size) / h_stride) + 1
+
+    kernel_weights = kernel_weights.reshape(-1, ch_out)
+    bias_weights = bias_weights.reshape(1, ch_out)
+
+    out_grps = []
+    for grp in range(1, groups + 1):
+        x_in = x[..., (grp - 1) * ch_in : grp * ch_in]
+        stride_shape = (n_batch, h_out, kernel_size, ch_in)
+        strides = (
+            x_in.strides[0],
+            h_stride * x_in.strides[1],
+            x_in.strides[1],
+            x_in.strides[2],
+        )
+        inner_dim = kernel_size * ch_in
+        x_strided = as_strided(
+            x_in, shape=stride_shape, strides=strides
+        ).reshape(n_batch, h_out, inner_dim)
+        ch_out_groups = ch_out // groups
+        kernel_weights_grp = kernel_weights[
+            ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
+        ]
+        bias_weights_grp = bias_weights[
+            ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
+        ]
+        out_grps.append(x_strided @ kernel_weights_grp + bias_weights_grp)
+    out = np.concatenate(out_grps, axis=-1)
+    if data_format == "channels_first":
+        out = out.swapaxes(1, 2)
+    return out
+
+
+def np_conv2d(
+    x,
+    kernel_weights,
+    bias_weights,
+    strides,
+    padding,
+    data_format,
+    dilation_rate,
+    groups,
+):
+    if data_format == "channels_first":
+        x = x.transpose((0, 2, 3, 1))
+    if isinstance(strides, (tuple, list)):
+        h_stride, w_stride = strides
+    else:
+        h_stride = strides
+        w_stride = strides
+    if isinstance(dilation_rate, (tuple, list)):
+        h_dilation, w_dilation = dilation_rate
+    else:
+        h_dilation = dilation_rate
+        w_dilation = dilation_rate
+    h_kernel, w_kernel, ch_in, ch_out = kernel_weights.shape
+
+    if h_dilation > 1 or w_dilation > 1:
+        new_h_kernel = h_kernel + (h_dilation - 1) * (h_kernel - 1)
+        new_w_kernel = w_kernel + (w_dilation - 1) * (w_kernel - 1)
+        new_kenel_size_tuple = (new_h_kernel, new_w_kernel)
+        new_kernel_weights = np.zeros(
+            (*new_kenel_size_tuple, ch_in, ch_out),
+            dtype=kernel_weights.dtype,
+        )
+        new_kernel_weights[::h_dilation, ::w_dilation] = kernel_weights
+        kernel_weights = new_kernel_weights
+        h_kernel, w_kernel = kernel_weights.shape[:2]
+
+    if padding == "same":
+        n_batch, h_x, w_x, _ = x.shape
+        h_pad = _same_padding(h_x, h_kernel, h_stride)
+        w_pad = _same_padding(w_x, w_kernel, w_stride)
+        npad = [(0, 0)] * x.ndim
+        npad[1] = h_pad
+        npad[2] = w_pad
+        x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
+
+    n_batch, h_x, w_x, _ = x.shape
+    h_out = int((h_x - h_kernel) / h_stride) + 1
+    w_out = int((w_x - w_kernel) / w_stride) + 1
+
+    out_grps = []
+    for grp in range(1, groups + 1):
+        x_in = x[..., (grp - 1) * ch_in : grp * ch_in]
+        stride_shape = (n_batch, h_out, w_out, h_kernel, w_kernel, ch_in)
+        strides = (
+            x_in.strides[0],
+            h_stride * x_in.strides[1],
+            w_stride * x_in.strides[2],
+            x_in.strides[1],
+            x_in.strides[2],
+            x_in.strides[3],
+        )
+        inner_dim = h_kernel * w_kernel * ch_in
+        x_strided = as_strided(
+            x_in, shape=stride_shape, strides=strides
+        ).reshape(-1, inner_dim)
+        ch_out_groups = ch_out // groups
+        kernel_weights_grp = kernel_weights[
+            ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
+        ].reshape(-1, ch_out_groups)
+        bias_weights_grp = bias_weights[
+            ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
+        ]
+        out_grps.append(x_strided @ kernel_weights_grp + bias_weights_grp)
+    out = np.concatenate(out_grps, axis=-1).reshape(
+        n_batch, h_out, w_out, ch_out
+    )
+    if data_format == "channels_first":
+        out = out.transpose((0, 3, 1, 2))
+    return out
+
+
+def np_conv3d(
+    x,
+    kernel_weights,
+    bias_weights,
+    strides,
+    padding,
+    data_format,
+    dilation_rate,
+    groups,
+):
+    if data_format == "channels_first":
+        x = x.transpose((0, 2, 3, 4, 1))
+    if isinstance(strides, (tuple, list)):
+        h_stride, w_stride, d_stride = strides
+    else:
+        h_stride = strides
+        w_stride = strides
+        d_stride = strides
+    if isinstance(dilation_rate, (tuple, list)):
+        h_dilation, w_dilation, d_dilation = dilation_rate
+    else:
+        h_dilation = dilation_rate
+        w_dilation = dilation_rate
+        d_dilation = dilation_rate
+
+    h_kernel, w_kernel, d_kernel, ch_in, ch_out = kernel_weights.shape
+
+    if h_dilation > 1 or w_dilation > 1 or d_dilation > 1:
+        new_h_kernel = h_kernel + (h_dilation - 1) * (h_kernel - 1)
+        new_w_kernel = w_kernel + (w_dilation - 1) * (w_kernel - 1)
+        new_d_kernel = d_kernel + (d_dilation - 1) * (d_kernel - 1)
+        new_kenel_size_tuple = (new_h_kernel, new_w_kernel, new_d_kernel)
+        new_kernel_weights = np.zeros(
+            (*new_kenel_size_tuple, ch_in, ch_out),
+            dtype=kernel_weights.dtype,
+        )
+        new_kernel_weights[
+            ::h_dilation, ::w_dilation, ::d_dilation
+        ] = kernel_weights
+        kernel_weights = new_kernel_weights
+        h_kernel, w_kernel, d_kernel = kernel_weights.shape[:3]
+
+    if padding == "same":
+        n_batch, h_x, w_x, d_x, _ = x.shape
+        h_pad = _same_padding(h_x, h_kernel, h_stride)
+        w_pad = _same_padding(w_x, w_kernel, w_stride)
+        d_pad = _same_padding(d_x, d_kernel, d_stride)
+        npad = [(0, 0)] * x.ndim
+        npad[1] = h_pad
+        npad[2] = w_pad
+        npad[3] = d_pad
+        x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
+
+    n_batch, h_x, w_x, d_x, _ = x.shape
+    h_out = int((h_x - h_kernel) / h_stride) + 1
+    w_out = int((w_x - w_kernel) / w_stride) + 1
+    d_out = int((d_x - d_kernel) / d_stride) + 1
+
+    out_grps = []
+    for grp in range(1, groups + 1):
+        x_in = x[..., (grp - 1) * ch_in : grp * ch_in]
+        stride_shape = (
+            n_batch,
+            h_out,
+            w_out,
+            d_out,
+            h_kernel,
+            w_kernel,
+            d_kernel,
+            ch_in,
+        )
+        strides = (
+            x_in.strides[0],
+            h_stride * x_in.strides[1],
+            w_stride * x_in.strides[2],
+            d_stride * x_in.strides[3],
+            x_in.strides[1],
+            x_in.strides[2],
+            x_in.strides[3],
+            x_in.strides[4],
+        )
+        inner_dim = h_kernel * w_kernel * d_kernel * ch_in
+        x_strided = as_strided(
+            x_in, shape=stride_shape, strides=strides
+        ).reshape(-1, inner_dim)
+        ch_out_groups = ch_out // groups
+        kernel_weights_grp = kernel_weights[
+            ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
+        ].reshape(-1, ch_out_groups)
+        bias_weights_grp = bias_weights[
+            ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
+        ]
+        out_grps.append(x_strided @ kernel_weights_grp + bias_weights_grp)
+    out = np.concatenate(out_grps, axis=-1).reshape(
+        n_batch, h_out, w_out, d_out, ch_out
+    )
+    if data_format == "channels_first":
+        out = out.transpose((0, 4, 1, 2, 3))
+    return out
+
+
 class ConvBasicTest(testing.TestCase, parameterized.TestCase):
     @parameterized.parameters(
         {
@@ -245,270 +508,6 @@ class ConvBasicTest(testing.TestCase, parameterized.TestCase):
 
 
 class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
-    def _same_padding(self, input_size, kernel_size, stride):
-        if input_size % stride == 0:
-            padding = max(kernel_size - stride, 0)
-        else:
-            padding = max(kernel_size - (input_size % stride), 0)
-        return padding // 2, padding - padding // 2
-
-    def _np_conv1d(
-        self,
-        x,
-        kernel_weights,
-        bias_weights,
-        strides,
-        padding,
-        data_format,
-        dilation_rate,
-        groups,
-    ):
-        if data_format == "channels_first":
-            x = x.swapaxes(1, 2)
-        if isinstance(strides, (tuple, list)):
-            h_stride = strides[0]
-        else:
-            h_stride = strides
-        if isinstance(dilation_rate, (tuple, list)):
-            dilation_rate = dilation_rate[0]
-        kernel_size, ch_in, ch_out = kernel_weights.shape
-
-        if dilation_rate > 1:
-            new_kernel_size = kernel_size + (dilation_rate - 1) * (
-                kernel_size - 1
-            )
-            new_kernel_weights = np.zeros(
-                (new_kernel_size, ch_in, ch_out), dtype=kernel_weights.dtype
-            )
-            new_kernel_weights[::dilation_rate] = kernel_weights
-            kernel_weights = new_kernel_weights
-            kernel_size = kernel_weights.shape[0]
-
-        if padding != "valid":
-            n_batch, h_x, _ = x.shape
-            h_pad = self._same_padding(h_x, kernel_size, h_stride)
-            npad = [(0, 0)] * x.ndim
-            if padding == "causal":
-                npad[1] = (h_pad[0] + h_pad[1], 0)
-            else:
-                npad[1] = h_pad
-            x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
-
-        n_batch, h_x, _ = x.shape
-        h_out = int((h_x - kernel_size) / h_stride) + 1
-
-        kernel_weights = kernel_weights.reshape(-1, ch_out)
-        bias_weights = bias_weights.reshape(1, ch_out)
-
-        out_grps = []
-        for grp in range(1, groups + 1):
-            x_in = x[..., (grp - 1) * ch_in : grp * ch_in]
-            stride_shape = (n_batch, h_out, kernel_size, ch_in)
-            strides = (
-                x_in.strides[0],
-                h_stride * x_in.strides[1],
-                x_in.strides[1],
-                x_in.strides[2],
-            )
-            inner_dim = kernel_size * ch_in
-            x_strided = as_strided(
-                x_in, shape=stride_shape, strides=strides
-            ).reshape(n_batch, h_out, inner_dim)
-            ch_out_groups = ch_out // groups
-            kernel_weights_grp = kernel_weights[
-                ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
-            ]
-            bias_weights_grp = bias_weights[
-                ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
-            ]
-            out_grps.append(x_strided @ kernel_weights_grp + bias_weights_grp)
-        out = np.concatenate(out_grps, axis=-1)
-        if data_format == "channels_first":
-            out = out.swapaxes(1, 2)
-        return out
-
-    def _np_conv2d(
-        self,
-        x,
-        kernel_weights,
-        bias_weights,
-        strides,
-        padding,
-        data_format,
-        dilation_rate,
-        groups,
-    ):
-        if data_format == "channels_first":
-            x = x.transpose((0, 2, 3, 1))
-        if isinstance(strides, (tuple, list)):
-            h_stride, w_stride = strides
-        else:
-            h_stride = strides
-            w_stride = strides
-        if isinstance(dilation_rate, (tuple, list)):
-            h_dilation, w_dilation = dilation_rate
-        else:
-            h_dilation = dilation_rate
-            w_dilation = dilation_rate
-        h_kernel, w_kernel, ch_in, ch_out = kernel_weights.shape
-
-        if h_dilation > 1 or w_dilation > 1:
-            new_h_kernel = h_kernel + (h_dilation - 1) * (h_kernel - 1)
-            new_w_kernel = w_kernel + (w_dilation - 1) * (w_kernel - 1)
-            new_kenel_size_tuple = (new_h_kernel, new_w_kernel)
-            new_kernel_weights = np.zeros(
-                (*new_kenel_size_tuple, ch_in, ch_out),
-                dtype=kernel_weights.dtype,
-            )
-            new_kernel_weights[::h_dilation, ::w_dilation] = kernel_weights
-            kernel_weights = new_kernel_weights
-            h_kernel, w_kernel = kernel_weights.shape[:2]
-
-        if padding == "same":
-            n_batch, h_x, w_x, _ = x.shape
-            h_pad = self._same_padding(h_x, h_kernel, h_stride)
-            w_pad = self._same_padding(w_x, w_kernel, w_stride)
-            npad = [(0, 0)] * x.ndim
-            npad[1] = h_pad
-            npad[2] = w_pad
-            x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
-
-        n_batch, h_x, w_x, _ = x.shape
-        h_out = int((h_x - h_kernel) / h_stride) + 1
-        w_out = int((w_x - w_kernel) / w_stride) + 1
-
-        out_grps = []
-        for grp in range(1, groups + 1):
-            x_in = x[..., (grp - 1) * ch_in : grp * ch_in]
-            stride_shape = (n_batch, h_out, w_out, h_kernel, w_kernel, ch_in)
-            strides = (
-                x_in.strides[0],
-                h_stride * x_in.strides[1],
-                w_stride * x_in.strides[2],
-                x_in.strides[1],
-                x_in.strides[2],
-                x_in.strides[3],
-            )
-            inner_dim = h_kernel * w_kernel * ch_in
-            x_strided = as_strided(
-                x_in, shape=stride_shape, strides=strides
-            ).reshape(-1, inner_dim)
-            ch_out_groups = ch_out // groups
-            kernel_weights_grp = kernel_weights[
-                ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
-            ].reshape(-1, ch_out_groups)
-            bias_weights_grp = bias_weights[
-                ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
-            ]
-            out_grps.append(x_strided @ kernel_weights_grp + bias_weights_grp)
-        out = np.concatenate(out_grps, axis=-1).reshape(
-            n_batch, h_out, w_out, ch_out
-        )
-        if data_format == "channels_first":
-            out = out.transpose((0, 3, 1, 2))
-        return out
-
-    def _np_conv3d(
-        self,
-        x,
-        kernel_weights,
-        bias_weights,
-        strides,
-        padding,
-        data_format,
-        dilation_rate,
-        groups,
-    ):
-        if data_format == "channels_first":
-            x = x.transpose((0, 2, 3, 4, 1))
-        if isinstance(strides, (tuple, list)):
-            h_stride, w_stride, d_stride = strides
-        else:
-            h_stride = strides
-            w_stride = strides
-            d_stride = strides
-        if isinstance(dilation_rate, (tuple, list)):
-            h_dilation, w_dilation, d_dilation = dilation_rate
-        else:
-            h_dilation = dilation_rate
-            w_dilation = dilation_rate
-            d_dilation = dilation_rate
-
-        h_kernel, w_kernel, d_kernel, ch_in, ch_out = kernel_weights.shape
-
-        if h_dilation > 1 or w_dilation > 1 or d_dilation > 1:
-            new_h_kernel = h_kernel + (h_dilation - 1) * (h_kernel - 1)
-            new_w_kernel = w_kernel + (w_dilation - 1) * (w_kernel - 1)
-            new_d_kernel = d_kernel + (d_dilation - 1) * (d_kernel - 1)
-            new_kenel_size_tuple = (new_h_kernel, new_w_kernel, new_d_kernel)
-            new_kernel_weights = np.zeros(
-                (*new_kenel_size_tuple, ch_in, ch_out),
-                dtype=kernel_weights.dtype,
-            )
-            new_kernel_weights[
-                ::h_dilation, ::w_dilation, ::d_dilation
-            ] = kernel_weights
-            kernel_weights = new_kernel_weights
-            h_kernel, w_kernel, d_kernel = kernel_weights.shape[:3]
-
-        if padding == "same":
-            n_batch, h_x, w_x, d_x, _ = x.shape
-            h_pad = self._same_padding(h_x, h_kernel, h_stride)
-            w_pad = self._same_padding(w_x, w_kernel, w_stride)
-            d_pad = self._same_padding(d_x, d_kernel, d_stride)
-            npad = [(0, 0)] * x.ndim
-            npad[1] = h_pad
-            npad[2] = w_pad
-            npad[3] = d_pad
-            x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
-
-        n_batch, h_x, w_x, d_x, _ = x.shape
-        h_out = int((h_x - h_kernel) / h_stride) + 1
-        w_out = int((w_x - w_kernel) / w_stride) + 1
-        d_out = int((d_x - d_kernel) / d_stride) + 1
-
-        out_grps = []
-        for grp in range(1, groups + 1):
-            x_in = x[..., (grp - 1) * ch_in : grp * ch_in]
-            stride_shape = (
-                n_batch,
-                h_out,
-                w_out,
-                d_out,
-                h_kernel,
-                w_kernel,
-                d_kernel,
-                ch_in,
-            )
-            strides = (
-                x_in.strides[0],
-                h_stride * x_in.strides[1],
-                w_stride * x_in.strides[2],
-                d_stride * x_in.strides[3],
-                x_in.strides[1],
-                x_in.strides[2],
-                x_in.strides[3],
-                x_in.strides[4],
-            )
-            inner_dim = h_kernel * w_kernel * d_kernel * ch_in
-            x_strided = as_strided(
-                x_in, shape=stride_shape, strides=strides
-            ).reshape(-1, inner_dim)
-            ch_out_groups = ch_out // groups
-            kernel_weights_grp = kernel_weights[
-                ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
-            ].reshape(-1, ch_out_groups)
-            bias_weights_grp = bias_weights[
-                ..., (grp - 1) * ch_out_groups : grp * ch_out_groups
-            ]
-            out_grps.append(x_strided @ kernel_weights_grp + bias_weights_grp)
-        out = np.concatenate(out_grps, axis=-1).reshape(
-            n_batch, h_out, w_out, d_out, ch_out
-        )
-        if data_format == "channels_first":
-            out = out.transpose((0, 4, 1, 2, 3))
-        return out
-
     @parameterized.parameters(
         {
             "filters": 5,
@@ -586,7 +585,7 @@ class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
         layer.bias.assign(bias_weights)
 
         outputs = layer(inputs)
-        expected = self._np_conv1d(
+        expected = np_conv1d(
             inputs,
             kernel_weights,
             bias_weights,
@@ -684,7 +683,7 @@ class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
         layer.bias.assign(bias_weights)
 
         outputs = layer(inputs)
-        expected = self._np_conv2d(
+        expected = np_conv2d(
             inputs,
             kernel_weights,
             bias_weights,
@@ -773,7 +772,7 @@ class ConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
         layer.bias.assign(bias_weights)
 
         outputs = layer(inputs)
-        expected = self._np_conv3d(
+        expected = np_conv3d(
             inputs,
             kernel_weights,
             bias_weights,

--- a/keras_core/layers/convolutional/depthwise_conv_test.py
+++ b/keras_core/layers/convolutional/depthwise_conv_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
+from numpy.lib.stride_tricks import as_strided
 
 from keras_core import layers
 from keras_core import testing
@@ -158,6 +159,93 @@ class DepthwiseConvBasicTest(testing.TestCase, parameterized.TestCase):
 
 
 class DepthwiseConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
+    def _same_padding(self, input_size, kernel_size, stride):
+        if input_size % stride == 0:
+            padding = max(kernel_size - stride, 0)
+        else:
+            padding = max(kernel_size - (input_size % stride), 0)
+        return padding // 2, padding - padding // 2
+
+    def _np_depthwise_conv2d(
+        self,
+        x,
+        kernel_weights,
+        bias_weights,
+        strides,
+        padding,
+        data_format,
+        dilation_rate,
+    ):
+        if data_format == "channels_first":
+            x = x.transpose((0, 2, 3, 1))
+        if isinstance(strides, (tuple, list)):
+            h_stride, w_stride = strides
+        else:
+            h_stride = strides
+            w_stride = strides
+        if isinstance(dilation_rate, (tuple, list)):
+            h_dilation, w_dilation = dilation_rate
+        else:
+            h_dilation = dilation_rate
+            w_dilation = dilation_rate
+        h_kernel, w_kernel, ch_in, ch_out = kernel_weights.shape
+
+        if h_dilation > 1 or w_dilation > 1:
+            new_h_kernel = h_kernel + (h_dilation - 1) * (h_kernel - 1)
+            new_w_kernel = w_kernel + (w_dilation - 1) * (w_kernel - 1)
+            new_kenel_size_tuple = (new_h_kernel, new_w_kernel)
+            new_kernel_weights = np.zeros(
+                (*new_kenel_size_tuple, ch_in, ch_out),
+                dtype=kernel_weights.dtype,
+            )
+            new_kernel_weights[::h_dilation, ::w_dilation] = kernel_weights
+            kernel_weights = new_kernel_weights
+            h_kernel, w_kernel = kernel_weights.shape[:2]
+
+        if padding == "same":
+            n_batch, h_x, w_x, _ = x.shape
+            h_pad = self._same_padding(h_x, h_kernel, h_stride)
+            w_pad = self._same_padding(w_x, w_kernel, w_stride)
+            npad = [(0, 0)] * x.ndim
+            npad[1] = h_pad
+            npad[2] = w_pad
+            x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
+
+        n_batch, h_x, w_x, _ = x.shape
+        h_out = int((h_x - h_kernel) / h_stride) + 1
+        w_out = int((w_x - w_kernel) / w_stride) + 1
+
+        out_grps = []
+        bias_weights = bias_weights.reshape(ch_in, ch_out)
+        for ch_in_idx in range(ch_in):
+            for ch_out_idx in range(ch_out):
+                x_in = np.ascontiguousarray(x[..., ch_in_idx])
+                stride_shape = (n_batch, h_out, w_out, h_kernel, w_kernel)
+                strides = (
+                    x_in.strides[0],
+                    h_stride * x_in.strides[1],
+                    w_stride * x_in.strides[2],
+                    x_in.strides[1],
+                    x_in.strides[2],
+                )
+                inner_dim = h_kernel * w_kernel
+                x_strided = as_strided(
+                    x_in, shape=stride_shape, strides=strides
+                ).reshape(-1, inner_dim)
+                kernel_weights_grp = kernel_weights[
+                    ..., ch_in_idx, ch_out_idx
+                ].reshape(-1, 1)
+                bias_weights_grp = bias_weights[..., ch_in_idx, ch_out_idx]
+                out_grps.append(
+                    (x_strided @ kernel_weights_grp + bias_weights_grp).reshape(
+                        n_batch, h_out, w_out, 1
+                    )
+                )
+        out = np.concatenate(out_grps, axis=-1)
+        if data_format == "channels_first":
+            out = out.transpose((0, 3, 1, 2))
+        return out
+
     @parameterized.parameters(
         {
             "depth_multiplier": 5,
@@ -270,28 +358,25 @@ class DepthwiseConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
             data_format=data_format,
             dilation_rate=dilation_rate,
         )
-        tf_keras_layer = tf.keras.layers.DepthwiseConv2D(
-            depth_multiplier=depth_multiplier,
-            kernel_size=kernel_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-            dilation_rate=dilation_rate,
-        )
 
         inputs = np.random.normal(size=[2, 8, 8, 4])
         layer.build(input_shape=inputs.shape)
-        tf_keras_layer.build(input_shape=inputs.shape)
 
         kernel_shape = layer.kernel.shape
         kernel_weights = np.random.normal(size=kernel_shape)
         bias_weights = np.random.normal(size=(depth_multiplier * 4,))
         layer.kernel.assign(kernel_weights)
-        tf_keras_layer.depthwise_kernel.assign(kernel_weights)
-
         layer.bias.assign(bias_weights)
-        tf_keras_layer.bias.assign(bias_weights)
 
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
-        self.assertAllClose(outputs, expected)
+        expected = self._np_depthwise_conv2d(
+            inputs,
+            kernel_weights,
+            bias_weights,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            dilation_rate=dilation_rate,
+        )
+        self.assertAllClose(outputs.shape, expected.shape)
+        self.assertAllClose(outputs, expected, atol=1e-5)

--- a/keras_core/layers/convolutional/depthwise_conv_test.py
+++ b/keras_core/layers/convolutional/depthwise_conv_test.py
@@ -1,11 +1,169 @@
 import numpy as np
 import pytest
-import tensorflow as tf
 from absl.testing import parameterized
 from numpy.lib.stride_tricks import as_strided
 
 from keras_core import layers
 from keras_core import testing
+
+
+def _same_padding(input_size, kernel_size, stride):
+    if input_size % stride == 0:
+        padding = max(kernel_size - stride, 0)
+    else:
+        padding = max(kernel_size - (input_size % stride), 0)
+    return padding // 2, padding - padding // 2
+
+
+def np_depthwise_conv1d(
+    x,
+    kernel_weights,
+    bias_weights,
+    strides,
+    padding,
+    data_format,
+    dilation_rate,
+):
+    if data_format == "channels_first":
+        x = x.transpose((0, 2, 1))
+    if isinstance(strides, (tuple, list)):
+        h_stride = strides[0]
+    else:
+        h_stride = strides
+    if isinstance(dilation_rate, (tuple, list)):
+        h_dilation = dilation_rate[0]
+    else:
+        h_dilation = dilation_rate
+    h_kernel, ch_in, ch_out = kernel_weights.shape
+
+    if h_dilation > 1:
+        new_h_kernel = h_kernel + (h_dilation - 1) * (h_kernel - 1)
+        new_kernel_weights = np.zeros(
+            (new_h_kernel, ch_in, ch_out),
+            dtype=kernel_weights.dtype,
+        )
+        new_kernel_weights[::h_dilation] = kernel_weights
+        kernel_weights = new_kernel_weights
+        h_kernel = kernel_weights.shape[0]
+
+    if padding == "same":
+        n_batch, h_x, _ = x.shape
+        h_pad = _same_padding(h_x, h_kernel, h_stride)
+        npad = [(0, 0)] * x.ndim
+        npad[1] = h_pad
+        x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
+
+    n_batch, h_x, _ = x.shape
+    h_out = int((h_x - h_kernel) / h_stride) + 1
+
+    out_grps = []
+    bias_weights = bias_weights.reshape(ch_in, ch_out)
+    for ch_in_idx in range(ch_in):
+        for ch_out_idx in range(ch_out):
+            x_in = np.ascontiguousarray(x[..., ch_in_idx])
+            stride_shape = (n_batch, h_out, h_kernel)
+            strides = (
+                x_in.strides[0],
+                h_stride * x_in.strides[1],
+                x_in.strides[1],
+            )
+            inner_dim = h_kernel
+            x_strided = as_strided(
+                x_in, shape=stride_shape, strides=strides
+            ).reshape(-1, inner_dim)
+            kernel_weights_grp = kernel_weights[
+                ..., ch_in_idx, ch_out_idx
+            ].reshape(-1, 1)
+            bias_weights_grp = bias_weights[..., ch_in_idx, ch_out_idx]
+            out_grps.append(
+                (x_strided @ kernel_weights_grp + bias_weights_grp).reshape(
+                    n_batch, h_out, 1
+                )
+            )
+    out = np.concatenate(out_grps, axis=-1)
+    if data_format == "channels_first":
+        out = out.transpose((0, 2, 1))
+    return out
+
+
+def np_depthwise_conv2d(
+    x,
+    kernel_weights,
+    bias_weights,
+    strides,
+    padding,
+    data_format,
+    dilation_rate,
+):
+    if data_format == "channels_first":
+        x = x.transpose((0, 2, 3, 1))
+    if isinstance(strides, (tuple, list)):
+        h_stride, w_stride = strides
+    else:
+        h_stride = strides
+        w_stride = strides
+    if isinstance(dilation_rate, (tuple, list)):
+        h_dilation, w_dilation = dilation_rate
+    else:
+        h_dilation = dilation_rate
+        w_dilation = dilation_rate
+    h_kernel, w_kernel, ch_in, ch_out = kernel_weights.shape
+
+    if h_dilation > 1 or w_dilation > 1:
+        new_h_kernel = h_kernel + (h_dilation - 1) * (h_kernel - 1)
+        new_w_kernel = w_kernel + (w_dilation - 1) * (w_kernel - 1)
+        new_kenel_size_tuple = (new_h_kernel, new_w_kernel)
+        new_kernel_weights = np.zeros(
+            (*new_kenel_size_tuple, ch_in, ch_out),
+            dtype=kernel_weights.dtype,
+        )
+        new_kernel_weights[::h_dilation, ::w_dilation] = kernel_weights
+        kernel_weights = new_kernel_weights
+        h_kernel, w_kernel = kernel_weights.shape[:2]
+
+    if padding == "same":
+        n_batch, h_x, w_x, _ = x.shape
+        h_pad = _same_padding(h_x, h_kernel, h_stride)
+        w_pad = _same_padding(w_x, w_kernel, w_stride)
+        npad = [(0, 0)] * x.ndim
+        npad[1] = h_pad
+        npad[2] = w_pad
+        x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
+
+    n_batch, h_x, w_x, _ = x.shape
+    h_out = int((h_x - h_kernel) / h_stride) + 1
+    w_out = int((w_x - w_kernel) / w_stride) + 1
+
+    out_grps = []
+    bias_weights = bias_weights.reshape(ch_in, ch_out)
+    for ch_in_idx in range(ch_in):
+        for ch_out_idx in range(ch_out):
+            x_in = np.ascontiguousarray(x[..., ch_in_idx])
+            stride_shape = (n_batch, h_out, w_out, h_kernel, w_kernel)
+            strides = (
+                x_in.strides[0],
+                h_stride * x_in.strides[1],
+                w_stride * x_in.strides[2],
+                x_in.strides[1],
+                x_in.strides[2],
+            )
+            inner_dim = h_kernel * w_kernel
+            x_strided = as_strided(
+                x_in, shape=stride_shape, strides=strides
+            ).reshape(-1, inner_dim)
+            kernel_weights_grp = kernel_weights[
+                ..., ch_in_idx, ch_out_idx
+            ].reshape(-1, 1)
+            bias_weights_grp = bias_weights[..., ch_in_idx, ch_out_idx]
+            out_grps.append(
+                (x_strided @ kernel_weights_grp + bias_weights_grp).reshape(
+                    n_batch, h_out, w_out, 1
+                )
+            )
+    out = np.concatenate(out_grps, axis=-1)
+    if data_format == "channels_first":
+        out = out.transpose((0, 3, 1, 2))
+    return out
 
 
 class DepthwiseConvBasicTest(testing.TestCase, parameterized.TestCase):
@@ -159,93 +317,6 @@ class DepthwiseConvBasicTest(testing.TestCase, parameterized.TestCase):
 
 
 class DepthwiseConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
-    def _same_padding(self, input_size, kernel_size, stride):
-        if input_size % stride == 0:
-            padding = max(kernel_size - stride, 0)
-        else:
-            padding = max(kernel_size - (input_size % stride), 0)
-        return padding // 2, padding - padding // 2
-
-    def _np_depthwise_conv2d(
-        self,
-        x,
-        kernel_weights,
-        bias_weights,
-        strides,
-        padding,
-        data_format,
-        dilation_rate,
-    ):
-        if data_format == "channels_first":
-            x = x.transpose((0, 2, 3, 1))
-        if isinstance(strides, (tuple, list)):
-            h_stride, w_stride = strides
-        else:
-            h_stride = strides
-            w_stride = strides
-        if isinstance(dilation_rate, (tuple, list)):
-            h_dilation, w_dilation = dilation_rate
-        else:
-            h_dilation = dilation_rate
-            w_dilation = dilation_rate
-        h_kernel, w_kernel, ch_in, ch_out = kernel_weights.shape
-
-        if h_dilation > 1 or w_dilation > 1:
-            new_h_kernel = h_kernel + (h_dilation - 1) * (h_kernel - 1)
-            new_w_kernel = w_kernel + (w_dilation - 1) * (w_kernel - 1)
-            new_kenel_size_tuple = (new_h_kernel, new_w_kernel)
-            new_kernel_weights = np.zeros(
-                (*new_kenel_size_tuple, ch_in, ch_out),
-                dtype=kernel_weights.dtype,
-            )
-            new_kernel_weights[::h_dilation, ::w_dilation] = kernel_weights
-            kernel_weights = new_kernel_weights
-            h_kernel, w_kernel = kernel_weights.shape[:2]
-
-        if padding == "same":
-            n_batch, h_x, w_x, _ = x.shape
-            h_pad = self._same_padding(h_x, h_kernel, h_stride)
-            w_pad = self._same_padding(w_x, w_kernel, w_stride)
-            npad = [(0, 0)] * x.ndim
-            npad[1] = h_pad
-            npad[2] = w_pad
-            x = np.pad(x, pad_width=npad, mode="constant", constant_values=0)
-
-        n_batch, h_x, w_x, _ = x.shape
-        h_out = int((h_x - h_kernel) / h_stride) + 1
-        w_out = int((w_x - w_kernel) / w_stride) + 1
-
-        out_grps = []
-        bias_weights = bias_weights.reshape(ch_in, ch_out)
-        for ch_in_idx in range(ch_in):
-            for ch_out_idx in range(ch_out):
-                x_in = np.ascontiguousarray(x[..., ch_in_idx])
-                stride_shape = (n_batch, h_out, w_out, h_kernel, w_kernel)
-                strides = (
-                    x_in.strides[0],
-                    h_stride * x_in.strides[1],
-                    w_stride * x_in.strides[2],
-                    x_in.strides[1],
-                    x_in.strides[2],
-                )
-                inner_dim = h_kernel * w_kernel
-                x_strided = as_strided(
-                    x_in, shape=stride_shape, strides=strides
-                ).reshape(-1, inner_dim)
-                kernel_weights_grp = kernel_weights[
-                    ..., ch_in_idx, ch_out_idx
-                ].reshape(-1, 1)
-                bias_weights_grp = bias_weights[..., ch_in_idx, ch_out_idx]
-                out_grps.append(
-                    (x_strided @ kernel_weights_grp + bias_weights_grp).reshape(
-                        n_batch, h_out, w_out, 1
-                    )
-                )
-        out = np.concatenate(out_grps, axis=-1)
-        if data_format == "channels_first":
-            out = out.transpose((0, 3, 1, 2))
-        return out
-
     @parameterized.parameters(
         {
             "depth_multiplier": 5,
@@ -289,30 +360,26 @@ class DepthwiseConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
             data_format=data_format,
             dilation_rate=dilation_rate,
         )
-        tf_keras_layer = tf.keras.layers.DepthwiseConv1D(
-            depth_multiplier=depth_multiplier,
-            kernel_size=kernel_size,
-            strides=strides,
-            padding=padding,
-            data_format=data_format,
-            dilation_rate=dilation_rate,
-        )
 
         inputs = np.random.normal(size=[2, 8, 4])
         layer.build(input_shape=inputs.shape)
-        tf_keras_layer.build(input_shape=inputs.shape)
 
         kernel_shape = layer.kernel.shape
         kernel_weights = np.random.normal(size=kernel_shape)
         bias_weights = np.random.normal(size=(depth_multiplier * 4,))
         layer.kernel.assign(kernel_weights)
-        tf_keras_layer.depthwise_kernel.assign(kernel_weights)
-
         layer.bias.assign(bias_weights)
-        tf_keras_layer.bias.assign(bias_weights)
 
         outputs = layer(inputs)
-        expected = tf_keras_layer(inputs)
+        expected = np_depthwise_conv1d(
+            inputs,
+            kernel_weights,
+            bias_weights,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            dilation_rate=dilation_rate,
+        )
         self.assertAllClose(outputs, expected)
 
     @parameterized.parameters(
@@ -369,7 +436,7 @@ class DepthwiseConvCorrectnessTest(testing.TestCase, parameterized.TestCase):
         layer.bias.assign(bias_weights)
 
         outputs = layer(inputs)
-        expected = self._np_depthwise_conv2d(
+        expected = np_depthwise_conv2d(
             inputs,
             kernel_weights,
             bias_weights,


### PR DESCRIPTION
* Removes `tf.keras` from Depthwise and Separable conv tests.
* Implemented separable conv as a combination of depthwise followed by regular conv with 1x1 kernel.  So imported the numpy test implementations for separable conv test.

Will send another PR to remove `tf.keras` from Transpose Conv test.