### PR TITLE
Fix naming in `mobilenet_v3` and `densenet`

### DIFF
--- a/keras_core/applications/densenet.py
+++ b/keras_core/applications/densenet.py
@@ -215,11 +215,11 @@ def DenseNet(
     bn_axis = 3 if backend.image_data_format() == "channels_last" else 1
 
     x = layers.ZeroPadding2D(padding=((3, 3), (3, 3)))(img_input)
-    x = layers.Conv2D(64, 7, strides=2, use_bias=False, name="conv1/conv")(x)
+    x = layers.Conv2D(64, 7, strides=2, use_bias=False, name="conv1_conv")(x)
     x = layers.BatchNormalization(
-        axis=bn_axis, epsilon=1.001e-5, name="conv1/bn"
+        axis=bn_axis, epsilon=1.001e-5, name="conv1_bn"
     )(x)
-    x = layers.Activation("relu", name="conv1/relu")(x)
+    x = layers.Activation("relu", name="conv1_relu")(x)
     x = layers.ZeroPadding2D(padding=((1, 1), (1, 1)))(x)
     x = layers.MaxPooling2D(3, strides=2, name="pool1")(x)
 

--- a/keras_core/ops/operation.py
+++ b/keras_core/ops/operation.py
@@ -17,10 +17,11 @@ class Operation:
     def __init__(self, name=None):
         if name is None:
             name = auto_name(self.__class__.__name__)
-        if not isinstance(name, str):
+        if not isinstance(name, str) or "/" in name:
             raise ValueError(
-                "Argument `name` should be a string. "
-                f"Received instead: name={name} (of type {type(name)})"
+                "Argument `name` must be a string and "
+                "cannot contain character `/`. "
+                f"Received: name={name} (of type {type(name)})"
             )
         self.name = name
         self._inbound_nodes = []

--- a/keras_core/ops/operation_test.py
+++ b/keras_core/ops/operation_test.py
@@ -152,3 +152,11 @@ class OperationTest(testing.TestCase):
         out = op(x, y, z)
         self.assertTrue(backend.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2,)))
+
+    def test_valid_naming(self):
+        OpWithMultipleOutputs(name="test_op")
+
+        with self.assertRaisesRegex(
+            ValueError, "must be a string and cannot contain character `/`."
+        ):
+            OpWithMultipleOutputs(name="test/op")


### PR DESCRIPTION
This PR fixes the naming error in MobileNetV3 and DenseNet caused by the introduction of `name_scope`.

A new assertion in `keras_core/ops/operation.py` and corresponding tests have been added.
