### PR TITLE
Fix error message which would print the article "the" twice.

### DIFF
--- a/keras_core/layers/preprocessing/hashed_crossing.py
+++ b/keras_core/layers/preprocessing/hashed_crossing.py
@@ -219,7 +219,10 @@ class HashedCrossing(Layer):
                 "All `HashedCrossing` inputs should be dense tensors. "
                 f"Received: inputs={inputs}"
             )
-        if not all(tf.as_dtype(x.dtype).is_integer or x.dtype == tf.string for x in inputs):
+        if not all(
+            tf.as_dtype(x.dtype).is_integer or x.dtype == tf.string
+            for x in inputs
+        ):
             raise ValueError(
                 "All `HashedCrossing` inputs should have an integer or "
                 f"string dtype. Received: inputs={inputs}"

--- a/keras_core/trainers/epoch_iterator.py
+++ b/keras_core/trainers/epoch_iterator.py
@@ -220,7 +220,7 @@ class EpochIterator:
 def raise_unsupported_arg(arg_name, arg_description, input_type):
     raise ValueError(
         f"When providing `x` as a {input_type}, `{arg_name}` "
-        f"should not be passed. Instead, the {arg_description} should "
+        f"should not be passed. Instead, {arg_description} should "
         f"be included as part of the {input_type}."
     )
 

--- a/keras_core/utils/tf_utils.py
+++ b/keras_core/utils/tf_utils.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from keras_core.utils.module_utils import tensorflow as tf
 
 


### PR DESCRIPTION
In all cases, `arg_description` already contains the article "the". The error message would then contain "the" twice, for instance "Intead, the the targets should...".

 Also fixed some formatting issues caught by lint.