### PR TITLE
Add implementation for Distribution API

### DIFF
--- a/keras_core/backend/__init__.py
+++ b/keras_core/backend/__init__.py
@@ -32,12 +32,16 @@ from keras_core.utils.io_utils import print_msg
 if backend() == "tensorflow":
     print_msg("Using TensorFlow backend")
     from keras_core.backend.tensorflow import *  # noqa: F403
+
+    distribution_lib = None
 elif backend() == "jax":
     print_msg("Using JAX backend.")
     from keras_core.backend.jax import *  # noqa: F403
 elif backend() == "torch":
     print_msg("Using PyTorch backend.")
     from keras_core.backend.torch import *  # noqa: F403
+
+    distribution_lib = None
 elif backend() == "numpy":
     print_msg(
         "Using NumPy backend.\nThe NumPy backend does not support "
@@ -45,5 +49,7 @@ elif backend() == "numpy":
         "and debugging."
     )
     from keras_core.backend.numpy import *  # noqa: F403
+
+    distribution_lib = None
 else:
     raise ValueError(f"Unable to import backend : {backend()}")

--- a/keras_core/backend/jax/__init__.py
+++ b/keras_core/backend/jax/__init__.py
@@ -1,4 +1,5 @@
 from keras_core.backend.jax import core
+from keras_core.backend.jax import distribution_lib
 from keras_core.backend.jax import image
 from keras_core.backend.jax import math
 from keras_core.backend.jax import nn

--- a/keras_core/backend/jax/distribution_lib.py
+++ b/keras_core/backend/jax/distribution_lib.py
@@ -1,0 +1,56 @@
+"""!!!DO NOT USE!!!
+
+Distribution related class for JAX backend.
+
+This is just a prototype and we might want to unify it
+with other backends in the future.
+"""
+import jax
+
+
+def list_devices(device_type=None):
+    """Return all the available devices based on the device type.
+
+    Note that this should return the global devices in a distributed setting.
+
+    Args:
+        device_type: string of 'CPU', 'GPU' or 'TPU'. Default to GPU or TPU if
+            available when device_type is not provided. Otherwise will return
+            the CPU devices.
+
+    Return:
+        List of devices that are available for distribute computation.
+    """
+    device_type = device_type.lower() if device_type else "cpu"
+    return jax.devices(backend=device_type)
+
+
+def to_backend_mesh(device_mesh):
+    """Convert the DeviceMesh to JAX backend specific Mesh.
+
+    Args:
+        device_mesh: DeviceMesh instance to convert.
+
+    Returns:
+        A `jax.sharding.Mesh` instance.
+    """
+    return jax.sharding.Mesh(device_mesh.devices, device_mesh.axis_names)
+
+
+def to_backend_layout(tensor_layout):
+    """Convert the TensorLayout to JAX backend specific Sharding.
+
+    Args:
+        tensor_layout: TensorLayout instance to convert.
+
+    Returns:
+        A `jax.sharding.NamedSharding` instance.
+    """
+    if tensor_layout.device_mesh is None:
+        raise ValueError(
+            "Cannot create sharding when device mesh is not set "
+            "for TensorLayout."
+        )
+    partition_spec = jax.sharding.PartitionSpec(*tensor_layout.axes)
+    jax_mesh = to_backend_mesh(tensor_layout.device_mesh)
+    return jax.sharding.NamedSharding(jax_mesh, partition_spec)

--- a/keras_core/distribute/distribution.py
+++ b/keras_core/distribute/distribution.py
@@ -1,0 +1,142 @@
+"""Unified high level distribution APIs across backends.
+
+!!!DO NOT USE!!! Currently under development and APIs are not final.
+
+Currently only the JAX backend has been implemented, and the Tensorflow backend
+will be implemented in future (via tf.dtensor API).
+"""
+
+import contextlib
+from typing import Any
+
+from keras_core import KerasVariable
+from keras_core.backend.common import global_state
+
+GLOBAL_ATTRIBUTE_NAME = "distribution"
+
+
+def list_devices(device_type: str = None) -> list[str]:
+    """Return all the available devices based on the device type.
+
+    Note that this should return the global devices in a distributed setting.
+    
+    Args:
+        device_type: CPU, GPU or TPU. Default to GPU or TPU if available when
+            device_type is not provided. Otherwise will return the CPU devices.
+
+    Return:
+        List of devices that are available for distribute computation.
+    """
+    pass
+
+
+class DeviceMesh:
+    """The cluster of computation devices for distributed computation.
+    
+    This is aligned with `jax.sharding.Mesh` and `tf.dtensor.Mesh`, which
+    represents the computation devices in the global context.
+
+    See more details in 
+    https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.Mesh
+    and https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Mesh.
+    """
+
+    def __init__(self,
+                 shape: list|tuple,
+                 axis_names: list[str],
+                 devices: list[str] = None):
+        """Initialize the DeviceMesh for the given topology.
+        
+        Args:
+            shape: the shape of the overall DeviceMesh, e.g. (8,) for a data
+                parallel only distribution, or (4, 2) for a model+data parallel
+                distribution.
+            axis_names: The logical name of the each axis for the DeviceMesh.
+                The length of the `axis_names` should match to the rank of the 
+                `shape`. The `axis_names` will be used to match/create the 
+                `TensorLayout` when distribute the data and weights.
+            devices: Optional list of devices. Default to all the available
+                devices locally from `list_devices()`.
+        """
+        pass
+
+
+class TensorLayout:
+    """The layout of a Tensor.
+    
+    This is aligned with `jax.sharding.NamedSharding` and `tf.dtensor.Layout`,
+    which allocate the tensor to its logic axis based on the `DeviceMesh`. With
+    `DeviceMesh` and `TensorLayout`, the actual mapping between a Tensor to the
+    physical devices can be determined.
+
+    See more details in 
+    https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.NamedSharding
+    and https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Layout.
+    """
+
+    def __init__(self, layout_spec: list|tuple):
+        """Initialize the TensorLayout with layout_spec.
+        
+        Args:
+            layout_spec: list of strings that should map to the `axis_names` in
+                `DeviceMesh`. For any dimentions that doesn't need any sharding,
+                A `None` can be used a placeholder.
+        """
+        pass
+
+
+class Distribution:
+    """Base class for the distribution.
+    
+    The `Distribution` has following key functionalities.
+
+    1. Distribute the model variables to the `DeviceMesh`.
+    2. Distribute the input data to the `DeviceMesh`.
+
+    It can create a context scope so that the framework to properly detect the
+    `Distribution` and distribute the variable/data accordingly.
+    """
+
+    def __init__(self, device_mesh: DeviceMesh):
+        pass
+
+    def distribute_data(self, data) -> Any:
+        """Shard the input data based on the Distribution setting.
+        
+        Args:
+            data: input data, can be Tensor and np.Array.
+        
+        Returns:
+            distributed data tensor.
+        """
+        pass
+
+    def distribute_variable(self, variable: KerasVariable) -> KerasVariable:
+        """Distribute the variable based on the Distribution setting.
+        
+        Args:
+            variable: a keras variable for distribution.
+
+        return:
+            distributed keras variable.
+        """
+        pass
+
+    def as_global_distribution(self):
+        """Set the current `Distribution` as the global distribution setting."""
+        pass
+
+    @contextlib.contextmanager
+    def scope(self):
+        """Context manager to make the `Distribution` current."""
+        pass
+
+
+def get_global_distribution():
+    """Retrieve the current distribution from global context."""
+    return global_state.get_global_attribute(GLOBAL_ATTRIBUTE_NAME)
+
+
+def set_global_distribution(distribution: Distribution):
+    """Set the distribution as the global distribution setting."""
+    distribution.as_global_distribution()

--- a/keras_core/distribute/distribution.py
+++ b/keras_core/distribute/distribution.py
@@ -19,7 +19,7 @@ def list_devices(device_type: str = None) -> list[str]:
     """Return all the available devices based on the device type.
 
     Note that this should return the global devices in a distributed setting.
-    
+
     Args:
         device_type: CPU, GPU or TPU. Default to GPU or TPU if available when
             device_type is not provided. Otherwise will return the CPU devices.
@@ -32,28 +32,30 @@ def list_devices(device_type: str = None) -> list[str]:
 
 class DeviceMesh:
     """The cluster of computation devices for distributed computation.
-    
+
     This is aligned with `jax.sharding.Mesh` and `tf.dtensor.Mesh`, which
     represents the computation devices in the global context.
 
-    See more details in 
+    See more details in
     https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.Mesh
     and https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Mesh.
     """
 
-    def __init__(self,
-                 shape: list|tuple,
-                 axis_names: list[str],
-                 devices: list[str] = None):
+    def __init__(
+        self,
+        shape: list | tuple,
+        axis_names: list[str],
+        devices: list[str] = None,
+    ):
         """Initialize the DeviceMesh for the given topology.
-        
+
         Args:
             shape: the shape of the overall DeviceMesh, e.g. (8,) for a data
                 parallel only distribution, or (4, 2) for a model+data parallel
                 distribution.
             axis_names: The logical name of the each axis for the DeviceMesh.
-                The length of the `axis_names` should match to the rank of the 
-                `shape`. The `axis_names` will be used to match/create the 
+                The length of the `axis_names` should match to the rank of the
+                `shape`. The `axis_names` will be used to match/create the
                 `TensorLayout` when distribute the data and weights.
             devices: Optional list of devices. Default to all the available
                 devices locally from `list_devices()`.
@@ -63,20 +65,20 @@ class DeviceMesh:
 
 class TensorLayout:
     """The layout of a Tensor.
-    
+
     This is aligned with `jax.sharding.NamedSharding` and `tf.dtensor.Layout`,
     which allocate the tensor to its logic axis based on the `DeviceMesh`. With
     `DeviceMesh` and `TensorLayout`, the actual mapping between a Tensor to the
     physical devices can be determined.
 
-    See more details in 
+    See more details in
     https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.NamedSharding
-    and https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Layout.
+    and https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Layout.  # noqa: E501
     """
 
-    def __init__(self, layout_spec: list|tuple):
+    def __init__(self, layout_spec: list | tuple):
         """Initialize the TensorLayout with layout_spec.
-        
+
         Args:
             layout_spec: list of strings that should map to the `axis_names` in
                 `DeviceMesh`. For any dimentions that doesn't need any sharding,
@@ -87,7 +89,7 @@ class TensorLayout:
 
 class Distribution:
     """Base class for the distribution.
-    
+
     The `Distribution` has following key functionalities.
 
     1. Distribute the model variables to the `DeviceMesh`.
@@ -102,10 +104,10 @@ class Distribution:
 
     def distribute_data(self, data) -> Any:
         """Shard the input data based on the Distribution setting.
-        
+
         Args:
             data: input data, can be Tensor and np.Array.
-        
+
         Returns:
             distributed data tensor.
         """
@@ -113,7 +115,7 @@ class Distribution:
 
     def distribute_variable(self, variable: KerasVariable) -> KerasVariable:
         """Distribute the variable based on the Distribution setting.
-        
+
         Args:
             variable: a keras variable for distribution.
 

--- a/keras_core/distribution/distribution_lib.py
+++ b/keras_core/distribution/distribution_lib.py
@@ -35,10 +35,10 @@ class DeviceMesh:
     This is aligned with `jax.sharding.Mesh` and `tf.dtensor.Mesh`, which
     represents the computation devices in the global context.
 
-    See more details in [jax.sharding.Mesh]
-    (https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.Mesh)
-    and [tf.dtensor.Mesh]
-    (https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Mesh).
+    See more details in [jax.sharding.Mesh](
+        https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.Mesh)
+    and [tf.dtensor.Mesh](
+        https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Mesh).
     """
 
     def __init__(
@@ -72,10 +72,10 @@ class TensorLayout:
     `DeviceMesh` and `TensorLayout`, the actual mapping between a Tensor to the
     physical devices can be determined.
 
-    See more details in [jax.sharding.NamedSharding]
-    (https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.NamedSharding)
-    and [tf.dtensor.Layout]
-    (https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Layout).
+    See more details in [jax.sharding.NamedSharding](
+        https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.NamedSharding)
+    and [tf.dtensor.Layout](
+        https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Layout).
     """
 
     def __init__(self, axes):
@@ -132,11 +132,15 @@ class Distribution:
         pass
 
 
-def get_distribution():
+def distribution():
     """Retrieve the current distribution from global context."""
     return global_state.get_global_attribute(GLOBAL_ATTRIBUTE_NAME)
 
 
-def set_distribution(distribution):
-    """Set the distribution as the global distribution setting."""
-    global_state.set_global_attribute(GLOBAL_ATTRIBUTE_NAME, distribution)
+def set_distribution(value):
+    """Set the distribution as the global distribution setting.
+
+    Args:
+        value: a `Distribution` instance.
+    """
+    global_state.set_global_attribute(GLOBAL_ATTRIBUTE_NAME, value)

--- a/keras_core/distribution/distribution_lib.py
+++ b/keras_core/distribution/distribution_lib.py
@@ -7,7 +7,9 @@ will be implemented in future (via tf.dtensor API).
 """
 
 import contextlib
+import numpy as np
 
+from keras_core.backend import distribution_lib
 from keras_core.backend.common import global_state
 
 GLOBAL_ATTRIBUTE_NAME = "distribution"
@@ -26,7 +28,7 @@ def list_devices(device_type=None):
     Return:
         List of devices that are available for distribute computation.
     """
-    pass
+    return distribution_lib.list_devices(device_type)
 
 
 class DeviceMesh:
@@ -61,7 +63,42 @@ class DeviceMesh:
             devices: Optional list of devices. Default to all the available
                 devices locally from `list_devices()`.
         """
-        pass
+        if not shape or not axis_names:
+            raise ValueError(
+                "Shape and axis_names cannot be empty. Got "
+                f"shape: {shape}, axis_names: {axis_names}"
+            )
+
+        if len(shape) != len(axis_names):
+            raise ValueError(
+                "Shape and axis_names should have same size,"
+                f"got shape: {shape} and axis_names: {axis_names}"
+            )
+        if not devices:
+            devices = list_devices()
+        devices = np.array(devices)
+        if np.prod(shape) != np.prod(devices.shape):
+            raise ValueError(
+                "Shape does not match the number of devices. "
+                f"Got shape: {shape}, and shape of the "
+                f"devices: {devices.shape}"
+            )
+
+        self._shape = shape
+        self._axis_names = axis_names
+        self._devices = np.reshape(devices, shape)
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def axis_names(self):
+        return self._axis_names
+
+    @property
+    def devices(self):
+        return self._devices
 
 
 class TensorLayout:
@@ -78,15 +115,48 @@ class TensorLayout:
         https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Layout).
     """
 
-    def __init__(self, axes):
+    def __init__(self, axes, device_mesh=None):
         """Initialize the TensorLayout with axis names.
 
         Args:
             axes: list of strings that should map to the `axis_names` in
                 `DeviceMesh`. For any dimentions that doesn't need any sharding,
                 A `None` can be used a placeholder.
+            device_mesh: Optional `DeviceMesh` that will be used to create
+                the layout. The actual mapping of tensor to physical device
+                is not known until the mesh is specified.
         """
-        pass
+        self._axes = axes
+        self._device_mesh = device_mesh
+        self._validate_axes()
+
+    @property
+    def axes(self):
+        return self._axes
+
+    @property
+    def device_mesh(self):
+        return self._device_mesh
+
+    @device_mesh.setter
+    def device_mesh(self, device_mesh):
+        if self._device_mesh is not None:
+            raise ValueError(
+                "Cannot override device mesh value. Existing "
+                f"value is {self._device_mesh}"
+            )
+        self._device_mesh = device_mesh
+        self._validate_axes()
+
+    def _validate_axes(self):
+        if self._device_mesh:
+            valid_axis_names = set(self._device_mesh.axis_names)
+            axis_names = set(self._axes) - set([None])
+            if axis_names - valid_axis_names:
+                raise ValueError(
+                    "Invalid axis names for Layout. Valid axis "
+                    f"names: {valid_axis_names}, Got {axis_names}"
+                )
 
 
 class Distribution:

--- a/keras_core/distribution/distribution_lib.py
+++ b/keras_core/distribution/distribution_lib.py
@@ -111,7 +111,7 @@ class Distribution:
             data_shape: shape for the input data in list or tuple format.
 
         Returns:
-            The `TensorLayout` for the data, which can be used by 
+            The `TensorLayout` for the data, which can be used by
             `backend.distribute_tensor()` to redistribute a input data.
         """
         pass
@@ -125,7 +125,7 @@ class Distribution:
             variable_path: string, the path for the variable to be distributed.
 
         return:
-            The `TensorLayout` for the variable, which can be used by 
+            The `TensorLayout` for the variable, which can be used by
             `backend.distribute_tensor()` to redistribute a variable.
         """
         pass

--- a/keras_core/distribution/distribution_lib.py
+++ b/keras_core/distribution/distribution_lib.py
@@ -7,22 +7,21 @@ will be implemented in future (via tf.dtensor API).
 """
 
 import contextlib
-from typing import Any
 
-from keras_core import KerasVariable
 from keras_core.backend.common import global_state
 
 GLOBAL_ATTRIBUTE_NAME = "distribution"
 
 
-def list_devices(device_type: str = None) -> list[str]:
+def list_devices(device_type=None):
     """Return all the available devices based on the device type.
 
     Note that this should return the global devices in a distributed setting.
 
     Args:
-        device_type: CPU, GPU or TPU. Default to GPU or TPU if available when
-            device_type is not provided. Otherwise will return the CPU devices.
+        device_type: string of 'CPU', 'GPU' or 'TPU'. Default to GPU or TPU if
+            available when device_type is not provided. Otherwise will return
+            the CPU devices.
 
     Return:
         List of devices that are available for distribute computation.
@@ -36,27 +35,29 @@ class DeviceMesh:
     This is aligned with `jax.sharding.Mesh` and `tf.dtensor.Mesh`, which
     represents the computation devices in the global context.
 
-    See more details in
-    https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.Mesh
-    and https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Mesh.
+    See more details in [jax.sharding.Mesh]
+    (https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.Mesh)
+    and [tf.dtensor.Mesh]
+    (https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Mesh).
     """
 
     def __init__(
         self,
-        shape: list | tuple,
-        axis_names: list[str],
-        devices: list[str] = None,
+        shape,
+        axis_names,
+        devices=None,
     ):
         """Initialize the DeviceMesh for the given topology.
 
         Args:
-            shape: the shape of the overall DeviceMesh, e.g. (8,) for a data
-                parallel only distribution, or (4, 2) for a model+data parallel
-                distribution.
-            axis_names: The logical name of the each axis for the DeviceMesh.
-                The length of the `axis_names` should match to the rank of the
-                `shape`. The `axis_names` will be used to match/create the
-                `TensorLayout` when distribute the data and weights.
+            shape: tuple of list of integers. The shape of the overall
+                DeviceMesh, e.g. `(8,)` for a data parallel only distribution,
+                or `(4, 2)` for a model+data parallel distribution.
+            axis_names: List of string. The logical name of the each axis for
+                the DeviceMesh. The length of the `axis_names` should match to
+                the rank of the `shape`. The `axis_names` will be used to
+                match/create the `TensorLayout` when distribute the data and
+                weights.
             devices: Optional list of devices. Default to all the available
                 devices locally from `list_devices()`.
         """
@@ -71,16 +72,17 @@ class TensorLayout:
     `DeviceMesh` and `TensorLayout`, the actual mapping between a Tensor to the
     physical devices can be determined.
 
-    See more details in
-    https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.NamedSharding
-    and https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Layout.  # noqa: E501
+    See more details in [jax.sharding.NamedSharding]
+    (https://jax.readthedocs.io/en/latest/jax.sharding.html#jax.sharding.NamedSharding)
+    and [tf.dtensor.Layout]
+    (https://www.tensorflow.org/api_docs/python/tf/experimental/dtensor/Layout).
     """
 
-    def __init__(self, layout_spec: list | tuple):
-        """Initialize the TensorLayout with layout_spec.
+    def __init__(self, axes):
+        """Initialize the TensorLayout with axis names.
 
         Args:
-            layout_spec: list of strings that should map to the `axis_names` in
+            axes: list of strings that should map to the `axis_names` in
                 `DeviceMesh`. For any dimentions that doesn't need any sharding,
                 A `None` can be used a placeholder.
         """
@@ -99,10 +101,10 @@ class Distribution:
     `Distribution` and distribute the variable/data accordingly.
     """
 
-    def __init__(self, device_mesh: DeviceMesh):
+    def __init__(self, device_mesh):
         pass
 
-    def distribute_data(self, data) -> Any:
+    def distribute_data(self, data):
         """Shard the input data based on the Distribution setting.
 
         Args:
@@ -113,7 +115,7 @@ class Distribution:
         """
         pass
 
-    def distribute_variable(self, variable: KerasVariable) -> KerasVariable:
+    def distribute_variable(self, variable):
         """Distribute the variable based on the Distribution setting.
 
         Args:
@@ -124,21 +126,17 @@ class Distribution:
         """
         pass
 
-    def as_global_distribution(self):
-        """Set the current `Distribution` as the global distribution setting."""
-        pass
-
     @contextlib.contextmanager
     def scope(self):
         """Context manager to make the `Distribution` current."""
         pass
 
 
-def get_global_distribution():
+def get_distribution():
     """Retrieve the current distribution from global context."""
     return global_state.get_global_attribute(GLOBAL_ATTRIBUTE_NAME)
 
 
-def set_global_distribution(distribution: Distribution):
+def set_distribution(distribution):
     """Set the distribution as the global distribution setting."""
-    distribution.as_global_distribution()
+    global_state.set_global_attribute(GLOBAL_ATTRIBUTE_NAME, distribution)

--- a/keras_core/distribution/distribution_lib.py
+++ b/keras_core/distribution/distribution_lib.py
@@ -104,25 +104,29 @@ class Distribution:
     def __init__(self, device_mesh):
         pass
 
-    def distribute_data(self, data):
-        """Shard the input data based on the Distribution setting.
+    def get_data_layout(self, data_shape):
+        """Retrieve the `TensorLayout` for the input data.
 
         Args:
-            data: input data, can be Tensor and np.Array.
+            data_shape: shape for the input data in list or tuple format.
 
         Returns:
-            distributed data tensor.
+            The `TensorLayout` for the data, which can be used by 
+            `backend.distribute_tensor()` to redistribute a input data.
         """
         pass
 
-    def distribute_variable(self, variable):
-        """Distribute the variable based on the Distribution setting.
+    def get_variable_layout(self, variable_path):
+        """Retrieve the `TensorLayout` for the variable based on the path.
+
+        The path of the variable is available by `variable.path`.
 
         Args:
-            variable: a keras variable for distribution.
+            variable_path: string, the path for the variable to be distributed.
 
         return:
-            distributed keras variable.
+            The `TensorLayout` for the variable, which can be used by 
+            `backend.distribute_tensor()` to redistribute a variable.
         """
         pass
 

--- a/keras_core/distribution/distribution_lib_test.py
+++ b/keras_core/distribution/distribution_lib_test.py
@@ -1,0 +1,143 @@
+"""Test for distribution_lib.py."""
+
+import os
+
+import jax
+import pytest
+
+from keras_core import backend
+from keras_core.backend import distribution_lib as backend_dlib
+from keras_core.distribution import distribution_lib
+from keras_core import testing
+
+if backend.backend() == "jax":
+    # Due to https://github.com/google/jax/issues/17188, we can't
+    # override the XLA flag after the JAX back init. We have to
+    # run this at top level to let JAX pick the flag value.
+    xla_flags = os.getenv("XLA_FLAGS") or ""
+    # Don't override user-specified device count, or other XLA flags.
+    if "xla_force_host_platform_device_count" not in xla_flags:
+        os.environ["XLA_FLAGS"] = (
+            xla_flags + " --xla_force_host_platform_device_count=8"
+        )
+
+
+class DeviceMeshTest(testing.TestCase):
+    def test_mesh_creation(self):
+        devices = ["CPU:{i}" for i in range(8)]
+        shape = (4, 2)
+        axis_names = ["batch", "model"]
+
+        mesh = distribution_lib.DeviceMesh(shape, axis_names, devices)
+        self.assertEqual(mesh.shape, shape)
+        self.assertEqual(mesh.axis_names, axis_names)
+        self.assertEqual(mesh.devices.shape, shape)
+
+    def test_input_validation(self):
+        devices = ["CPU:{i}" for i in range(4)]
+        with self.assertRaisesRegex(
+            ValueError, "Shape and axis_names cannot be empty"
+        ):
+            distribution_lib.DeviceMesh((4,), "", devices)
+
+        with self.assertRaisesRegex(
+            ValueError, "Shape and axis_names should have same size"
+        ):
+            distribution_lib.DeviceMesh((4, 2), ["batch"], devices)
+
+        with self.assertRaisesRegex(
+            ValueError, "Shape does not match the number of devices"
+        ):
+            distribution_lib.DeviceMesh((4, 2), ["batch", "model"], devices)
+
+
+class TensorLayoutTest(testing.TestCase):
+    def setUp(self):
+        self.mesh = distribution_lib.DeviceMesh(
+            (4, 2), ["data", "model"], [f"CPU:{i}" for i in range(8)]
+        )
+
+    def test_tensor_layout_creation(self):
+        axes = ["data", None]
+        layout = distribution_lib.TensorLayout(axes, self.mesh)
+
+        self.assertEqual(layout.device_mesh, self.mesh)
+        self.assertEqual(layout.axes, axes)
+
+    def test_tensor_layout_validation(self):
+        axes = ["data", "unknown", None]
+        with self.assertRaisesRegex(
+            ValueError, "Invalid axis names for Layout"
+        ):
+            distribution_lib.TensorLayout(axes, self.mesh)
+
+    def test_lazy_device_mesh_injection(self):
+        axes = ["data", None]
+        layout = distribution_lib.TensorLayout(axes, None)
+
+        self.assertIsNone(layout.device_mesh)
+        self.assertEqual(layout.axes, axes)
+
+        layout.device_mesh = self.mesh
+
+        self.assertEqual(layout.device_mesh, self.mesh)
+        self.assertEqual(layout.axes, axes)
+
+    def test_lazy_device_mesh_validation(self):
+        axes = ["data", "unknown", None]
+        layout = distribution_lib.TensorLayout(axes, None)
+
+        self.assertIsNone(layout.device_mesh)
+        self.assertEqual(layout.axes, axes)
+
+        with self.assertRaisesRegex(
+            ValueError, "Invalid axis names for Layout"
+        ):
+            layout.device_mesh = self.mesh
+
+
+@pytest.mark.skipif(
+    backend.backend() != "jax",
+    reason="Backend specific test",
+)
+class JaxDistributionLibTest(testing.TestCase):
+    def test_list_devices(self):
+        self.assertEqual(len(distribution_lib.list_devices()), 8)
+        self.assertEqual(len(distribution_lib.list_devices("cpu")), 8)
+        self.assertEqual(len(distribution_lib.list_devices("CPU")), 8)
+
+    def test_to_backend_mesh(self):
+        devices = ["CPU:{i}" for i in range(8)]
+        shape = (4, 2)
+        axis_names = ["batch", "model"]
+
+        mesh = distribution_lib.DeviceMesh(shape, axis_names, devices)
+        jax_mesh = backend_dlib.to_backend_mesh(mesh)
+
+        self.assertIsInstance(jax_mesh, jax.sharding.Mesh)
+        self.assertEqual(jax_mesh.devices.shape, shape)
+        self.assertEqual(jax_mesh.axis_names, ("batch", "model"))
+
+    def test_to_backend_layout(self):
+        axes = ["data", None]
+        mesh = distribution_lib.DeviceMesh(
+            (4, 2), ["data", "model"], [f"CPU:{i}" for i in range(8)]
+        )
+        layout = distribution_lib.TensorLayout(axes, mesh)
+        jax_sharding = backend_dlib.to_backend_layout(layout)
+        jax_mesh = backend_dlib.to_backend_mesh(mesh)
+        self.assertEqual(
+            jax_sharding,
+            jax.sharding.NamedSharding(
+                jax_mesh, jax.sharding.PartitionSpec("data", None)
+            ),
+        )
+
+    def test_validation_for_device_mesh(self):
+        axes = ["data", None]
+        layout = distribution_lib.TensorLayout(axes, device_mesh=None)
+
+        with self.assertRaisesRegex(
+            ValueError, "Cannot create sharding when device mesh is not set"
+        ):
+            backend_dlib.to_backend_layout(layout)


### PR DESCRIPTION
1. Implemented DeviceMesh and TensorLayout
2. Implemented list_devices.
3. Add backend functions for list_devices, and conversion functions to jax native Mesh and Sharding.
4. Update the TensorLayout to also include the DeviceMesh, which is needed when converting the actual backend layout.
5. Added unit tests.

Note that there is a dummy distribution_lib in the backend/__init__.py, the unit test will fail for other backends (due to import) if this dummy placeholder is not there.