### PR TITLE
Fix bug: Softmax function to support tuple axes + Add more tests

### DIFF
--- a/keras_core/activations/activations_test.py
+++ b/keras_core/activations/activations_test.py
@@ -31,16 +31,13 @@ class ActivationsTest(testing.TestCase):
             expected[:, i] = _ref_softmax(x[:, i])
         self.assertAllClose(result, expected, rtol=1e-05)
 
-    # TODO: Fails on Tuple Axis
-    # ops/nn_ops.py:3824: TypeError:
-    # '<=' not supported between instances of 'int' and 'tuple'
-    # def test_softmax_3d_axis_tuple(self):
-    #     x = np.random.random((2, 3, 5))
-    #     result = activations.softmax([x], axis=(1, 2))[0]
-    #     expected = np.zeros((2, 3, 5))
-    #     for i in range(2):
-    #         expected[i, :, :] = _ref_softmax(x[i, :, :])
-    #     self.assertAllClose(result, expected, rtol=1e-05)
+    def test_softmax_3d_axis_tuple(self):
+        x = np.random.random((2, 3, 5))
+        result = activations.softmax([x], axis=(1, 2))[0]
+        expected = np.zeros((2, 3, 5))
+        for i in range(2):
+            expected[i, :, :] = _ref_softmax(x[i, :, :])
+        self.assertAllClose(result, expected, rtol=1e-05)
 
     def test_temporal_softmax(self):
         x = np.random.random((2, 2, 3)) * 10

--- a/keras_core/activations/activations_test.py
+++ b/keras_core/activations/activations_test.py
@@ -54,6 +54,15 @@ class ActivationsTest(testing.TestCase):
                 expected[i, j, :, :] = _ref_softmax(x[i, j, :, :])
         self.assertAllClose(result, expected, rtol=1e-05)
 
+    def test_softmax_higher_dim_multiple_axes(self):
+        x = np.random.random((2, 3, 4, 5, 6))
+        result = activations.softmax(x, axis=(2, 3, 4))
+        expected = np.zeros((2, 3, 4, 5, 6))
+        for i in range(2):
+            for j in range(3):
+                expected[i, j, :, :, :] = _ref_softmax(x[i, j, :, :, :])
+        self.assertAllClose(result, expected, rtol=1e-05)
+
     def test_softmax_negative_axis(self):
         x = np.random.random((2, 5))
         result = activations.softmax(x, axis=-1)

--- a/keras_core/activations/activations_test.py
+++ b/keras_core/activations/activations_test.py
@@ -33,7 +33,7 @@ class ActivationsTest(testing.TestCase):
 
     def test_softmax_3d_axis_tuple(self):
         x = np.random.random((2, 3, 5))
-        result = activations.softmax(x, axis=(1, 2))[0]
+        result = activations.softmax(x, axis=(1, 2))
         expected = np.zeros((2, 3, 5))
         for i in range(2):
             expected[i, :, :] = _ref_softmax(x[i, :, :])

--- a/keras_core/activations/activations_test.py
+++ b/keras_core/activations/activations_test.py
@@ -39,6 +39,29 @@ class ActivationsTest(testing.TestCase):
             expected[i, :, :] = _ref_softmax(x[i, :, :])
         self.assertAllClose(result, expected, rtol=1e-05)
 
+    def test_softmax_1d(self):
+        x = np.random.random(5)
+        result = activations.softmax(x)
+        expected = _ref_softmax(x)
+        self.assertAllClose(result, expected, rtol=1e-05)
+
+    def test_softmax_higher_dim(self):
+        x = np.random.random((2, 3, 4, 5))
+        result = activations.softmax(x, axis=(2, 3))
+        expected = np.zeros((2, 3, 4, 5))
+        for i in range(2):
+            for j in range(3):
+                expected[i, j, :, :] = _ref_softmax(x[i, j, :, :])
+        self.assertAllClose(result, expected, rtol=1e-05)
+
+    def test_softmax_negative_axis(self):
+        x = np.random.random((2, 5))
+        result = activations.softmax(x, axis=-1)
+        expected = np.zeros((2, 5))
+        for i in range(2):
+            expected[i, :] = _ref_softmax(x[i, :])
+        self.assertAllClose(result, expected, rtol=1e-05)
+
     def test_temporal_softmax(self):
         x = np.random.random((2, 2, 3)) * 10
         result = activations.softmax(x[np.newaxis, :])[0]

--- a/keras_core/activations/activations_test.py
+++ b/keras_core/activations/activations_test.py
@@ -33,7 +33,7 @@ class ActivationsTest(testing.TestCase):
 
     def test_softmax_3d_axis_tuple(self):
         x = np.random.random((2, 3, 5))
-        result = activations.softmax([x], axis=(1, 2))[0]
+        result = activations.softmax(x, axis=(1, 2))[0]
         expected = np.zeros((2, 3, 5))
         for i in range(2):
             expected[i, :, :] = _ref_softmax(x[i, :, :])

--- a/keras_core/ops/nn.py
+++ b/keras_core/ops/nn.py
@@ -494,8 +494,6 @@ def softmax(x, axis=-1):
     """
     if any_symbolic_tensors((x,)):
         return Softmax(axis).symbolic_call(x)
-    if isinstance(x, list):
-        x = KerasTensor(x)
     if isinstance(axis, tuple):
         original_shape = x.shape
         new_shape = []

--- a/keras_core/ops/nn.py
+++ b/keras_core/ops/nn.py
@@ -494,8 +494,9 @@ def softmax(x, axis=-1):
     """
     if any_symbolic_tensors((x,)):
         return Softmax(axis).symbolic_call(x)
+    if isinstance(x, list):
+        x = np.array(x)
     if isinstance(axis, tuple):
-        # Get original shape
         original_shape = x.shape
         new_shape = []
         skip_dims = set(axis)

--- a/keras_core/ops/nn.py
+++ b/keras_core/ops/nn.py
@@ -495,7 +495,7 @@ def softmax(x, axis=-1):
     if any_symbolic_tensors((x,)):
         return Softmax(axis).symbolic_call(x)
     if isinstance(x, list):
-        x = np.array(x)
+        x = KerasTensor(x)
     if isinstance(axis, tuple):
         original_shape = x.shape
         new_shape = []

--- a/keras_core/ops/nn.py
+++ b/keras_core/ops/nn.py
@@ -494,7 +494,28 @@ def softmax(x, axis=-1):
     """
     if any_symbolic_tensors((x,)):
         return Softmax(axis).symbolic_call(x)
-    return backend.nn.softmax(x, axis=axis)
+    if isinstance(axis, tuple):
+        # Get original shape
+        original_shape = x.shape
+        new_shape = []
+        skip_dims = set(axis)
+        i = 0
+        while i < len(original_shape):
+            if i in skip_dims:
+                size = 1
+                while i in skip_dims:
+                    size *= original_shape[i]
+                    i += 1
+                new_shape.append(size)
+            else:
+                new_shape.append(original_shape[i])
+                i += 1
+        x = x.reshape(new_shape)
+        x = backend.nn.softmax(x, axis=-1)
+        x = x.reshape(original_shape)
+        return x
+    else:
+        return backend.nn.softmax(x, axis=axis)
 
 
 class LogSoftmax(Operation):


### PR DESCRIPTION
Fixing the softmax function in keras_core.ops to handle tuple axes.


**Why :**

[One ](https://github.com/keras-team/keras-core/blob/38c9f7d1691d5d7af79811afd3f5df4e53352094/keras_core/activations/activations_test.py#L34C7-L34C32)of the TODOs 


**Changes**:

1. Updated softmax function in keras_core.ops.
2. Added back test test_softmax_3d_axis_tuple to validate changes.
3. Added comprehensive test cases for the softmax activation function to ensure its correctness and robustness across various scenarios: 
                  -               Handle 1D inputs, 
                  -               Support higher-dimensional tensors.
                  -               Process negative axis values.
                  -               Higher dimensions with even higher axes.