### PR TITLE
Added imports to keras_core.applications __init__ file

### DIFF
--- a/keras_core/applications/__init__.py
+++ b/keras_core/applications/__init__.py
@@ -3,12 +3,36 @@ from keras_core.applications.convnext import ConvNeXtSmall
 from keras_core.applications.convnext import ConvNeXtBase
 from keras_core.applications.convnext import ConvNeXtLarge
 from keras_core.applications.convnext import ConvNeXtXLarge
+from keras_core.applications.convnext import preprocess_input
+from keras_core.applications.convnext import decode_predictions
 
 from keras_core.applications.densenet import DenseNet121
 from keras_core.applications.densenet import DenseNet169
 from keras_core.applications.densenet import DenseNet201
+from keras_core.applications.densenet import preprocess_input
+from keras_core.applications.densenet import decode_predictions
 
 from keras_core.applications.efficientnet import EfficientNetB0
+from keras_core.applications.efficientnet import EfficientNetB1
+from keras_core.applications.efficientnet import EfficientNetB2
+from keras_core.applications.efficientnet import EfficientNetB3
+from keras_core.applications.efficientnet import EfficientNetB4
+from keras_core.applications.efficientnet import EfficientNetB5
+from keras_core.applications.efficientnet import EfficientNetB6
+from keras_core.applications.efficientnet import EfficientNetB7
+from keras_core.applications.efficientnet import preprocess_input
+from keras_core.applications.efficientnet import decode_predictions
+
+from keras_core.applications.efficientnet_v2 import EfficientNetV2B0
+from keras_core.applications.efficientnet_v2 import EfficientNetV2B1
+from keras_core.applications.efficientnet_v2 import EfficientNetV2B2
+from keras_core.applications.efficientnet_v2 import EfficientNetV2B3
+from keras_core.applications.efficientnet_v2 import EfficientNetV2M
+from keras_core.applications.efficientnet_v2 import EfficientNetV2S
+from keras_core.applications.efficientnet_v2 import EfficientNetV2L
+from keras_core.applications.efficientnet_v2 import preprocess_input
+from keras_core.applications.efficientnet_v2 import decode_predictions
+
 
 from keras_core.applications.vgg16 import VGG16
 from keras_core.applications.vgg16 import preprocess_input

--- a/keras_core/applications/__init__.py
+++ b/keras_core/applications/__init__.py
@@ -1,0 +1,19 @@
+from keras_core.applications.convnext import ConvNeXtTiny
+from keras_core.applications.convnext import ConvNeXtSmall
+from keras_core.applications.convnext import ConvNeXtBase
+from keras_core.applications.convnext import ConvNeXtLarge
+from keras_core.applications.convnext import ConvNeXtXLarge
+
+from keras_core.applications.densenet import DenseNet121
+from keras_core.applications.densenet import DenseNet169
+from keras_core.applications.densenet import DenseNet201
+
+from keras_core.applications.efficientnet import EfficientNetB0
+
+from keras_core.applications.vgg16 import VGG16
+from keras_core.applications.vgg16 import preprocess_input
+from keras_core.applications.vgg16 import decode_predictions
+
+from keras_core.applications.vgg19 import VGG19
+from keras_core.applications.vgg19 import preprocess_input
+from keras_core.applications.vgg19 import decode_predictions


### PR DESCRIPTION
I had issue #756 which occurred while trying to import VGG16 model from keras_core.applications as the __init__.py doesn't import the models built in the keras_core.applications. 

I have included the imports to the VGG16, VGG19, and EfficientNet models with this PR.