### PR TITLE
Split fix

### DIFF
--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -772,7 +772,7 @@ def sort(x, axis=-1):
 
 def split(x, indices_or_sections, axis=0):
     x = convert_to_tensor(x)
-    if isinstance(indices_or_sections, list):
+    if isinstance(indices_or_sections, (list, tuple)):
         idxs = convert_to_tensor(indices_or_sections)
         start_size = indices_or_sections[0]
         end_size = x.shape[axis] - indices_or_sections[-1]

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -4339,7 +4339,9 @@ def sort(x, axis=-1):
 class Split(Operation):
     def __init__(self, indices_or_sections, axis=0):
         super().__init__()
-        self.indices_or_sections = tuple(indices_or_sections)
+        if not isinstance(indices_or_sections, int):
+            indices_or_sections = tuple(indices_or_sections)
+        self.indices_or_sections = indices_or_sections
         self.axis = axis
 
     def call(self, x):

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -4339,7 +4339,7 @@ def sort(x, axis=-1):
 class Split(Operation):
     def __init__(self, indices_or_sections, axis=0):
         super().__init__()
-        self.indices_or_sections = list(indices_or_sections)
+        self.indices_or_sections = tuple(indices_or_sections)
         self.axis = axis
 
     def call(self, x):
@@ -4369,11 +4369,7 @@ class Split(Operation):
                 for _ in range(self.indices_or_sections)
             ]
 
-        indices_or_sections = (
-            [0]
-            + self.indices_or_sections
-            + [x_size_on_axis]
-        )
+        indices_or_sections = (0, *self.indices_or_sections, x_size_on_axis)
         output_size = np.diff(indices_or_sections)
         outputs = []
         for i in range(len(output_size)):

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -4339,7 +4339,7 @@ def sort(x, axis=-1):
 class Split(Operation):
     def __init__(self, indices_or_sections, axis=0):
         super().__init__()
-        self.indices_or_sections = indices_or_sections
+        self.indices_or_sections = list(indices_or_sections)
         self.axis = axis
 
     def call(self, x):
@@ -4369,7 +4369,11 @@ class Split(Operation):
                 for _ in range(self.indices_or_sections)
             ]
 
-        indices_or_sections = [0] + self.indices_or_sections
+        indices_or_sections = (
+            [0]
+            + self.indices_or_sections
+            + [x_size_on_axis]
+        )
         output_size = np.diff(indices_or_sections)
         outputs = []
         for i in range(len(output_size)):

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -1141,7 +1141,10 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor([None, 3, 3])
         self.assertEqual(knp.split(x, 2)[0].shape, (None, 3, 3))
         self.assertEqual(knp.split(x, 3, axis=1)[0].shape, (None, 1, 3))
+        self.assertEqual(len(knp.split(x, [1, 3], axis=1)), 3)
+        self.assertEqual(knp.split(x, [1, 3], axis=1)[0].shape, (None, 1, 3))
         self.assertEqual(knp.split(x, [1, 3], axis=1)[1].shape, (None, 2, 3))
+        self.assertEqual(knp.split(x, [1, 3], axis=1)[2].shape, (None, 0, 3))
 
     def test_sqrt(self):
         x = KerasTensor([None, 3])
@@ -1603,7 +1606,10 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(len(knp.split(x, 2)), 2)
         self.assertEqual(knp.split(x, 2)[0].shape, (1, 3))
         self.assertEqual(knp.split(x, 3, axis=1)[0].shape, (2, 1))
+        self.assertEqual(len(knp.split(x, [1, 3], axis=1)), 3)
+        self.assertEqual(knp.split(x, [1, 3], axis=1)[0].shape, (2, 1))
         self.assertEqual(knp.split(x, [1, 3], axis=1)[1].shape, (2, 2))
+        self.assertEqual(knp.split(x, [1, 3], axis=1)[2].shape, (2, 0))
 
         with self.assertRaises(ValueError):
             knp.split(x, 2, axis=1)


### PR DESCRIPTION
Split's `compute_output_spec` does not return the final element (though the underlying `call` does). This addresses this, plus allows passing tuples to `keras.ops.split` without error.