### PR TITLE
Fix argument order in stft and istft

### DIFF
--- a/keras_core/ops/math.py
+++ b/keras_core/ops/math.py
@@ -763,7 +763,11 @@ def stft(
     """
     if any_symbolic_tensors((x,)):
         return STFT(
-            sequence_length, sequence_stride, fft_length, center, window
+            sequence_length=sequence_length,
+            sequence_stride=sequence_stride,
+            fft_length=fft_length,
+            window=window,
+            center=center,
         ).symbolic_call(x)
     return backend.math.stft(
         x,
@@ -883,7 +887,11 @@ def istft(
     """
     if any_symbolic_tensors(x):
         return ISTFT(
-            sequence_length, sequence_stride, fft_length, length, center, window
+            sequence_length=sequence_length,
+            sequence_stride=sequence_stride,
+            fft_length=fft_length,
+            window=window,
+            center=center,
         ).symbolic_call(x)
     return backend.math.istft(
         x,


### PR DESCRIPTION
(Sorry for the typo in previous PR)

The argument order in the stft and istft functions was incorrect.
`(sequence_length, sequence_stride, fft_length, center, window)` should be `(sequence_length, sequence_stride, fft_length, window, center)`

This PR addresses it by using kwargs to validate the provided args.
