### PR TITLE
Fix bug: Log_Softmax with tuple axes + Add tests

### DIFF
--- a/keras_core/activations/activations_test.py
+++ b/keras_core/activations/activations_test.py
@@ -17,8 +17,9 @@ def _ref_softplus(x):
 
 def _ref_log_softmax(values):
     max_val = np.max(values)  # for numerical stability
-    log_sum_exp = np.log(np.sum(np.exp(values - max_val)))
-    return values - log_sum_exp
+    stabilized_values = values - max_val
+    log_sum_exp = np.log(np.sum(np.exp(stabilized_values)))
+    return stabilized_values - log_sum_exp
 
 
 class ActivationsTest(testing.TestCase):

--- a/keras_core/activations/activations_test.py
+++ b/keras_core/activations/activations_test.py
@@ -15,6 +15,12 @@ def _ref_softplus(x):
     return np.log(np.ones_like(x) + np.exp(x))
 
 
+def _ref_log_softmax(values):
+    max_val = np.max(values)  # for numerical stability
+    log_sum_exp = np.log(np.sum(np.exp(values - max_val)))
+    return values - log_sum_exp
+
+
 class ActivationsTest(testing.TestCase):
     def test_softmax(self):
         x = np.random.random((2, 5))
@@ -75,6 +81,60 @@ class ActivationsTest(testing.TestCase):
         x = np.random.random((2, 2, 3)) * 10
         result = activations.softmax(x[np.newaxis, :])[0]
         expected = _ref_softmax(x[0, 0])
+        self.assertAllClose(result[0, 0], expected, rtol=1e-05)
+
+    def test_log_softmax_2d_axis_0(self):
+        x = np.random.random((2, 5))
+        result = activations.log_softmax(x[np.newaxis, :], axis=1)[0]
+        expected = np.zeros((2, 5))
+        for i in range(5):
+            expected[:, i] = _ref_log_softmax(x[:, i])
+        self.assertAllClose(result, expected, rtol=1e-05)
+
+    def test_log_softmax_3d_axis_tuple(self):
+        x = np.random.random((2, 3, 5))
+        result = activations.log_softmax(x, axis=(1, 2))
+        expected = np.zeros((2, 3, 5))
+        for i in range(2):
+            expected[i, :, :] = _ref_log_softmax(x[i, :, :])
+        self.assertAllClose(result, expected, rtol=1e-05)
+
+    def test_log_softmax_1d(self):
+        x = np.random.random(5)
+        result = activations.log_softmax(x)
+        expected = _ref_log_softmax(x)
+        self.assertAllClose(result, expected, rtol=1e-05)
+
+    def test_log_softmax_higher_dim(self):
+        x = np.random.random((2, 3, 4, 5))
+        result = activations.log_softmax(x, axis=(2, 3))
+        expected = np.zeros((2, 3, 4, 5))
+        for i in range(2):
+            for j in range(3):
+                expected[i, j, :, :] = _ref_log_softmax(x[i, j, :, :])
+        self.assertAllClose(result, expected, rtol=1e-05)
+
+    def test_log_softmax_higher_dim_multiple_axes(self):
+        x = np.random.random((2, 3, 4, 5, 6))
+        result = activations.log_softmax(x, axis=(2, 3, 4))
+        expected = np.zeros((2, 3, 4, 5, 6))
+        for i in range(2):
+            for j in range(3):
+                expected[i, j, :, :, :] = _ref_log_softmax(x[i, j, :, :, :])
+        self.assertAllClose(result, expected, rtol=1e-05)
+
+    def test_log_softmax_negative_axis(self):
+        x = np.random.random((2, 5))
+        result = activations.log_softmax(x, axis=-1)
+        expected = np.zeros((2, 5))
+        for i in range(2):
+            expected[i, :] = _ref_log_softmax(x[i, :])
+        self.assertAllClose(result, expected, rtol=1e-05)
+
+    def test_temporal_log_softmax(self):
+        x = np.random.random((2, 2, 3)) * 10
+        result = activations.log_softmax(x[np.newaxis, :])[0]
+        expected = _ref_log_softmax(x[0, 0])
         self.assertAllClose(result[0, 0], expected, rtol=1e-05)
 
     def test_selu(self):

--- a/keras_core/ops/nn.py
+++ b/keras_core/ops/nn.py
@@ -559,7 +559,27 @@ def log_softmax(x, axis=-1):
     """
     if any_symbolic_tensors((x,)):
         return LogSoftmax(axis).symbolic_call(x)
-    return backend.nn.log_softmax(x, axis=axis)
+    if isinstance(axis, tuple):
+        original_shape = x.shape
+        new_shape = []
+        skip_dims = set(axis)
+        i = 0
+        while i < len(original_shape):
+            if i in skip_dims:
+                size = 1
+                while i in skip_dims:
+                    size *= original_shape[i]
+                    i += 1
+                new_shape.append(size)
+            else:
+                new_shape.append(original_shape[i])
+                i += 1
+        x = x.reshape(new_shape)
+        x = backend.nn.log_softmax(x, axis=-1)
+        x = x.reshape(original_shape)
+        return x
+    else:
+        return backend.nn.log_softmax(x, axis=axis)
 
 
 class MaxPool(Operation):


### PR DESCRIPTION
The PR aims to fix a bug associated with the `log_softmax` function when provided with tuple `axes`. In addition, several tests have been added to ensure the correctness of the function across various scenarios.


**Key Updates**:

1. **File**: `keras_core/ops/nn.py`
    - Modified the `log_softmax` function to handle tuple `axes`.

2. **File**: `keras_core/activations/activations_test.py`
    - Added a reference function `_ref_log_softmax` that implements the log-softmax operation for testing.
    - Introduced various tests for the `log_softmax` function, including:
        - `test_log_softmax_2d_axis_0`
        - `test_log_softmax_3d_axis_tuple`
        - `test_log_softmax_1d`
        - `test_log_softmax_higher_dim`
        - `test_log_softmax_higher_dim_multiple_axes`
        - `test_log_softmax_negative_axis`
        - `test_temporal_log_softmax`





