### PR TITLE
Update example losses on docstrings

### DIFF
--- a/keras_core/metrics/accuracy_metrics.py
+++ b/keras_core/metrics/accuracy_metrics.py
@@ -48,7 +48,7 @@ class Accuracy(reduction_metrics.MeanMetricWrapper):
 
     ```python
     model.compile(optimizer='sgd',
-                  loss='mse',
+                  loss='binary_crossentropy',
                   metrics=[keras_core.metrics.Accuracy()])
     ```
     """
@@ -108,7 +108,7 @@ class BinaryAccuracy(reduction_metrics.MeanMetricWrapper):
 
     ```python
     model.compile(optimizer='sgd',
-                  loss='mse',
+                  loss='binary_crossentropy',
                   metrics=[keras_core.metrics.BinaryAccuracy()])
     ```
     """
@@ -194,7 +194,7 @@ class CategoricalAccuracy(reduction_metrics.MeanMetricWrapper):
 
     ```python
     model.compile(optimizer='sgd',
-                  loss='mse',
+                  loss='categorical_crossentropy',
                   metrics=[keras_core.metrics.CategoricalAccuracy()])
     ```
     """
@@ -278,7 +278,7 @@ class SparseCategoricalAccuracy(reduction_metrics.MeanMetricWrapper):
 
     ```python
     model.compile(optimizer='sgd',
-                  loss='mse',
+                  loss='sparse_categorical_crossentropy',
                   metrics=[keras_core.metrics.SparseCategoricalAccuracy()])
     ```
     """
@@ -349,7 +349,7 @@ class TopKCategoricalAccuracy(reduction_metrics.MeanMetricWrapper):
 
     ```python
     model.compile(optimizer='sgd',
-                  loss='mse',
+                  loss='categorical_crossentropy',
                   metrics=[keras_core.metrics.TopKCategoricalAccuracy()])
     ```
     """
@@ -423,7 +423,7 @@ class SparseTopKCategoricalAccuracy(reduction_metrics.MeanMetricWrapper):
 
     ```python
     model.compile(optimizer='sgd',
-                  loss='mse',
+                  loss='sparse_categorical_crossentropy',
                   metrics=[keras_core.metrics.SparseTopKCategoricalAccuracy()])
     ```
     """


### PR DESCRIPTION
It is better to demonstrate those metrics using suitable loss functions rather than `mse`