### PR TITLE
Add a check for class_id argument

### DIFF
--- a/keras_core/metrics/confusion_metrics_test.py
+++ b/keras_core/metrics/confusion_metrics_test.py
@@ -501,13 +501,13 @@ class PrecisionTest(testing.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            r"When class_id is provided, y_pred must be a 2D array with shape "
-            r"(num_samples, num_classes), found shape: *"
+            r"When class_id is provided, y_pred must be a 2D array "
+            r"with shape \(num_samples, num_classes\), found shape:.*"
         ):
-            p_obj(y_true, y_pred, class_id=2)
+            p_obj(y_true, y_pred)
 
     def test_unweighted_class_id_multiclass(self):
-        p_obj = metrics.Precision()
+        p_obj = metrics.Precision(class_id=1)
 
         y_pred = np.array([[0.1, 0.2, 0.7],
                            [0.5, 0.3, 0.2],
@@ -521,7 +521,7 @@ class PrecisionTest(testing.TestCase):
                            [1., 0., 0.],
                            [0., 0., 1.]])
 
-        result = p_obj(y_true, y_pred, class_id=1)
+        result = p_obj(y_true, y_pred)
         self.assertAlmostEqual(1.0, result)
         self.assertAlmostEqual(1.0, p_obj.true_positives)
         self.assertAlmostEqual(0.0, p_obj.false_positives)
@@ -653,13 +653,14 @@ class RecallTest(testing.TestCase):
         y_true = np.array([0, 1, 1, 0, 0])
 
         with self.assertRaisesRegex(
-            ValueError, r"When class_id is provided, y_pred must be a 2D array"
-                        r" with shape (num_samples, num_classes), found shape:*"
+            ValueError,
+            r"When class_id is provided, y_pred must be a 2D array "
+            r"with shape \(num_samples, num_classes\), found shape:.*"
         ):
             r_obj(y_true, y_pred)
 
     def test_unweighted_class_id_multiclass(self):
-        r_obj = metrics.Recall(class_id=2)
+        r_obj = metrics.Recall(class_id=1)
 
         y_pred = np.array([[0.1, 0.2, 0.7],
                            [0.5, 0.3, 0.2],

--- a/keras_core/metrics/confusion_metrics_test.py
+++ b/keras_core/metrics/confusion_metrics_test.py
@@ -493,46 +493,38 @@ class PrecisionTest(testing.TestCase):
         expected_precision = tp / predicted_positives
         self.assertAlmostEqual(expected_precision, result)
 
-    def test_unweighted_class_id(self):
+    def test_unweighted_class_id_should_throw_error_1d(self):
         p_obj = metrics.Precision(class_id=2)
 
         y_pred = np.array([0.2, 0.1, 0.6, 0, 0.2])
         y_true = np.array([0, 1, 1, 0, 0])
-        result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual(1, result)
-        self.assertAlmostEqual(1, p_obj.true_positives)
-        self.assertAlmostEqual(0, p_obj.false_positives)
 
-        y_pred = np.array([0.2, 0.1, 0, 0, 0.2])
-        y_true = np.array([0, 1, 1, 0, 0])
-        result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual(1, result)
-        self.assertAlmostEqual(1, p_obj.true_positives)
-        self.assertAlmostEqual(0, p_obj.false_positives)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"When class_id is provided, y_pred must be a 2D array with shape "
+            r"(num_samples, num_classes), found shape: *"
+        ):
+            p_obj(y_true, y_pred, class_id=2)
 
-        y_pred = np.array([0.2, 0.1, 0.6, 0, 0.2])
-        y_true = np.array([0, 1, 0, 0, 0])
-        result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual(0.5, result)
-        self.assertAlmostEqual(1, p_obj.true_positives)
-        self.assertAlmostEqual(1, p_obj.false_positives)
+    def test_unweighted_class_id_multiclass(self):
+        p_obj = metrics.Precision()
 
-    def test_unweighted_top_k_and_class_id(self):
-        p_obj = metrics.Precision(class_id=2, top_k=2)
+        y_pred = np.array([[0.1, 0.2, 0.7],
+                           [0.5, 0.3, 0.2],
+                           [0.2, 0.6, 0.2],
+                           [0.7, 0.2, 0.1],
+                           [0.1, 0.1, 0.8]])
 
-        y_pred = np.array([0.2, 0.6, 0.3, 0, 0.2])
-        y_true = np.array([0, 1, 1, 0, 0])
-        result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual(1, result)
-        self.assertAlmostEqual(1, p_obj.true_positives)
-        self.assertAlmostEqual(0, p_obj.false_positives)
+        y_true = np.array([[0., 0., 1.],
+                           [1., 0., 0.],
+                           [0., 1., 0.],
+                           [1., 0., 0.],
+                           [0., 0., 1.]])
 
-        y_pred = np.array([1, 1, 0.9, 1, 1])
-        y_true = np.array([0, 1, 1, 0, 0])
-        result = p_obj(y_true, y_pred)
-        self.assertAlmostEqual(1, result)
-        self.assertAlmostEqual(1, p_obj.true_positives)
-        self.assertAlmostEqual(0, p_obj.false_positives)
+        result = p_obj(y_true, y_pred, class_id=1)
+        self.assertAlmostEqual(1.0, result)
+        self.assertAlmostEqual(1.0, p_obj.true_positives)
+        self.assertAlmostEqual(0.0, p_obj.false_positives)
 
     def test_unweighted_top_k_and_threshold(self):
         p_obj = metrics.Precision(thresholds=0.7, top_k=2)
@@ -654,41 +646,37 @@ class RecallTest(testing.TestCase):
         expected_recall = tp / positives
         self.assertAlmostEqual(expected_recall, result)
 
-    def test_unweighted_class_id(self):
+    def test_unweighted_class_id_should_throw_error_1d(self):
         r_obj = metrics.Recall(class_id=2)
 
         y_pred = np.array([0.2, 0.1, 0.6, 0, 0.2])
         y_true = np.array([0, 1, 1, 0, 0])
-        self.assertAlmostEqual(1, r_obj(y_true, y_pred))
-        self.assertAlmostEqual(1, r_obj.true_positives)
-        self.assertAlmostEqual(0, r_obj.false_negatives)
 
-        y_pred = np.array([0.2, 0.1, 0, 0, 0.2])
-        y_true = np.array([0, 1, 1, 0, 0])
-        self.assertAlmostEqual(0.5, r_obj(y_true, y_pred))
-        self.assertAlmostEqual(1, r_obj.true_positives)
-        self.assertAlmostEqual(1, r_obj.false_negatives)
+        with self.assertRaisesRegex(
+            ValueError, r"When class_id is provided, y_pred must be a 2D array"
+                        r" with shape (num_samples, num_classes), found shape:*"
+        ):
+            r_obj(y_true, y_pred)
 
-        y_pred = np.array([0.2, 0.1, 0.6, 0, 0.2])
-        y_true = np.array([0, 1, 0, 0, 0])
-        self.assertAlmostEqual(0.5, r_obj(y_true, y_pred))
-        self.assertAlmostEqual(1, r_obj.true_positives)
-        self.assertAlmostEqual(1, r_obj.false_negatives)
+    def test_unweighted_class_id_multiclass(self):
+        r_obj = metrics.Recall(class_id=2)
 
-    def test_unweighted_top_k_and_class_id(self):
-        r_obj = metrics.Recall(class_id=2, top_k=2)
+        y_pred = np.array([[0.1, 0.2, 0.7],
+                           [0.5, 0.3, 0.2],
+                           [0.2, 0.6, 0.2],
+                           [0.7, 0.2, 0.1],
+                           [0.1, 0.1, 0.8]])
 
-        y_pred = np.array([0.2, 0.6, 0.3, 0, 0.2])
-        y_true = np.array([0, 1, 1, 0, 0])
-        self.assertAlmostEqual(1, r_obj(y_true, y_pred))
-        self.assertAlmostEqual(1, r_obj.true_positives)
-        self.assertAlmostEqual(0, r_obj.false_negatives)
+        y_true = np.array([[0., 0., 1.],
+                           [1., 0., 0.],
+                           [0., 1., 0.],
+                           [1., 0., 0.],
+                           [0., 0., 1.]])
 
-        y_pred = np.array([1, 1, 0.9, 1, 1])
-        y_true = np.array([0, 1, 1, 0, 0])
-        self.assertAlmostEqual(0.5, r_obj(y_true, y_pred))
-        self.assertAlmostEqual(1, r_obj.true_positives)
-        self.assertAlmostEqual(1, r_obj.false_negatives)
+        result = r_obj(y_true, y_pred)
+        self.assertAlmostEqual(1.0, result)
+        self.assertAlmostEqual(1.0, r_obj.true_positives)
+        self.assertAlmostEqual(0.0, r_obj.false_negatives)
 
     def test_unweighted_top_k_and_threshold(self):
         r_obj = metrics.Recall(thresholds=0.7, top_k=2)

--- a/keras_core/metrics/metrics_utils.py
+++ b/keras_core/metrics/metrics_utils.py
@@ -462,7 +462,15 @@ def update_confusion_matrix_variables(
 
     if top_k is not None:
         y_pred = _filter_top_k(y_pred, top_k)
+
     if class_id is not None:
+        if len(y_pred.shape) == 1:
+            raise ValueError(
+                "When class_id is provided, y_pred must be a 2D array "
+                "with shape (num_samples, num_classes), found shape: "
+                f"{y_pred.shape}"
+            )
+
         # Preserve dimension to match with sample_weight
         y_true = y_true[..., class_id, None]
         y_pred = y_pred[..., class_id, None]


### PR DESCRIPTION
Consider the case:

```python
import keras_core
import numpy as np

label = np.random.randint(0, high = 2, size = 100)

keras_core.metrics.Precision(class_id = 20)(label, label)
```

If one of the inputs are 1D and `class_id` is provided, the code will still execute without any errors, but it seems like the results may not be what we expect. It effectively reduces the inputs to a single value right now.

So I added a check before using `class_id` 🤔 or is this something intended? If not, the tests need to be updated aswell.