### PR TITLE
fixed apply_mask bug in losses

### DIFF
--- a/keras_core/losses/loss.py
+++ b/keras_core/losses/loss.py
@@ -170,7 +170,12 @@ def apply_mask(sample_weight, mask, dtype, reduction):
             #   = sum(loss * sample_weight * total / valid) / total
             #   = sum(loss * sample_weight) / total * total / valid
             #   = sum(loss * sample_weight) / valid
-            total = ops.cast(ops.shape(mask)[0], dtype=dtype)
+            total = ops.cast(
+                ops.prod(
+                    ops.convert_to_tensor(ops.shape(mask), dtype="int32")
+                ),
+                dtype,
+            )
             valid = ops.sum(mask)  # May be 0!
             mask *= total / (valid + backend.epsilon())
 

--- a/keras_core/losses/loss.py
+++ b/keras_core/losses/loss.py
@@ -171,9 +171,7 @@ def apply_mask(sample_weight, mask, dtype, reduction):
             #   = sum(loss * sample_weight) / total * total / valid
             #   = sum(loss * sample_weight) / valid
             total = ops.cast(
-                ops.prod(
-                    ops.convert_to_tensor(ops.shape(mask), dtype="int32")
-                ),
+                ops.prod(ops.convert_to_tensor(ops.shape(mask), dtype="int32")),
                 dtype,
             )
             valid = ops.sum(mask)  # May be 0!

--- a/keras_core/losses/loss_test.py
+++ b/keras_core/losses/loss_test.py
@@ -117,6 +117,29 @@ class LossTest(testing.TestCase):
             loss,
         )
 
+    def test_mask_and_sample_weight_rank2(self):
+        # check loss of inputs with duplicate rows doesn't change
+        sample_weight = np.array([0.4, 0.3, 0.2, 0.1])
+        y_true = np.array([1.0, 0.0, 1.0, 0.0])
+        y_pred = np.array([0.1, 0.2, 0.3, 0.4])
+        mask = np.array([True, False, True, True])
+
+        mask = ops.convert_to_tensor(mask)
+        y_true = ops.convert_to_tensor(y_true)
+        y_pred = ops.convert_to_tensor(y_pred)
+        y_pred._keras_mask = mask
+
+        loss_fn = ExampleLoss()
+        rank1_loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)
+        
+        # duplicate rows
+        mask = ops.tile(ops.expand_dims(mask, axis=0), (2, 1))
+        y_true = ops.tile(ops.expand_dims(y_true, axis=0), (2, 1))
+        y_pred = ops.tile(ops.expand_dims(y_pred, axis=0), (2, 1))
+        y_pred._keras_mask = mask
+        rank2_loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)
+        self.assertAllClose(rank1_loss, rank2_loss)
+
     # @testing.parametrize(
     #     "uprank", ["mask", "sample_weight", "y_true", "y_pred"])
     # TODO: use parameterization decorator

--- a/keras_core/losses/loss_test.py
+++ b/keras_core/losses/loss_test.py
@@ -131,11 +131,12 @@ class LossTest(testing.TestCase):
 
         loss_fn = ExampleLoss()
         rank1_loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)
-        
+
         # duplicate rows
         mask = ops.tile(ops.expand_dims(mask, axis=0), (2, 1))
         y_true = ops.tile(ops.expand_dims(y_true, axis=0), (2, 1))
         y_pred = ops.tile(ops.expand_dims(y_pred, axis=0), (2, 1))
+        sample_weight = ops.tile(ops.expand_dims(sample_weight, axis=0), (2, 1))
         y_pred._keras_mask = mask
         rank2_loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)
         self.assertAllClose(rank1_loss, rank2_loss)

--- a/keras_core/losses/loss_test.py
+++ b/keras_core/losses/loss_test.py
@@ -117,6 +117,10 @@ class LossTest(testing.TestCase):
             loss,
         )
 
+    @pytest.mark.skipif(
+        backend.backend() == "numpy",
+        reason="Numpy backend does not support masking.",
+    )
     def test_mask_and_sample_weight_rank2(self):
         # check loss of inputs with duplicate rows doesn't change
         sample_weight = np.array([0.4, 0.3, 0.2, 0.1])


### PR DESCRIPTION
This fix ensures that losses evaluated with a `sample_weights == ops.cast(mask, "float32")` are the same as those evaluated with either argument but not both `None`. Note this `total` is consistent with the `batch_size` used in `reduce_values`, corresponding to the total size of all elements as opposed to the leading dimension. Another fix might be to leave `apply_mask` alone and change `reduce_values` to divide by the leading dimension only rather than the total size.

I'm unsure of a concise way to unit test this because AFAIK there's no way to pass a mask in using only the public API...