### PR TITLE
Fixed misc mixed precision issues

### DIFF
--- a/keras_core/activations/activations.py
+++ b/keras_core/activations/activations.py
@@ -86,6 +86,7 @@ class ReLU(ops.Operation):
         clip_max = max_value is not None
         if threshold != 0:
             # computes x for x > threshold else 0
+            threshold = ops.cast(threshold, dtype=x.dtype)
             x = x * backend.cast(
                 backend.numpy.greater(x, threshold), dtype=x.dtype
             )
@@ -97,7 +98,9 @@ class ReLU(ops.Operation):
             x = backend.nn.relu(x)
 
         if clip_max:
-            x = backend.numpy.clip(x, 0.0, max_value)
+            min_value = ops.cast(0.0, dtype=x.dtype)
+            max_value = ops.cast(max_value, dtype=x.dtype)
+            x = backend.numpy.clip(x, min_value, max_value)
 
         if negative_slope != 0.0:
             x -= negative_slope * negative_part

--- a/keras_core/backend/common/variables.py
+++ b/keras_core/backend/common/variables.py
@@ -477,20 +477,21 @@ class AutocastScope:
     """
 
     def __init__(self, dtype):
-        dtype = standardize_dtype(dtype)
-        if not is_float_dtype(dtype):
-            raise ValueError(
-                "`AutocastScope` can only be used with "
-                "a floating-point target dtype, such as 'float16'. "
-                f"Received: dtype={dtype}"
-            )
+        if dtype is not None:
+            dtype = standardize_dtype(dtype)
+            if not is_float_dtype(dtype):
+                raise ValueError(
+                    "`AutocastScope` can only be used with "
+                    "a floating-point target dtype, such as 'float16'. "
+                    f"Received: dtype={dtype}"
+                )
         self.dtype = dtype
         self.original_scope = None
 
     def maybe_cast(self, value):
         from keras_core import backend
 
-        if is_float_dtype(value.dtype):
+        if self.dtype is not None and is_float_dtype(value.dtype):
             return backend.cast(value, dtype=self.dtype)
         return value
 

--- a/keras_core/backend/numpy/image.py
+++ b/keras_core/backend/numpy/image.py
@@ -101,6 +101,11 @@ def affine_transform(
             f"transform.shape={transform.shape}"
         )
 
+    # scipy.ndimage.map_coordinates lacks support for half precision.
+    input_dtype = image.dtype
+    if input_dtype == "float16":
+        image = image.astype("float32")
+
     # unbatched case
     need_squeeze = False
     if len(image.shape) == 3:
@@ -165,4 +170,6 @@ def affine_transform(
         affined = np.transpose(affined, (0, 3, 1, 2))
     if need_squeeze:
         affined = np.squeeze(affined, axis=0)
+    if input_dtype == "float16":
+        affined = affined.astype(input_dtype)
     return affined

--- a/keras_core/backend/tensorflow/image.py
+++ b/keras_core/backend/tensorflow/image.py
@@ -47,7 +47,7 @@ def resize(
             resized = tf.transpose(resized, (0, 3, 1, 2))
         elif len(image.shape) == 3:
             resized = tf.transpose(resized, (2, 0, 1))
-    return resized
+    return tf.cast(resized, image.dtype)
 
 
 AFFINE_TRANSFORM_INTERPOLATIONS = (

--- a/keras_core/layers/core/wrapper_test.py
+++ b/keras_core/layers/core/wrapper_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from keras_core import layers
+from keras_core import ops
 from keras_core import testing
 
 
@@ -8,7 +9,7 @@ class ExampleWrapper(layers.Wrapper):
     """Simple Wrapper subclass."""
 
     def call(self, inputs, **kwargs):
-        return self.layer(inputs, **kwargs)
+        return ops.cast(self.layer(inputs, **kwargs), self.compute_dtype)
 
 
 class WrapperTest(testing.TestCase):

--- a/keras_core/layers/layer.py
+++ b/keras_core/layers/layer.py
@@ -740,9 +740,7 @@ class Layer(BackendLayer, Operation):
         # 7. Call the layer.
         try:
             with backend.name_scope(self.name, caller=self):
-                if self.autocast and self.compute_dtype != self.variable_dtype:
-                    # For mixed precision, we automatically cast layer variables
-                    # (float ones only) to the compute dtype upon access.
+                if self.autocast and backend.is_float_dtype(self.compute_dtype):
                     with backend.AutocastScope(self.compute_dtype):
                         outputs = super().__call__(*args, **kwargs)
                 else:

--- a/keras_core/layers/layer.py
+++ b/keras_core/layers/layer.py
@@ -740,8 +740,20 @@ class Layer(BackendLayer, Operation):
         # 7. Call the layer.
         try:
             with backend.name_scope(self.name, caller=self):
-                if self.autocast and backend.is_float_dtype(self.compute_dtype):
-                    with backend.AutocastScope(self.compute_dtype):
+                current_scope = backend.get_autocast_scope()
+                new_scope = None
+                if current_scope is not None:
+                    # Clear or update the current scope if necessary.
+                    if not self.autocast:
+                        new_scope = backend.AutocastScope(None)
+                    elif current_scope.dtype != self.compute_dtype:
+                        new_scope = backend.AutocastScope(self.compute_dtype)
+                elif self.compute_dtype != self.variable_dtype:
+                    # Enter a new scope if our dtypes are "mixed".
+                    new_scope = backend.AutocastScope(self.compute_dtype)
+
+                if new_scope is not None:
+                    with new_scope:
                         outputs = super().__call__(*args, **kwargs)
                 else:
                     outputs = super().__call__(*args, **kwargs)

--- a/keras_core/layers/normalization/batch_normalization.py
+++ b/keras_core/layers/normalization/batch_normalization.py
@@ -236,7 +236,7 @@ class BatchNormalization(Layer):
             beta = ops.reshape(self.beta, broadcast_shape)
             beta = ops.cast(beta, outputs.dtype)
             outputs = outputs + beta
-        return outputs
+        return ops.cast(outputs, input_dtype)
 
     def get_config(self):
         base_config = super().get_config()

--- a/keras_core/layers/normalization/spectral_normalization.py
+++ b/keras_core/layers/normalization/spectral_normalization.py
@@ -79,7 +79,7 @@ class SpectralNormalization(Wrapper):
             self.normalize_weights()
 
         output = self.layer(inputs)
-        return output
+        return ops.cast(output, inputs.dtype)
 
     def compute_output_shape(self, input_shape):
         return self.layer.compute_output_shape(input_shape)

--- a/keras_core/layers/normalization/spectral_normalization_test.py
+++ b/keras_core/layers/normalization/spectral_normalization_test.py
@@ -28,6 +28,7 @@ class SpectralNormalizationTest(testing.TestCase):
             layers.Conv2D(
                 1, (2, 2), kernel_initializer=initializers.Constant(value=1)
             ),
+            power_iterations=8,
         )
 
         result = sn_wrapper(images, training=False)

--- a/keras_core/layers/pooling/average_pooling_test.py
+++ b/keras_core/layers/pooling/average_pooling_test.py
@@ -105,6 +105,8 @@ class AveragePoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            # Incomplete op support on tensorflow.
+            run_mixed_precision_check=False,
         )
 
 

--- a/keras_core/layers/pooling/max_pooling_test.py
+++ b/keras_core/layers/pooling/max_pooling_test.py
@@ -104,6 +104,8 @@ class MaxPoolingBasicTest(testing.TestCase, parameterized.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_losses=0,
             supports_masking=False,
+            # Incomplete op support on tensorflow.
+            run_mixed_precision_check=False,
         )
 
 

--- a/keras_core/layers/preprocessing/hashed_crossing_test.py
+++ b/keras_core/layers/preprocessing/hashed_crossing_test.py
@@ -23,6 +23,8 @@ class HashedCrossingTest(testing.TestCase):
             expected_num_losses=0,
             supports_masking=False,
             run_training_check=False,
+            # Incomplete op support on tensorflow.
+            run_mixed_precision_check=False,
         )
         self.run_layer_test(
             layers.HashedCrossing,
@@ -35,6 +37,8 @@ class HashedCrossingTest(testing.TestCase):
             expected_num_losses=0,
             supports_masking=False,
             run_training_check=False,
+            # Incomplete op support on tensorflow.
+            run_mixed_precision_check=False,
         )
 
     def test_correctness(self):

--- a/keras_core/layers/preprocessing/normalization.py
+++ b/keras_core/layers/preprocessing/normalization.py
@@ -164,14 +164,12 @@ class Normalization(Layer):
             self.adapt_mean = self.add_weight(
                 name="mean",
                 shape=mean_and_var_shape,
-                dtype=self.compute_dtype,
                 initializer="zeros",
                 trainable=False,
             )
             self.adapt_variance = self.add_weight(
                 name="variance",
                 shape=mean_and_var_shape,
-                dtype=self.compute_dtype,
                 initializer="ones",
                 trainable=False,
             )

--- a/keras_core/layers/preprocessing/random_contrast.py
+++ b/keras_core/layers/preprocessing/random_contrast.py
@@ -67,6 +67,7 @@ class RandomContrast(TFDataLayer):
                 minval=1.0 - self.lower,
                 maxval=1.0 + self.upper,
                 seed=seed_generator,
+                dtype=self.compute_dtype,
             )
 
             outputs = self._adjust_constrast(inputs, factor)

--- a/keras_core/layers/rnn/bidirectional.py
+++ b/keras_core/layers/rnn/bidirectional.py
@@ -222,6 +222,8 @@ class Bidirectional(Wrapper):
         y_rev = self.backward_layer(
             backward_inputs, initial_state=backward_state, **kwargs
         )
+        y = ops.cast(y, self.compute_dtype)
+        y_rev = ops.cast(y_rev, self.compute_dtype)
 
         if self.return_state:
             states = y[1:] + y_rev[1:]

--- a/keras_core/layers/rnn/rnn.py
+++ b/keras_core/layers/rnn/rnn.py
@@ -4,13 +4,10 @@ from keras_core import backend
 from keras_core import ops
 from keras_core.api_export import keras_core_export
 from keras_core.layers.layer import Layer
+from keras_core.layers.rnn.dropout_rnn_cell import DropoutRNNCell
 from keras_core.layers.rnn.stacked_rnn_cells import StackedRNNCells
 from keras_core.saving import serialization_lib
 from keras_core.utils import tracking
-
-
-class DropoutRNNCellMixin:
-    pass
 
 
 @keras_core_export("keras_core.layers.RNN")
@@ -305,7 +302,7 @@ class RNN(Layer):
             init_state = get_initial_state_fn(batch_size=batch_size)
         else:
             return [
-                ops.zeros((batch_size, d), dtype=self.compute_dtype)
+                ops.zeros((batch_size, d), dtype=self.cell.compute_dtype)
                 for d in self.state_size
             ]
 
@@ -387,7 +384,9 @@ class RNN(Layer):
         # Note that states may be deeply nested
         # (e.g. in the stacked cells case).
         initial_state = tree.map_structure(
-            lambda x: backend.convert_to_tensor(x, dtype=self.compute_dtype),
+            lambda x: backend.convert_to_tensor(
+                x, dtype=self.cell.compute_dtype
+            ),
             initial_state,
         )
 
@@ -396,6 +395,11 @@ class RNN(Layer):
             initial_state=initial_state,
             mask=mask,
             training=training,
+        )
+        last_output = ops.cast(last_output, self.compute_dtype)
+        outputs = ops.cast(outputs, self.compute_dtype)
+        states = tree.map_structure(
+            lambda x: ops.cast(x, dtype=self.compute_dtype), states
         )
         self._maybe_reset_dropout_masks(self.cell)
 
@@ -418,7 +422,7 @@ class RNN(Layer):
         return output
 
     def _maybe_reset_dropout_masks(self, cell):
-        if isinstance(cell, DropoutRNNCellMixin):
+        if isinstance(cell, DropoutRNNCell):
             cell.reset_dropout_mask()
             cell.reset_recurrent_dropout_mask()
         if isinstance(cell, StackedRNNCells):

--- a/keras_core/testing/test_case.py
+++ b/keras_core/testing/test_case.py
@@ -342,6 +342,12 @@ class TestCase(unittest.TestCase):
             if run_training_check:
                 run_training_step(layer, input_data, output_data)
 
+            # Never test mixed precision on torch CPU. Torch lacks support.
+            if run_mixed_precision_check and backend.backend() == "torch":
+                import torch
+
+                run_mixed_precision_check = torch.cuda.is_available()
+
             if run_mixed_precision_check:
                 layer = layer_cls(**{**init_kwargs, "dtype": "mixed_float16"})
                 if isinstance(input_data, dict):

--- a/keras_core/testing/test_case.py
+++ b/keras_core/testing/test_case.py
@@ -9,6 +9,8 @@ import tree
 from keras_core import backend
 from keras_core import ops
 from keras_core import utils
+from keras_core.backend.common import is_float_dtype
+from keras_core.backend.common import standardize_dtype
 from keras_core.models import Model
 from keras_core.utils import traceback_utils
 
@@ -123,6 +125,7 @@ class TestCase(unittest.TestCase):
         expected_mask_shape=None,
         custom_objects=None,
         run_training_check=True,
+        run_mixed_precision_check=True,
     ):
         """Run basic checks on a layer.
 
@@ -159,6 +162,8 @@ class TestCase(unittest.TestCase):
                 considered during deserialization.
             run_training_check: Whether to attempt to train the layer
                 (if an input shape or input data was provided).
+            run_mixed_precision_check: Whether to test the layer with a mixed
+                precision dtype policy.
         """
         if input_shape is not None and input_data is not None:
             raise ValueError(
@@ -336,6 +341,21 @@ class TestCase(unittest.TestCase):
 
             if run_training_check:
                 run_training_step(layer, input_data, output_data)
+
+            if run_mixed_precision_check:
+                layer = layer_cls(**{**init_kwargs, "dtype": "mixed_float16"})
+                if isinstance(input_data, dict):
+                    output_data = layer(**input_data, **call_kwargs)
+                else:
+                    output_data = layer(input_data, **call_kwargs)
+                for tensor in tree.flatten(output_data):
+                    dtype = standardize_dtype(tensor.dtype)
+                    if is_float_dtype(dtype):
+                        self.assertEqual(dtype, "float16")
+                for weight in layer.weights:
+                    dtype = standardize_dtype(weight.dtype)
+                    if is_float_dtype(dtype):
+                        self.assertEqual(dtype, "float32")
 
 
 def create_keras_tensors(input_shape, dtype):


### PR DESCRIPTION
The main goal of this is to add dtype support for the MHA layer. E.g. get `MultHeadAttention(dtype="mixed_float16")` to work correctly (it does not today).

But tried out adding a mixed precision test for all layers, which caught some other bugs.