### PR TITLE
Refactor conv_transpose padding

### DIFF
--- a/keras_core/backend/common/backend_utils.py
+++ b/keras_core/backend/common/backend_utils.py
@@ -55,6 +55,7 @@ def _convert_conv_tranpose_padding_args_from_keras_to_torch(
     positive.
     """
     assert padding.lower() in {"valid", "same"}
+    original_kernel_size = kernel_size
     kernel_size = (kernel_size - 1) * dilation_rate + 1
 
     if padding.lower() == "valid":
@@ -86,15 +87,15 @@ def _convert_conv_tranpose_padding_args_from_keras_to_torch(
     if torch_padding > 0 and torch_output_padding > 0:
         warnings.warn(
             f"You might experience inconsistencies accross backends when "
-            f"calling conv transpose with {kernel_size}: kernel_size, "
-            f"{stride}: stride, {dilation_rate}: dilation_rate, "
-            f"{padding}: padding, {output_padding}: output_padding."
+            f"calling conv transpose with kernel_size={original_kernel_size}, "
+            f"stride={stride}, dilation_rate={dilation_rate}, "
+            f"padding={padding}, output_padding={output_padding}."
         )
 
     if torch_output_padding >= stride:
         raise ValueError(
-            f"The padding arguments (`padding`={padding}) and "
-            f"`output_padding`={output_padding}) lead to a Torch "
+            f"The padding arguments (padding={padding}) and "
+            f"output_padding={output_padding}) lead to a Torch "
             f"output_padding ({torch_output_padding}) that is greater than "
             f"strides ({stride}). This is not supported. You can change the "
             f"padding arguments, kernel or stride, or run on another backend. "

--- a/keras_core/backend/common/backend_utils.py
+++ b/keras_core/backend/common/backend_utils.py
@@ -1,35 +1,208 @@
-def compute_conv_transpose_output_length(
-    input_length,
-    kernel_size,
-    padding,
-    output_padding=None,
-    stride=1,
-    dilation=1,
+import warnings
+
+
+def _convert_conv_tranpose_padding_args_from_keras_to_jax(
+    kernel_size, stride, dilation_rate, padding, output_padding
 ):
-    """Computes output size of a transposed convolution given input size."""
-    assert padding in {"same", "valid"}
-    if input_length is None:
-        return None
+    """Convert the padding arguments from Keras to the ones used by JAX.
+    JAX starts with an shape of size `(input-1) * stride - kernel_size + 2`,
+    then adds `left_pad` on the left, and `right_pad` on the right.
+    In Keras, the `padding` argument determines a base shape, to which
+    `output_padding` is added on the right. If `output_padding` is None, it will
+    be given a default value.
+    """
 
-    # Get the dilated kernel size
-    kernel_size = kernel_size + (kernel_size - 1) * (dilation - 1)
+    assert padding.lower() in {"valid", "same"}
+    kernel_size = (kernel_size - 1) * dilation_rate + 1
 
-    # Infer length if output padding is None, else compute the exact length
-    if output_padding is None:
-        if padding == "valid":
-            length = input_length * stride + max(kernel_size - stride, 0)
-        else:
-            length = input_length * stride
-    else:
-        if padding == "same":
-            pad = kernel_size // 2
-        else:
-            pad = 0
-
-        length = (
-            (input_length - 1) * stride + kernel_size - 2 * pad + output_padding
+    if padding.lower() == "valid":
+        # If output_padding is None, we fill it so that the shape of the ouput
+        # is `(input-1)*s + max(kernel_size, stride)`
+        output_padding = (
+            max(kernel_size, stride) - kernel_size
+            if output_padding is None
+            else output_padding
         )
-    return length
+        left_pad = kernel_size - 1
+        right_pad = kernel_size - 1 + output_padding
+
+    else:
+        if output_padding is None:
+            # When output_padding is None, we want the shape of the ouput to
+            # be `input * s`, therefore a total padding of
+            # `stride + kernel_size - 2`
+            pad_len = stride + kernel_size - 2
+        else:
+            # When output_padding is filled, we want the shape of the ouput to
+            # be `(input-1)*stride + kernel_size%2 + output_padding`
+            pad_len = kernel_size + kernel_size % 2 - 2 + output_padding
+        left_pad = min(pad_len // 2 + pad_len % 2, kernel_size - 1)
+        right_pad = pad_len - left_pad
+
+    return left_pad, right_pad
+
+
+def _convert_conv_tranpose_padding_args_from_keras_to_torch(
+    kernel_size, stride, dilation_rate, padding, output_padding
+):
+    """Convert the padding arguments from Keras to the ones used by Torch.
+    Torch starts with an output shape of `(input-1) * stride + kernel_size`,
+    then removes `torch_padding` from both sides, and adds
+    `torch_output_padding` on the right.
+    Because in Torch the output_padding can only be added to the right,
+    consistency with Tensorflow is not always possible. In particular this is
+    the case when both the Torch padding and output_padding values are stricly
+    positive.
+    """
+    assert padding.lower() in {"valid", "same"}
+    kernel_size = (kernel_size - 1) * dilation_rate + 1
+
+    if padding.lower() == "valid":
+        # If output_padding is None, we fill it so that the shape of the ouput
+        # is `(i-1)*s + max(k, s)`
+        output_padding = (
+            max(kernel_size, stride) - kernel_size
+            if output_padding is None
+            else output_padding
+        )
+        torch_padding = 0
+        torch_output_padding = output_padding
+
+    else:
+        # When output_padding is None, we want the shape of the ouput to be
+        # `input * s`, otherwise we use the value provided.
+        output_padding = (
+            stride - kernel_size % 2
+            if output_padding is None
+            else output_padding
+        )
+        torch_padding = max(
+            -((kernel_size % 2 - kernel_size + output_padding) // 2), 0
+        )
+        torch_output_padding = (
+            2 * torch_padding + kernel_size % 2 - kernel_size + output_padding
+        )
+
+    if torch_padding > 0 and torch_output_padding > 0:
+        warnings.warn(
+            f"You might experience inconsistencies accross backends when "
+            f"calling conv transpose with {kernel_size}: kernel_size, "
+            f"{stride}: stride, {dilation_rate}: dilation_rate, "
+            f"{padding}: padding, {output_padding}: output_padding."
+        )
+
+    if torch_output_padding >= stride:
+        raise ValueError(
+            f"The padding arguments (`padding`={padding}) and "
+            f"`output_padding`={output_padding}) lead to a Torch "
+            f"output_padding ({torch_output_padding}) that is greater than "
+            f"strides ({stride}). This is not supported. You can change the "
+            f"padding arguments, kernel or stride, or run on another backend. "
+        )
+
+    return torch_padding, torch_output_padding
+
+
+def compute_conv_transpose_padding_args_for_jax(
+    input_shape,
+    kernel_shape,
+    strides,
+    padding,
+    output_padding,
+    dilation_rate,
+):
+    num_spatial_dims = len(input_shape) - 2
+    kernel_spatial_shape = kernel_shape[:-2]
+
+    jax_padding = []
+    for i in range(num_spatial_dims):
+        output_padding_i = (
+            output_padding
+            if output_padding is None or isinstance(output_padding, int)
+            else output_padding[i]
+        )
+        strides_i = strides if isinstance(strides, int) else strides[i]
+        dilation_rate_i = (
+            dilation_rate
+            if isinstance(dilation_rate, int)
+            else dilation_rate[i]
+        )
+        (
+            pad_left,
+            pad_right,
+        ) = _convert_conv_tranpose_padding_args_from_keras_to_jax(
+            kernel_size=kernel_spatial_shape[i],
+            stride=strides_i,
+            dilation_rate=dilation_rate_i,
+            padding=padding,
+            output_padding=output_padding_i,
+        )
+        jax_padding.append((pad_left, pad_right))
+
+    return jax_padding
+
+
+def compute_conv_transpose_padding_args_for_torch(
+    input_shape,
+    kernel_shape,
+    strides,
+    padding,
+    output_padding,
+    dilation_rate,
+):
+    num_spatial_dims = len(input_shape) - 2
+    kernel_spatial_shape = kernel_shape[:-2]
+
+    torch_paddings = []
+    torch_output_paddings = []
+    for i in range(num_spatial_dims):
+        output_padding_i = (
+            output_padding
+            if output_padding is None or isinstance(output_padding, int)
+            else output_padding[i]
+        )
+        strides_i = strides if isinstance(strides, int) else strides[i]
+        dilation_rate_i = (
+            dilation_rate
+            if isinstance(dilation_rate, int)
+            else dilation_rate[i]
+        )
+        (
+            torch_padding,
+            torch_output_padding,
+        ) = _convert_conv_tranpose_padding_args_from_keras_to_torch(
+            kernel_size=kernel_spatial_shape[i],
+            stride=strides_i,
+            dilation_rate=dilation_rate_i,
+            padding=padding,
+            output_padding=output_padding_i,
+        )
+        torch_paddings.append(torch_padding)
+        torch_output_paddings.append(torch_output_padding)
+
+    return torch_paddings, torch_output_paddings
+
+
+def _get_output_shape_given_tf_padding(
+    input_size, kernel_size, strides, padding, output_padding, dilation_rate
+):
+    assert padding.lower() in {"valid", "same"}
+
+    kernel_size = (kernel_size - 1) * dilation_rate + 1
+
+    if padding.lower() == "valid":
+        output_padding = (
+            max(kernel_size, strides) - kernel_size
+            if output_padding is None
+            else output_padding
+        )
+        return (input_size - 1) * strides + kernel_size + output_padding
+
+    else:
+        if output_padding is None:
+            return input_size * strides
+        else:
+            return (input_size - 1) * strides + kernel_size % 2 + output_padding
 
 
 def compute_conv_transpose_output_shape(
@@ -62,94 +235,19 @@ def compute_conv_transpose_output_shape(
         current_output_padding = (
             None if output_padding is None else output_padding[i]
         )
-        output_shape.append(
-            compute_conv_transpose_output_length(
-                input_spatial_shape[i],
-                kernel_spatial_shape[i],
-                padding=padding,
-                output_padding=current_output_padding,
-                stride=strides[i],
-                dilation=dilation_rate[i],
-            )
+
+        shape_i = _get_output_shape_given_tf_padding(
+            input_size=input_spatial_shape[i],
+            kernel_size=kernel_spatial_shape[i],
+            strides=strides[i],
+            padding=padding,
+            output_padding=current_output_padding,
+            dilation_rate=dilation_rate[i],
         )
+        output_shape.append(shape_i)
 
     if data_format == "channels_last":
         output_shape = [input_shape[0]] + output_shape + [filters]
     else:
         output_shape = [input_shape[0], filters] + output_shape
     return output_shape
-
-
-def _compute_conv_transpose_padding_one_dim(
-    input_length,
-    output_length,
-    kernel_size,
-    stride,
-    padding,
-    dilation_rate,
-):
-    """Computes adjusted padding for `conv_transpose` in one dim."""
-    kernel_size = (kernel_size - 1) * dilation_rate + 1
-    if padding == "valid":
-        padding_before = 0
-    else:
-        # padding == "same".
-        padding_needed = max(
-            0, (input_length - 1) * stride + kernel_size - output_length
-        )
-        padding_before = padding_needed // 2
-
-    expanded_input_length = (input_length - 1) * stride + 1
-    padded_out_length = output_length + kernel_size - 1
-    pad_before = kernel_size - 1 - padding_before
-    pad_after = padded_out_length - expanded_input_length - pad_before
-    return (pad_before, pad_after)
-
-
-def compute_conv_transpose_padding(
-    input_shape,
-    kernel_shape,
-    strides=1,
-    padding="valid",
-    output_padding=None,
-    data_format="channels_last",
-    dilation_rate=1,
-):
-    """Computes adjusted padding for `conv_transpose`."""
-    num_spatial_dims = len(input_shape) - 2
-    if isinstance(output_padding, int):
-        output_padding = (output_padding,) * num_spatial_dims
-    if isinstance(strides, int):
-        strides = (strides,) * num_spatial_dims
-    if isinstance(dilation_rate, int):
-        dilation_rate = (dilation_rate,) * num_spatial_dims
-
-    kernel_spatial_shape = kernel_shape[:-2]
-    if data_format == "channels_last":
-        input_spatial_shape = input_shape[1:-1]
-    else:
-        input_spatial_shape = input_shape[2:]
-    padding_values = []
-    for i in range(num_spatial_dims):
-        input_length = input_spatial_shape[i]
-        current_output_padding = (
-            None if output_padding is None else output_padding[i]
-        )
-        output_length = compute_conv_transpose_output_length(
-            input_spatial_shape[i],
-            kernel_spatial_shape[i],
-            padding=padding,
-            output_padding=current_output_padding,
-            stride=strides[i],
-            dilation=dilation_rate[i],
-        )
-        padding_value = _compute_conv_transpose_padding_one_dim(
-            input_length,
-            output_length,
-            kernel_spatial_shape[i],
-            strides[i],
-            padding=padding,
-            dilation_rate=dilation_rate[i],
-        )
-        padding_values.append(padding_value)
-    return padding_values

--- a/keras_core/backend/jax/nn.py
+++ b/keras_core/backend/jax/nn.py
@@ -6,7 +6,7 @@ from jax import nn as jnn
 
 from keras_core.backend import standardize_data_format
 from keras_core.backend.common.backend_utils import (
-    compute_conv_transpose_padding,
+    compute_conv_transpose_padding_args_for_jax,
 )
 from keras_core.backend.config import epsilon
 from keras_core.backend.jax.core import cast
@@ -361,14 +361,13 @@ def conv_transpose(
 ):
     data_format = standardize_data_format(data_format)
     num_spatial_dims = inputs.ndim - 2
-    padding_values = compute_conv_transpose_padding(
-        inputs.shape,
-        kernel.shape,
-        strides,
-        padding,
-        output_padding,
-        data_format,
-        dilation_rate,
+    padding_values = compute_conv_transpose_padding_args_for_jax(
+        input_shape=inputs.shape,
+        kernel_shape=kernel.shape,
+        strides=strides,
+        padding=padding,
+        output_padding=output_padding,
+        dilation_rate=dilation_rate,
     )
     dimension_numbers = _convert_to_lax_conv_dimension_numbers(
         num_spatial_dims,

--- a/keras_core/backend/numpy/nn.py
+++ b/keras_core/backend/numpy/nn.py
@@ -5,7 +5,7 @@ from jax import numpy as jnp
 
 from keras_core.backend import standardize_data_format
 from keras_core.backend.common.backend_utils import (
-    compute_conv_transpose_padding,
+    compute_conv_transpose_padding_args_for_jax,
 )
 from keras_core.backend.config import epsilon
 from keras_core.backend.numpy.core import cast
@@ -372,14 +372,13 @@ def conv_transpose(
 ):
     data_format = standardize_data_format(data_format)
     num_spatial_dims = inputs.ndim - 2
-    padding_values = compute_conv_transpose_padding(
-        inputs.shape,
-        kernel.shape,
-        strides,
-        padding,
-        output_padding,
-        data_format,
-        dilation_rate,
+    padding_values = compute_conv_transpose_padding_args_for_jax(
+        input_shape=inputs.shape,
+        kernel_shape=kernel.shape,
+        strides=strides,
+        padding=padding,
+        output_padding=output_padding,
+        dilation_rate=dilation_rate,
     )
     dimension_numbers = _convert_to_lax_conv_dimension_numbers(
         num_spatial_dims,

--- a/keras_core/layers/convolutional/conv_transpose_test.py
+++ b/keras_core/layers/convolutional/conv_transpose_test.py
@@ -1,15 +1,19 @@
 import numpy as np
 import pytest
+import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_core import backend
 from keras_core import layers
 from keras_core import testing
 from keras_core.backend.common.backend_utils import (
+    _convert_conv_tranpose_padding_args_from_keras_to_torch,
+)
+from keras_core.backend.common.backend_utils import (
     compute_conv_transpose_output_shape,
 )
 from keras_core.backend.common.backend_utils import (
-    compute_conv_transpose_padding,
+    compute_conv_transpose_padding_args_for_jax,
 )
 
 
@@ -290,16 +294,15 @@ class ConvTransposeCorrectnessTest(testing.TestCase, parameterized.TestCase):
             data_format,
             dilation_rate,
         )
-        (h_pad,) = compute_conv_transpose_padding(
-            x.shape,
-            kernel_weights.shape,
-            strides,
-            padding,
-            output_padding,
-            data_format,
-            dilation_rate,
+        jax_padding = compute_conv_transpose_padding_args_for_jax(
+            input_shape=x.shape,
+            kernel_shape=kernel_weights.shape,
+            strides=strides,
+            padding=padding,
+            output_padding=output_padding,
+            dilation_rate=dilation_rate,
         )
-        h_pad_side1 = h_kernel - 1 - h_pad[0]
+        h_pad_side1 = h_kernel - 1 - jax_padding[0][0]
 
         if h_dilation > 1:
             # Increase kernel size
@@ -366,17 +369,16 @@ class ConvTransposeCorrectnessTest(testing.TestCase, parameterized.TestCase):
             data_format,
             dilation_rate,
         )
-        h_pad, w_pad = compute_conv_transpose_padding(
-            x.shape,
-            kernel_weights.shape,
-            strides,
-            padding,
-            output_padding,
-            data_format,
-            dilation_rate,
+        jax_padding = compute_conv_transpose_padding_args_for_jax(
+            input_shape=x.shape,
+            kernel_shape=kernel_weights.shape,
+            strides=strides,
+            padding=padding,
+            output_padding=output_padding,
+            dilation_rate=dilation_rate,
         )
-        h_pad_side1 = h_kernel - 1 - h_pad[0]
-        w_pad_side1 = w_kernel - 1 - w_pad[0]
+        h_pad_side1 = h_kernel - 1 - jax_padding[0][0]
+        w_pad_side1 = w_kernel - 1 - jax_padding[1][0]
 
         if h_dilation > 1 or w_dilation > 1:
             # Increase kernel size
@@ -458,18 +460,17 @@ class ConvTransposeCorrectnessTest(testing.TestCase, parameterized.TestCase):
             data_format,
             dilation_rate,
         )
-        h_pad, w_pad, d_pad = compute_conv_transpose_padding(
-            x.shape,
-            kernel_weights.shape,
-            strides,
-            padding,
-            output_padding,
-            data_format,
-            dilation_rate,
+        jax_padding = compute_conv_transpose_padding_args_for_jax(
+            input_shape=x.shape,
+            kernel_shape=kernel_weights.shape,
+            strides=strides,
+            padding=padding,
+            output_padding=output_padding,
+            dilation_rate=dilation_rate,
         )
-        h_pad_side1 = h_kernel - 1 - h_pad[0]
-        w_pad_side1 = w_kernel - 1 - w_pad[0]
-        d_pad_side1 = d_kernel - 1 - d_pad[0]
+        h_pad_side1 = h_kernel - 1 - jax_padding[0][0]
+        w_pad_side1 = w_kernel - 1 - jax_padding[1][0]
+        d_pad_side1 = d_kernel - 1 - jax_padding[2][0]
 
         if h_dilation > 1 or w_dilation > 1 or d_dilation > 1:
             # Increase kernel size
@@ -749,3 +750,90 @@ class ConvTransposeCorrectnessTest(testing.TestCase, parameterized.TestCase):
             dilation_rate,
         )
         self.assertAllClose(outputs, expected, atol=1e-5)
+
+    @parameterized.product(
+        kernel_size=list(range(1, 5)),
+        strides=list(range(1, 5)),
+        padding=["same", "valid"],
+        output_padding=[None] + list(range(1, 5)),
+    )
+    def test_conv1d_vs_tf_implementation(
+        self, kernel_size, strides, padding, output_padding
+    ):
+        """Compares results from keras-core implementation to the results from
+        tf-keras, for a 1D input shape of length 3.
+        """
+
+        # output_padding cannot be greater than strides
+        if isinstance(output_padding, int) and output_padding >= strides:
+            pytest.skip(
+                "`output_padding` greater than `strides` is not supported"
+            )
+
+        input = np.ones(shape=(1, 3, 1))
+        kernel_weights = np.arange(1, kernel_size + 1).reshape(
+            (kernel_size, 1, 1)
+        )
+
+        # TF layer
+        tf_layer = tf.keras.layers.Conv1DTranspose(
+            filters=1,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            output_padding=output_padding,
+            dilation_rate=1,
+        )
+        tf_layer.build(input_shape=(1, 3, 1))
+        tf_layer.kernel.assign(kernel_weights)
+
+        # keras-core layer
+        kc_layer = layers.Conv1DTranspose(
+            filters=1,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            output_padding=output_padding,
+            dilation_rate=1,
+        )
+        kc_layer.build(input_shape=(1, 3, 1))
+        kc_layer.kernel.assign(kernel_weights)
+
+        # Special cases for Torch
+        if backend.backend() == "torch":
+            # The following set of arguments lead to Torch output padding to be
+            # greater than strides, which is not supported by Torch.
+            # An error is raised.
+            if (kernel_size, strides, padding, output_padding) in [
+                (2, 1, "same", None),
+                (4, 1, "same", None),
+            ]:
+                with pytest.raises(ValueError):
+                    kc_res = kc_layer(input)
+                return
+
+            # When both torch_padding and torch_output_padding are greater
+            # than 0, Torch outputs are inconsistent with the ones from
+            # Tensorflow. A warning is raised, and we expect the results to be
+            # different.
+            (
+                torch_padding,
+                torch_output_padding,
+            ) = _convert_conv_tranpose_padding_args_from_keras_to_torch(
+                kernel_size=kernel_size,
+                stride=strides,
+                dilation_rate=1,
+                padding=padding,
+                output_padding=output_padding,
+            )
+            if torch_padding > 0 and torch_output_padding > 0:
+                with pytest.raises(AssertionError):
+                    tf_res = tf_layer(input)
+                    kc_res = kc_layer(input)
+                    self.assertAllClose(tf_res, kc_res, atol=1e-5)
+                return
+
+        # Compare results
+        tf_res = tf_layer(input)
+        kc_res = kc_layer(input)
+        self.assertAllClose(tf_res, kc_res, atol=1e-5)

--- a/keras_core/layers/convolutional/conv_transpose_test.py
+++ b/keras_core/layers/convolutional/conv_transpose_test.py
@@ -755,7 +755,7 @@ class ConvTransposeCorrectnessTest(testing.TestCase, parameterized.TestCase):
         strides=list(range(1, 5)),
         padding=["same", "valid"],
         output_padding=[None] + list(range(1, 5)),
-    )    
+    )
     def test_conv1d_transpose_consistency(
         self, kernel_size, strides, padding, output_padding
     ):


### PR DESCRIPTION
This PR refactors the way padding arguments are handled by Conv Transpose functions, to fix the misalignment between backends (see https://github.com/keras-team/keras-core/issues/774).

The main change is to create two functions to convert the padding arguments from the Keras convention to the JAX / Torch conventions. As raised in the issue, it seems to me that some padding configurations are not possible to be translated in Torch; in which case, a warning is raised when using those configurations on a Torch backend.

Some caveat / interrogations:
* The padding conventions of conv transpose are not always very well documented by the original backends, so I had to infer their implementation. This PR implements the best of my understanding, but could be missing some edge case.
* I added some unit tests that check that the implementation gives the same result than the original keras implementation on a bunch of inputs. This helped capturing many edge cases, but not sure if you want to have the unit tests depending on tensorflow keras.
* Currently, a warning is raised when the padding configuration lead to differences between Torch and other backend. The warning is only raised when using Torch as backend, so not sure if it is better to raise it for all backend (the use-case would be that if a model is trained with a Torch backend, it wouldn't behave as expected when used with a TF backend).