### PR TITLE
Add `loss` attribute for backward compatibility

### DIFF
--- a/keras_core/trainers/trainer.py
+++ b/keras_core/trainers/trainer.py
@@ -18,7 +18,7 @@ class Trainer:
         self._run_eagerly = False
         self._jit_compile = None
         self.compiled = False
-        self.loss = {}
+        self.loss = None
         self.steps_per_execution = 1
 
     @traceback_utils.filter_traceback

--- a/keras_core/trainers/trainer.py
+++ b/keras_core/trainers/trainer.py
@@ -18,6 +18,7 @@ class Trainer:
         self._run_eagerly = False
         self._jit_compile = None
         self.compiled = False
+        self.loss = {}
         self.steps_per_execution = 1
 
     @traceback_utils.filter_traceback
@@ -42,6 +43,7 @@ class Trainer:
             self._compile_loss = CompileLoss(
                 loss, loss_weights, output_names=output_names
             )
+            self.loss = loss
         else:
             self._compile_loss = None
         if metrics is not None or weighted_metrics is not None:


### PR DESCRIPTION
The old implementation is here: https://github.com/keras-team/keras/blob/v2.14.0-rc0/keras/engine/training.py#L823
