### PR TITLE
Don't double cast layer norm weights in mixed precision

### DIFF
--- a/keras_core/layers/normalization/layer_normalization.py
+++ b/keras_core/layers/normalization/layer_normalization.py
@@ -142,6 +142,7 @@ class LayerNormalization(Layer):
         self.gamma_constraint = constraints.get(gamma_constraint)
 
         self.supports_masking = True
+        self.autocast = False
 
     def build(self, input_shape):
         if isinstance(self.axis, list):


### PR DESCRIPTION
Previously, under mixed precision, we would autocast full precision variables to half precision, then manually cast back to full precision.

Possibly this would compile away (no idea), but is certainly very slow in eagerly. We should set `autocast=False` to avoid the needless type conversion loop.