### PR TITLE
Fix the Jax distributed variable load issue.

### DIFF
--- a/keras_core/backend/jax/distribution_lib.py
+++ b/keras_core/backend/jax/distribution_lib.py
@@ -61,9 +61,12 @@ def distribute_value(value, tensor_layout):
 
     Args:
         value: `jax.Array` that need to be distributed.
-        tensor_layout: `TensorLayout` for the distribution information.
+        tensor_layout: `TensorLayout` for the distribution information, or a
+            `jax.sharding.Sharding` instance.
 
     Returns:
         Distributed value.
     """
-    return jax.device_put(value, to_jax_layout(tensor_layout))
+    if not isinstance(tensor_layout, jax.sharding.Sharding):
+        tensor_layout = to_jax_layout(tensor_layout)
+    return jax.device_put(value, tensor_layout)


### PR DESCRIPTION
The jax varaible will preserve the layout information at the init time, and will reuse it for any future assigned the value.

This will fix the issue for keras nlp/cv model that does the weight loading after the model creation, which unshard the variable back to the device:0