### PR TITLE
Make sure the Test CI action fails on bad lint

### DIFF
--- a/integration_tests/distribute_training_test.py
+++ b/integration_tests/distribute_training_test.py
@@ -3,8 +3,8 @@ import tensorflow as tf
 
 from keras_core import layers
 from keras_core import losses
-from keras_core import models
 from keras_core import metrics
+from keras_core import models
 from keras_core import optimizers
 from keras_core.utils import rng_utils
 
@@ -43,8 +43,8 @@ def test_model_fit():
             optimizer=optimizers.SGD(learning_rate=0.001, momentum=0.01),
             loss=losses.MeanSquaredError(),
             metrics=[metrics.MeanSquaredError()],
-            # TODO(scottzhu): Find out where is the variable that is not created eagerly
-            # and break the usage of XLA.
+            # TODO(scottzhu): Find out where is the variable
+            #  that is not created eagerly and break the usage of XLA.
             jit_compile=False,
         )
         history = model.fit(

--- a/integration_tests/model_visualization_test.py
+++ b/integration_tests/model_visualization_test.py
@@ -27,7 +27,7 @@ def plot_sequential_model():
     )
     plot_model(
         model,
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations.png",
+        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -35,7 +35,7 @@ def plot_sequential_model():
     )
     plot_model(
         model,
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png",
+        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -44,7 +44,7 @@ def plot_sequential_model():
     )
     plot_model(
         model,
-        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png",
+        "sequential-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -94,7 +94,7 @@ def plot_functional_model():
     )
     plot_model(
         model,
-        "functional-show_shapes-show_dtype-show_layer_names-show_layer_activations.png",
+        "functional-show_shapes-show_dtype-show_layer_names-show_layer_activations.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -102,7 +102,7 @@ def plot_functional_model():
     )
     plot_model(
         model,
-        "functional-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png",
+        "functional-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -111,7 +111,7 @@ def plot_functional_model():
     )
     plot_model(
         model,
-        "functional-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png",
+        "functional-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -164,7 +164,7 @@ def plot_subclassed_model():
     )
     plot_model(
         model,
-        "subclassed-show_shapes-show_dtype-show_layer_names-show_layer_activations.png",
+        "subclassed-show_shapes-show_dtype-show_layer_names-show_layer_activations.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -172,7 +172,7 @@ def plot_subclassed_model():
     )
     plot_model(
         model,
-        "subclassed-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png",
+        "subclassed-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -181,7 +181,7 @@ def plot_subclassed_model():
     )
     plot_model(
         model,
-        "subclassed-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png",
+        "subclassed-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -249,7 +249,7 @@ def plot_nested_functional_model():
     )
     plot_model(
         model,
-        "nested-functional-show_shapes-show_dtype-show_layer_names-show_layer_activations.png",
+        "nested-functional-show_shapes-show_dtype-show_layer_names-show_layer_activations.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -258,7 +258,7 @@ def plot_nested_functional_model():
     )
     plot_model(
         model,
-        "nested-functional-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png",
+        "nested-functional-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -268,7 +268,7 @@ def plot_nested_functional_model():
     )
     plot_model(
         model,
-        "nested-functional-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png",
+        "nested-functional-show_shapes-show_dtype-show_layer_names-show_layer_activations-show_trainable-LR.png",  # noqa: E501
         show_shapes=True,
         show_dtype=True,
         show_layer_names=True,
@@ -286,7 +286,7 @@ def plot_nested_functional_model():
     )
     plot_model(
         model,
-        "nested-functional-show_shapes-show_layer_activations-show_trainable.png",
+        "nested-functional-show_shapes-show_layer_activations-show_trainable.png",  # noqa: E501
         show_shapes=True,
         show_layer_activations=True,
         show_trainable=True,

--- a/keras_core/metrics/confusion_metrics_test.py
+++ b/keras_core/metrics/confusion_metrics_test.py
@@ -502,24 +502,32 @@ class PrecisionTest(testing.TestCase):
         with self.assertRaisesRegex(
             ValueError,
             r"When class_id is provided, y_pred must be a 2D array "
-            r"with shape \(num_samples, num_classes\), found shape:.*"
+            r"with shape \(num_samples, num_classes\), found shape:.*",
         ):
             p_obj(y_true, y_pred)
 
     def test_unweighted_class_id_multiclass(self):
         p_obj = metrics.Precision(class_id=1)
 
-        y_pred = np.array([[0.1, 0.2, 0.7],
-                           [0.5, 0.3, 0.2],
-                           [0.2, 0.6, 0.2],
-                           [0.7, 0.2, 0.1],
-                           [0.1, 0.1, 0.8]])
+        y_pred = np.array(
+            [
+                [0.1, 0.2, 0.7],
+                [0.5, 0.3, 0.2],
+                [0.2, 0.6, 0.2],
+                [0.7, 0.2, 0.1],
+                [0.1, 0.1, 0.8],
+            ]
+        )
 
-        y_true = np.array([[0., 0., 1.],
-                           [1., 0., 0.],
-                           [0., 1., 0.],
-                           [1., 0., 0.],
-                           [0., 0., 1.]])
+        y_true = np.array(
+            [
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
 
         result = p_obj(y_true, y_pred)
         self.assertAlmostEqual(1.0, result)
@@ -655,24 +663,32 @@ class RecallTest(testing.TestCase):
         with self.assertRaisesRegex(
             ValueError,
             r"When class_id is provided, y_pred must be a 2D array "
-            r"with shape \(num_samples, num_classes\), found shape:.*"
+            r"with shape \(num_samples, num_classes\), found shape:.*",
         ):
             r_obj(y_true, y_pred)
 
     def test_unweighted_class_id_multiclass(self):
         r_obj = metrics.Recall(class_id=1)
 
-        y_pred = np.array([[0.1, 0.2, 0.7],
-                           [0.5, 0.3, 0.2],
-                           [0.2, 0.6, 0.2],
-                           [0.7, 0.2, 0.1],
-                           [0.1, 0.1, 0.8]])
+        y_pred = np.array(
+            [
+                [0.1, 0.2, 0.7],
+                [0.5, 0.3, 0.2],
+                [0.2, 0.6, 0.2],
+                [0.7, 0.2, 0.1],
+                [0.1, 0.1, 0.8],
+            ]
+        )
 
-        y_true = np.array([[0., 0., 1.],
-                           [1., 0., 0.],
-                           [0., 1., 0.],
-                           [1., 0., 0.],
-                           [0., 0., 1.]])
+        y_true = np.array(
+            [
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
 
         result = r_obj(y_true, y_pred)
         self.assertAlmostEqual(1.0, result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,18 @@
 [tool.black]
 line-length = 80
 
+# black needs this to be a regex
+# to add more exclude expressions
+# append `| <regex-expr>` (e.g. `| .*_test\\.py`) to this list
+extend-exclude = """
+(
+  examples/
+)
+"""
 [tool.isort]
 profile = "black"
 force_single_line = "True"
 known_first_party = ["keras_core", "tests"]
 default_section = "THIRDPARTY"
 line_length = 80
+extend_skip_glob=["examples/*", "guides/*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,12 +40,19 @@ ignore =
     E266
 
 exclude =
-    *_pb2.py
-    *_pb2_grpc.py
+    *_pb2.py,
+    *_pb2_grpc.py,
+
+extend-exclude =
+    # excluding examples/ and guides/ since they are formatted as follow-along guides
+    examples,
+    guides,
+
 
 #imported but unused in __init__.py, that's ok.
 per-file-ignores =
     # import not used
     **/__init__.py:F401
     **/random.py:F401
+
 max-line-length = 80

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,9 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash
+set -Eeuo pipefail
 
 base_dir=$(dirname $(dirname $0))
-targets="${base_dir}/*.py ${base_dir}/keras_core/ ${base_dir}/benchmarks/"
 
-isort --sp "${base_dir}/pyproject.toml" ${targets}
-black --config "${base_dir}/pyproject.toml" ${targets}
+isort --sp "${base_dir}/pyproject.toml" .
 
-flake8 --config "${base_dir}/setup.cfg" ${targets}
+black --config "${base_dir}/pyproject.toml" .
+
+flake8 --config "${base_dir}/setup.cfg" .
+

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -1,9 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash
+set -Eeuo pipefail
 
 base_dir=$(dirname $(dirname $0))
-targets="${base_dir}/*.py ${base_dir}/keras_core/"
 
-isort --sp "${base_dir}/pyproject.toml" -c ${targets}
-black --config "${base_dir}/pyproject.toml" --check ${targets}
+isort --sp "${base_dir}/pyproject.toml" --check .
 
-flake8 --config "${base_dir}/setup.cfg" ${targets}
+black --config "${base_dir}/pyproject.toml" --check .
+
+flake8 --config "${base_dir}/setup.cfg" .
+


### PR DESCRIPTION
This PR fixes a couple of issues:

1. **Bad lint was not causing the CI to fail**: Happens becuase the `-e` flag was set on the shebang line and the CI action was being run as `bash shell/lint.sh`, therefore the `-e` flag was being ignored. Fixed by using `set -e` versus `#!/bin/bash -e`.
     For instance in [this build](https://github.com/keras-team/keras-core/actions/runs/6016918719/job/16321975971), lint clearly fails (see screenshot below) but the "Check the code format" action succeeds.
     
     ![image](https://github.com/keras-team/keras-core/assets/43595115/eb6cbe5a-78ad-4c64-96e0-588de8ff0e76)

2. **Moved exclude/include for isort, black and flake8 to the config files (`pyproject.toml` and `setup.cfg`)**: This puts all the configs in one place and makes it easy to invoke each tool separately during development. **Note:** I kept the `examples/` and `guides/` directories excluded since it seemed like they were being formatted for Codelab/notebooks.
3. **Linted `integration_tests/**`**: This directory was being excluded since we only included `./*.py` and `keras_core/*` in `lint.sh`