### PR TITLE
Always save the build config when building a layer

### DIFF
--- a/keras_core/backend/jax/layer.py
+++ b/keras_core/backend/jax/layer.py
@@ -1,4 +1,2 @@
 class JaxLayer:
-    def _post_build(self):
-        """Can be overriden to perform post-build actions."""
-        pass
+    pass

--- a/keras_core/backend/numpy/layer.py
+++ b/keras_core/backend/numpy/layer.py
@@ -1,3 +1,2 @@
 class NumpyLayer:
-    def _post_build(self):
-        pass
+    pass

--- a/keras_core/backend/tensorflow/layer.py
+++ b/keras_core/backend/tensorflow/layer.py
@@ -9,10 +9,6 @@ class TFLayer(tf.__internal__.tracking.AutoTrackable):
         self._saved_model_inputs_spec = None
         self._saved_model_arg_spec = None
 
-    def _post_build(self):
-        """Can be overriden to perform post-build actions."""
-        pass
-
     @tf.__internal__.tracking.no_automatic_dependency_tracking
     def _set_save_spec(self, inputs, args=None, kwargs=None):
         """Defines the save spec so that serialization can trace layer calls.

--- a/keras_core/layers/layer.py
+++ b/keras_core/layers/layer.py
@@ -218,7 +218,24 @@ class Layer(BackendLayer, Operation):
         def build_wrapper(*args, **kwargs):
             with backend.name_scope(obj.name, caller=obj):
                 original_build_method(*args, **kwargs)
+            # Record build config.
+            signature = inspect.signature(original_build_method)
+            obj._build_shapes_dict = signature.bind(*args, **kwargs).arguments
+            # Set built and lock.
             obj.built = True
+            if not obj._tracker.locked:
+                # No state updates past this point.
+                obj._tracker.lock(
+                    msg=(
+                        "You cannot add new elements of state "
+                        "(variables or sub-layers) "
+                        "to a layer that is already built. All state "
+                        "must be created in the `__init__()` method or "
+                        "in the`build()` method."
+                    )
+                )
+            # Hook used to do post-build actions
+            obj._post_build()
 
         obj.build = build_wrapper
         return obj
@@ -393,10 +410,8 @@ class Layer(BackendLayer, Operation):
         if config:
             if "input_shape" in config:
                 self.build(config["input_shape"])
-                self._build_shapes_dict = config
             elif "shapes_dict" in config:
                 self.build(**config["shapes_dict"])
-                self._build_shapes_dict = config["shapes_dict"]
             self.built = True
 
     def add_variable(
@@ -699,9 +714,10 @@ class Layer(BackendLayer, Operation):
         self._assert_input_compatibility(call_spec.first_arg)
 
         ################
-        # 4. Call build.
+        # 4. Call build and check compatibility again.
         with backend.name_scope(self.name, caller=self):
             self._maybe_build(call_spec)
+        self._assert_input_compatibility(call_spec.first_arg)
 
         ##########################
         # 5. Infer training value
@@ -1107,66 +1123,53 @@ class Layer(BackendLayer, Operation):
         return summary_utils.count_params(self.weights)
 
     def _maybe_build(self, call_spec):
-        if not self.built:
-            shapes_dict = get_shapes_dict(call_spec)
-            self._build_shapes_dict = shapes_dict
+        if self.built:
+            return
 
-            if not utils.is_default(self.build):
-                shapes_dict = update_shapes_dict_for_target_fn(
-                    self.build,
-                    shapes_dict=shapes_dict,
-                    call_spec=call_spec,
-                    class_name=self.__class__.__name__,
-                )
-                self.build(**shapes_dict)
-            elif might_have_unbuilt_state(self):
-                if len(shapes_dict) == 1:
-                    # Single arg: pass it positionally
-                    success = self._build_by_run_for_single_pos_arg(
-                        tuple(shapes_dict.values())[0]
-                    )
-                else:
-                    success = self._build_by_run_for_kwargs(shapes_dict)
-                if not success:
-                    if call_spec.eager:
-                        # Will let the actual eager call do state-building
-                        return
-                    raise ValueError(
-                        f"Layer '{self.name}' looks like it has "
-                        "unbuilt state, but Keras is not able to "
-                        "trace the layer `call()` in order to "
-                        "build it automatically. Possible causes:\n"
-                        "1. The `call()` method of your layer may be "
-                        "crashing. Try to `__call__()` the layer "
-                        "eagerly on some test input "
-                        "first to see if it works. "
-                        "E.g. `x = np.random.random((3, 4)); "
-                        "y = layer(x)`\n"
-                        "2. If the `call()` method is correct, "
-                        "then you may need to implement "
-                        "the `def build(self, input_shape)` method on your "
-                        "layer. It should create all variables used by the "
-                        "layer (e.g. by calling `layer.build()` on all its "
-                        "children layers)."
-                    )
-            self.built = True
+        shapes_dict = get_shapes_dict(call_spec)
+        first_shape = next(iter(shapes_dict.values()), None)
 
-            # Check input spec again (after build, since self.input_spec
-            # may have been updated
-            self._assert_input_compatibility(call_spec.first_arg)
-            # Hook used to do post-build actions
-            self._post_build()
-        if not self._tracker.locked:
-            # No state updates past this point.
-            self._tracker.lock(
-                msg=(
-                    "You cannot add new elements of state "
-                    "(variables or sub-layers) "
-                    "to a layer that is already built. All state "
-                    "must be created in the `__init__()` method or "
-                    "in the`build()` method."
-                )
+        # If the layer has a build method, call it with our input shapes.
+        if not utils.is_default(self.build):
+            shapes_dict = update_shapes_dict_for_target_fn(
+                self.build,
+                shapes_dict=shapes_dict,
+                call_spec=call_spec,
+                class_name=self.__class__.__name__,
             )
+            self.build(**shapes_dict)
+            return
+
+        # Otherwise, attempt to build the layer by calling it on symbolic input.
+        if might_have_unbuilt_state(self):
+            if len(shapes_dict) == 1:
+                success = self._build_by_run_for_single_pos_arg(first_shape)
+            else:
+                success = self._build_by_run_for_kwargs(shapes_dict)
+            if not success:
+                if call_spec.eager:
+                    # Will let the actual eager call do state-building
+                    return
+                raise ValueError(
+                    f"Layer '{self.name}' looks like it has "
+                    "unbuilt state, but Keras is not able to "
+                    "trace the layer `call()` in order to "
+                    "build it automatically. Possible causes:\n"
+                    "1. The `call()` method of your layer may be "
+                    "crashing. Try to `__call__()` the layer "
+                    "eagerly on some test input "
+                    "first to see if it works. "
+                    "E.g. `x = np.random.random((3, 4)); "
+                    "y = layer(x)`\n"
+                    "2. If the `call()` method is correct, "
+                    "then you may need to implement "
+                    "the `def build(self, input_shape)` method on your "
+                    "layer. It should create all variables used by the "
+                    "layer (e.g. by calling `layer.build()` on all its "
+                    "children layers)."
+                )
+
+        self.build(first_shape)
 
     def _build_by_run(self, *args, **kwargs):
         call_spec = CallSpec(self._call_signature, args, kwargs)

--- a/keras_core/layers/layer.py
+++ b/keras_core/layers/layer.py
@@ -221,21 +221,10 @@ class Layer(BackendLayer, Operation):
             # Record build config.
             signature = inspect.signature(original_build_method)
             obj._build_shapes_dict = signature.bind(*args, **kwargs).arguments
-            # Set built and lock.
+            # Set built, post build actions, and lock state.
             obj.built = True
-            if not obj._tracker.locked:
-                # No state updates past this point.
-                obj._tracker.lock(
-                    msg=(
-                        "You cannot add new elements of state "
-                        "(variables or sub-layers) "
-                        "to a layer that is already built. All state "
-                        "must be created in the `__init__()` method or "
-                        "in the`build()` method."
-                    )
-                )
-            # Hook used to do post-build actions
             obj._post_build()
+            obj._lock_state()
 
         obj.build = build_wrapper
         return obj
@@ -371,6 +360,23 @@ class Layer(BackendLayer, Operation):
                 "Make sure to implement a proper `build()` method."
             )
         self.built = True
+
+    def _post_build(self):
+        """Can be overridden for per backend post build actions."""
+        pass
+
+    def _lock_state(self):
+        """Prevent further state updates, called automatically in `build()`."""
+        if not self._tracker.locked:
+            self._tracker.lock(
+                msg=(
+                    "You cannot add new elements of state "
+                    "(variables or sub-layers) "
+                    "to a layer that is already built. All state "
+                    "must be created in the `__init__()` method or "
+                    "in the `build()` method."
+                )
+            )
 
     def get_build_config(self):
         """Returns a dictionary with the layer's input shape.
@@ -714,10 +720,9 @@ class Layer(BackendLayer, Operation):
         self._assert_input_compatibility(call_spec.first_arg)
 
         ################
-        # 4. Call build and check compatibility again.
+        # 4. Call build
         with backend.name_scope(self.name, caller=self):
             self._maybe_build(call_spec)
-        self._assert_input_compatibility(call_spec.first_arg)
 
         ##########################
         # 5. Infer training value
@@ -1138,6 +1143,9 @@ class Layer(BackendLayer, Operation):
                 class_name=self.__class__.__name__,
             )
             self.build(**shapes_dict)
+            # Check input spec again (after build, since self.input_spec
+            # may have been updated
+            self._assert_input_compatibility(call_spec.first_arg)
             return
 
         # Otherwise, attempt to build the layer by calling it on symbolic input.
@@ -1151,20 +1159,16 @@ class Layer(BackendLayer, Operation):
                     # Will let the actual eager call do state-building
                     return
                 raise ValueError(
-                    f"Layer '{self.name}' looks like it has "
-                    "unbuilt state, but Keras is not able to "
-                    "trace the layer `call()` in order to "
+                    f"Layer '{self.name}' looks like it has unbuilt state, but "
+                    "Keras is not able to trace the layer `call()` in order to "
                     "build it automatically. Possible causes:\n"
-                    "1. The `call()` method of your layer may be "
-                    "crashing. Try to `__call__()` the layer "
-                    "eagerly on some test input "
+                    "1. The `call()` method of your layer may be crashing. Try "
+                    "to `__call__()` the layer eagerly on some test input "
                     "first to see if it works. "
-                    "E.g. `x = np.random.random((3, 4)); "
-                    "y = layer(x)`\n"
-                    "2. If the `call()` method is correct, "
-                    "then you may need to implement "
-                    "the `def build(self, input_shape)` method on your "
-                    "layer. It should create all variables used by the "
+                    "E.g. `x = np.random.random((3, 4)); y = layer(x)`\n"
+                    "2. If the `call()` method is correct, then you may need "
+                    "to implement the `def build(self, input_shape)` method on "
+                    "your layer. It should create all variables used by the "
                     "layer (e.g. by calling `layer.build()` on all its "
                     "children layers)."
                 )

--- a/keras_core/models/functional.py
+++ b/keras_core/models/functional.py
@@ -154,13 +154,12 @@ class Functional(Function, Model):
             self.trainable = trainable
 
         self._layers = self.layers
-        self.built = True
+        self.build(None)
         # We will convert directly (to the correct dtype per input).
         self._convert_input_args = False
         self._allow_non_tensor_positional_args = True
         output_layers = [x._keras_history[0] for x in self.outputs]
         self.output_names = [x.name for x in output_layers]
-        self._post_build()
 
     @property
     def layers(self):

--- a/keras_core/models/sequential.py
+++ b/keras_core/models/sequential.py
@@ -111,19 +111,19 @@ class Sequential(Model):
                 f"add a different Input layer to it."
             )
 
+        self._tracker.locked = False
         self._layers.append(layer)
         if rebuild:
             self._maybe_rebuild()
         else:
             self.built = False
-            self._tracker.locked = False
             self._functional = None
 
     def pop(self, rebuild=True):
         """Removes the last layer in the model."""
+        self._tracker.locked = False
         layer = self._layers.pop()
         self.built = False
-        self._tracker.locked = False
         self._functional = None
         if rebuild:
             self._maybe_rebuild()
@@ -132,10 +132,10 @@ class Sequential(Model):
     def _maybe_rebuild(self):
         self.built = False
         self._functional = None
-        self._tracker.locked = False
         if isinstance(self._layers[0], InputLayer) and len(self._layers) > 1:
             input_shape = self._layers[0].batch_shape
             self.build(input_shape)
+        self._tracker.locked = False
 
     def build(self, input_shape=None):
         if not isinstance(input_shape, (tuple, list)):
@@ -180,7 +180,6 @@ class Sequential(Model):
         outputs = x
         self._functional = Functional(inputs=inputs, outputs=outputs)
         self.built = True
-        self._post_build()
 
     def call(self, inputs, training=None, mask=None):
         if self._functional:

--- a/keras_core/models/sequential.py
+++ b/keras_core/models/sequential.py
@@ -111,7 +111,6 @@ class Sequential(Model):
                 f"add a different Input layer to it."
             )
 
-        self._tracker.locked = False
         self._layers.append(layer)
         if rebuild:
             self._maybe_rebuild()
@@ -121,7 +120,6 @@ class Sequential(Model):
 
     def pop(self, rebuild=True):
         """Removes the last layer in the model."""
-        self._tracker.locked = False
         layer = self._layers.pop()
         self.built = False
         self._functional = None
@@ -135,7 +133,10 @@ class Sequential(Model):
         if isinstance(self._layers[0], InputLayer) and len(self._layers) > 1:
             input_shape = self._layers[0].batch_shape
             self.build(input_shape)
-        self._tracker.locked = False
+
+    def _lock_state(self):
+        # Unlike other layers, Sequential is mutable after build.
+        pass
 
     def build(self, input_shape=None):
         if not isinstance(input_shape, (tuple, list)):


### PR DESCRIPTION
This is trying to put us in a more consistent place with respect to implicitly vs explicitly built layers. Explicitly calling `build()` will now...
- Record the build config passed to the layer.
- Lock the layer so state cannot be mutated.

The last remaining difference is that implicitly we will attempt the build the layer by calling it symbolically, explicitly we do not. We could revisit that if we wanted, but I think that would be a slightly more complex change.