### PR TITLE
Uses `backend.shape`  in random preprocessing

### DIFF
--- a/keras_core/layers/preprocessing/random_brightness.py
+++ b/keras_core/layers/preprocessing/random_brightness.py
@@ -123,17 +123,18 @@ class RandomBrightness(TFDataLayer):
             return inputs
 
     def _randomly_adjust_brightness(self, images):
-        rank = len(images.shape)
+        images_shape = self.backend.shape(images)
+        rank = len(images_shape)
         if rank == 3:
             rgb_delta_shape = (1, 1, 1)
         elif rank == 4:
             # Keep only the batch dim. This will ensure to have same adjustment
             # with in one image, but different across the images.
-            rgb_delta_shape = [self.backend.shape(images)[0], 1, 1, 1]
+            rgb_delta_shape = [images_shape[0], 1, 1, 1]
         else:
             raise ValueError(
                 "Expected the input image to be rank 3 or 4. Received "
-                f"inputs.shape={images.shape}"
+                f"inputs.shape={images_shape}"
             )
 
         seed_generator = self._get_seed_generator(self.backend._backend)

--- a/keras_core/layers/preprocessing/random_flip.py
+++ b/keras_core/layers/preprocessing/random_flip.py
@@ -48,10 +48,13 @@ class RandomFlip(TFDataLayer):
         self._allow_non_tensor_positional_args = True
 
     def _randomly_flip_inputs(self, inputs):
-        unbatched = len(inputs.shape) == 3
+        inputs_shape = self.backend.shape(inputs)
+        unbatched = len(inputs_shape) == 3
         if unbatched:
             inputs = self.backend.numpy.expand_dims(inputs, axis=0)
-        batch_size = self.backend.shape(inputs)[0]
+            inputs_shape = self.backend.shape(inputs)
+
+        batch_size = inputs_shape[0]
         flipped_outputs = inputs
         seed_generator = self._get_seed_generator(self.backend._backend)
         if self.mode == HORIZONTAL or self.mode == HORIZONTAL_AND_VERTICAL:

--- a/keras_core/layers/preprocessing/random_rotation.py
+++ b/keras_core/layers/preprocessing/random_rotation.py
@@ -178,6 +178,8 @@ class RandomRotation(TFDataLayer):
             else:
                 image_height = shape[1]
                 image_width = shape[2]
+        image_height = float(image_height)
+        image_width = float(image_width)
 
         lower = self._factor[0] * 2.0 * self.backend.convert_to_tensor(np.pi)
         upper = self._factor[1] * 2.0 * self.backend.convert_to_tensor(np.pi)

--- a/keras_core/layers/preprocessing/random_translation.py
+++ b/keras_core/layers/preprocessing/random_translation.py
@@ -164,17 +164,19 @@ class RandomTranslation(TFDataLayer):
             return inputs
 
     def _randomly_translate_inputs(self, inputs):
-        unbatched = len(inputs.shape) == 3
+        inputs_shape = self.backend.shape(inputs)
+        unbatched = len(inputs_shape) == 3
         if unbatched:
             inputs = self.backend.numpy.expand_dims(inputs, axis=0)
+            inputs_shape = self.backend.shape(inputs)
 
-        batch_size = self.backend.shape(inputs)[0]
+        batch_size = inputs_shape[0]
         if self.data_format == "channels_first":
-            height = inputs.shape[-2]
-            width = inputs.shape[-1]
+            height = inputs_shape[-2]
+            width = inputs_shape[-1]
         else:
-            height = inputs.shape[-3]
-            width = inputs.shape[-2]
+            height = inputs_shape[-3]
+            width = inputs_shape[-2]
 
         seed_generator = self._get_seed_generator(self.backend._backend)
         height_translate = self.backend.random.uniform(

--- a/keras_core/layers/preprocessing/random_zoom.py
+++ b/keras_core/layers/preprocessing/random_zoom.py
@@ -171,17 +171,19 @@ class RandomZoom(TFDataLayer):
             return inputs
 
     def _randomly_zoom_inputs(self, inputs):
-        unbatched = len(inputs.shape) == 3
+        inputs_shape = self.backend.shape(inputs)
+        unbatched = len(inputs_shape) == 3
         if unbatched:
             inputs = self.backend.numpy.expand_dims(inputs, axis=0)
+            inputs_shape = self.backend.shape(inputs)
 
-        batch_size = self.backend.shape(inputs)[0]
+        batch_size = inputs_shape[0]
         if self.data_format == "channels_first":
-            height = inputs.shape[-2]
-            width = inputs.shape[-1]
+            height = inputs_shape[-2]
+            width = inputs_shape[-1]
         else:
-            height = inputs.shape[-3]
-            width = inputs.shape[-2]
+            height = inputs_shape[-3]
+            width = inputs_shape[-2]
 
         seed_generator = self._get_seed_generator(self.backend._backend)
         height_zoom = self.backend.random.uniform(
@@ -225,8 +227,8 @@ class RandomZoom(TFDataLayer):
         #      [0 0 1]]
         # where the last entry is implicit.
         # zoom matrices are always float32.
-        x_offset = ((image_width - 1.0) / 2.0) * (1.0 - zooms[:, 0:1])
-        y_offset = ((image_height - 1.0) / 2.0) * (1.0 - zooms[:, 1:])
+        x_offset = ((float(image_width) - 1.0) / 2.0) * (1.0 - zooms[:, 0:1])
+        y_offset = ((float(image_height) - 1.0) / 2.0) * (1.0 - zooms[:, 1:])
         return self.backend.numpy.concatenate(
             [
                 zooms[:, 0:1],


### PR DESCRIPTION
* Replace `inputs.shape` with `backend.shape`
* Convert values to float before doing floating point arithmetic.

This fixes #814 for other random augmentations.

Errors it fixes:
```
    Arguments received by RandomZoom.call():
      • inputs=tf.Tensor(shape=(None, None, None, 3), dtype=float32)
      • training=True

        height_translate = ag__.ld(height_translate) * ag__.ld(height)

    ValueError: Exception encountered when calling RandomTranslation.call().
    
    Tried to convert 'y' to a tensor and failed. Error: None values not supported.
    
    Arguments received by RandomTranslation.call():
      • inputs=tf.Tensor(shape=(None, None, None, 3), dtype=float32)
      • training=True

        x_offset = (ag__.ld(image_width) - 1 - (ag__.ld(cos_theta) * (ag__.ld(image_width) - 1) - ag__.ld(sin_theta) * (ag__.ld(image_height) - 1))) / 2.0

    TypeError: Exception encountered when calling RandomRotation.call().
    
    Input 'y' of 'Mul' Op has type int32 that does not match type float32 of argument 'x'.
    
    Arguments received by RandomRotation.call():
      • inputs=tf.Tensor(shape=(None, None, None, 3), dtype=float32)
      • training=True
```
