### PR TITLE
Add rank>2 support for `stft`

### DIFF
--- a/keras_core/ops/math.py
+++ b/keras_core/ops/math.py
@@ -691,11 +691,6 @@ class STFT(Operation):
         self.center = center
 
     def compute_output_spec(self, x):
-        if len(x.shape) not in {1, 2}:
-            raise ValueError(
-                f"Input should have rank 1 (single sequence) or 2 "
-                f"(batched sequences). Received: input shape = {x.shape}"
-            )
         if x.shape[-1] is not None:
             padded = 0 if self.center is False else (self.fft_length // 2) * 2
             num_sequences = (

--- a/keras_core/ops/math_test.py
+++ b/keras_core/ops/math_test.py
@@ -746,8 +746,8 @@ class MathOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(real_ref, real_output, atol=1e-5, rtol=1e-5)
         self.assertAllClose(imag_ref, imag_output, atol=1e-5, rtol=1e-5)
 
-        # Test 2D case.
-        x = np.random.random((3, 32))
+        # Test N-D case.
+        x = np.random.random((2, 3, 32))
         real_output, imag_output = kmath.stft(
             x, sequence_length, sequence_stride, fft_length, window, center
         )
@@ -794,16 +794,16 @@ class MathOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             window=window,
             center=center,
         )
-        if backend.backend() in ("numpy", "jax"):
-            # numpy and jax have different implementation for the boundary of
+        if backend.backend() in ("numpy", "jax", "torch"):
+            # these backends have different implementation for the boundary of
             # the output, so we need to truncate 5% befroe assertAllClose
             truncated_len = int(output.shape[-1] * 0.05)
             output = output[..., truncated_len:-truncated_len]
             ref = ref[..., truncated_len:-truncated_len]
         self.assertAllClose(output, ref, atol=1e-5, rtol=1e-5)
 
-        # Test 2D case.
-        x = np.random.random((3, 256))
+        # Test N-D case.
+        x = np.random.random((2, 3, 256))
         real_x, imag_x = _stft(
             x, sequence_length, sequence_stride, fft_length, window, center
         )
@@ -823,8 +823,8 @@ class MathOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
             window=window,
             center=center,
         )
-        if backend.backend() in ("numpy", "jax"):
-            # numpy and jax have different implementation for the boundary of
+        if backend.backend() in ("numpy", "jax", "torch"):
+            # these backends have different implementation for the boundary of
             # the output, so we need to truncate 5% befroe assertAllClose
             truncated_len = int(output.shape[-1] * 0.05)
             output = output[..., truncated_len:-truncated_len]


### PR DESCRIPTION
After experimenting with `stft` and `istft`, I have discovered that the input rank limitation imposed by `torch.stft` is inconvenient.

When containing multiple channels in single waveform, the input shape might be `(batch_size, num_samples, num_channels)` which is not supported by `torch.stft`. However, this format works well with other backends.

To address this, the PR has added `reshape` logic for `stft` function in the torch backend. The rank limitation of `ops.stft` has now been removed.

Furthermore, I have found that `torch.istft` works under specific condition which is common in audio processing.

The current implementation can be summarized in the following table:

|backend|stft|istft|
|-|-|-|
|numpy|`scipy.signal.stft`|`scipy.signal.istft`|
|jax|`jax.scipy.signal.stft`|`jax.scipy.signal.istft`|
|tf|`tf.signal.stft`|`tf.signal.inverse_stft`|
|torch|`torch.stft`|`torch.istft` & custom implementation|
