### PR TITLE
Improve the flexibility of `standardize_dtype` and fix `pad` in torch backend

### DIFF
--- a/keras_core/backend/common/variables.py
+++ b/keras_core/backend/common/variables.py
@@ -390,25 +390,21 @@ ALLOWED_DTYPES = {
 
 PYTHON_DTYPES_MAP = {
     bool: "bool",
-    int: "int",  # TBD by backend
+    int: "int64" if config.backend() == "tensorflow" else "int32",
     float: "float32",
     str: "string",
+    # special case for string value
+    "int": "int64" if config.backend() == "tensorflow" else "int32",
 }
 
 
 def standardize_dtype(dtype):
     if dtype is None:
         return config.floatx()
-    if dtype in PYTHON_DTYPES_MAP:
-        dtype = PYTHON_DTYPES_MAP.get(dtype)
-    if dtype == "int":
-        if config.backend() == "tensorflow":
-            dtype = "int64"
-        else:
-            dtype = "int32"
+    dtype = PYTHON_DTYPES_MAP.get(dtype, dtype)
     if hasattr(dtype, "name"):
         dtype = dtype.name
-    if hasattr(dtype, "__str__") and "torch" in str(dtype):
+    elif hasattr(dtype, "__str__") and "torch" in str(dtype):
         dtype = str(dtype).split(".")[-1]
 
     if dtype not in ALLOWED_DTYPES:

--- a/keras_core/backend/common/variables.py
+++ b/keras_core/backend/common/variables.py
@@ -408,7 +408,7 @@ def standardize_dtype(dtype):
             dtype = "int32"
     if hasattr(dtype, "name"):
         dtype = dtype.name
-    elif config.backend() == "torch":
+    if hasattr(dtype, "__str__") and "torch" in str(dtype):
         dtype = str(dtype).split(".")[-1]
 
     if dtype not in ALLOWED_DTYPES:

--- a/keras_core/backend/common/variables_test.py
+++ b/keras_core/backend/common/variables_test.py
@@ -61,3 +61,9 @@ class VariablesTest(test_case.TestCase):
 
         with AutocastScope("float16"):
             self.assertEqual(backend.standardize_dtype(v.value.dtype), "int32")
+
+    def test_standardize_dtype_with_torch_dtype(self):
+        import torch
+
+        x = torch.randn(4, 4)
+        backend.standardize_dtype(x.dtype)

--- a/keras_core/backend/numpy/numpy.py
+++ b/keras_core/backend/numpy/numpy.py
@@ -216,7 +216,7 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
 
 
 def digitize(x, bins):
-    return np.digitize(x, bins)
+    return np.digitize(x, bins).astype(np.int32)
 
 
 def dot(x, y):

--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -444,11 +444,12 @@ def imag(x):
 
 def isclose(x1, x2):
     x1, x2 = convert_to_tensor(x1), convert_to_tensor(x2)
-    result_dtype = torch.result_type(x1, x2)
-    if x1.dtype != result_dtype:
-        x1 = cast(x1, result_dtype)
-    else:
-        x2 = cast(x2, result_dtype)
+    if x1.dtype != x2.dtype:
+        result_dtype = torch.result_type(x1, x2)
+        if x1.dtype != result_dtype:
+            x1 = cast(x1, result_dtype)
+        else:
+            x2 = cast(x2, result_dtype)
     return torch.isclose(x1, x2)
 
 

--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -447,7 +447,7 @@ def isclose(x1, x2):
     result_dtype = torch.result_type(x1, x2)
     if x1.dtype != result_dtype:
         x1 = cast(x1, result_dtype)
-    if x2.dtype != result_dtype:
+    else:
         x2 = cast(x2, result_dtype)
     return torch.isclose(x1, x2)
 

--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -671,17 +671,42 @@ def pad(x, pad_width, mode="constant"):
     x = convert_to_tensor(x)
     pad_sum = []
     pad_width = list(pad_width)[::-1]  # torch uses reverse order
+    pad_width_sum = 0
+    for pad in pad_width:
+        pad_width_sum += pad[0] + pad[1]
     for pad in pad_width:
         pad_sum += pad
+        pad_width_sum -= pad[0] + pad[1]
+        if pad_width_sum == 0:  # early break when no padding in higher order
+            break
     if mode == "symmetric":
         mode = "replicate"
-    if mode != "constant" and x.ndim < 3:
+    if mode == "constant":
+        return torch.nn.functional.pad(x, pad=pad_sum, mode=mode)
+
+    # TODO: reflect and symmetric padding are implemented for padding the
+    # last 3 dimensions of a 4D or 5D input tensor, the last 2 dimensions of a
+    # 3D or 4D input tensor, or the last dimension of a 2D or 3D input tensor.
+    # https://pytorch.org/docs/stable/generated/torch.nn.functional.pad.html
+    ori_dtype = x.dtype
+    ori_ndim = x.ndim
+    need_squeeze = False
+    if x.ndim < 3:
+        need_squeeze = True
         new_dims = [1] * (3 - x.ndim)
-        if x.dtype not in (torch.float32, torch.float64):
-            x = cast(x, torch.float32)
         x = x.view(*new_dims, *x.shape)
-        return torch.nn.functional.pad(x, pad=pad_sum, mode=mode).squeeze()
-    return torch.nn.functional.pad(x, pad=pad_sum, mode=mode)
+    need_cast = False
+    if x.dtype not in (torch.float32, torch.float64):
+        # TODO: reflect and symmetric padding are only supported with float32/64
+        # https://github.com/pytorch/pytorch/issues/40763
+        need_cast = True
+        x = cast(x, torch.float32)
+    x = torch.nn.functional.pad(x, pad=pad_sum, mode=mode)
+    if need_cast:
+        x = cast(x, ori_dtype)
+    if need_squeeze:
+        x = torch.squeeze(x, dim=tuple(range(3 - ori_ndim)))
+    return x
 
 
 def prod(x, axis=None, keepdims=False, dtype=None):


### PR DESCRIPTION
One of the advantages of Keras Core is that we can integrate the workflow with different backends.
For example, we can train a tensorflow model using a torch dataloader.

However, operations containing `standardize_dtype` might fail when the dtype is `torch.Tensor.dtype` and the backend is NOT torch.

```python
import os

os.environ["KERAS_BACKEND"] = "tensorflow"

import torch

from keras_core import ops

x = torch.randn(4, 16, 16, 3)
y = ops.convert_to_tensor(x, dtype=x.dtype)  # failed w/o this PR
print(y.dtype)
```

This PR has addressed the issue by implementing a better check for `torch.Tensor.dtype`.
A unit test for this behavior has been included.
