### PR TITLE
Enable codecov flags and coverage carryover for keras_core and keras_…

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,10 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: [3.8]
         backend: [tensorflow, jax, torch, numpy]
     name: Run tests
     runs-on: ubuntu-latest
     env:
+      PYTHON: ${{ matrix.python-version }}
       KERAS_BACKEND: ${{ matrix.backend }}
     steps:
       - uses: actions/checkout@v3
@@ -25,10 +27,10 @@ jobs:
           filters: |
             applications:
               - 'keras_core/applications/**'
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -46,12 +48,25 @@ jobs:
       - name: Test applications with pytest
         if: ${{ steps.filter.outputs.applications == 'true' }}
         run: |
-          pytest keras_core/applications --cov=keras_core.applications --cov-branch --cov-report xml:apps-coverage.xml
+          pytest keras_core/applications --cov=keras_core.applications
+          coverage xml --include='keras_core/applications/*' -o apps-coverage.xml
+      - name: Codecov keras_core.applications
+        if: ${{ steps.filter.outputs.applications == 'true' }}
+        uses: codecov/codecov-action@v3
+        with:
+          env_vars: PYTHON,KERAS_BACKEND
+          flags: keras_core.applications
+          files: apps-coverage.xml
       - name: Test with pytest
         run: |
-          pytest keras_core --ignore keras_core/applications --cov-branch --cov=keras_core --cov-report xml:core-coverage.xml
-      - name: Codecov
+          pytest keras_core --ignore keras_core/applications --cov=keras_core
+          coverage xml --omit='keras_core/applications/*' -o core-coverage.xml
+      - name: Codecov keras_core
         uses: codecov/codecov-action@v3
+        with:
+          env_vars: PYTHON,KERAS_BACKEND
+          flags: keras_core
+          files: core-coverage.xml
 
   format:
     name: Check the code format

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ dist/**
 examples/**/*.jpg
 .python-version
 .coverage
-coverage.xml
+*coverage.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,4 +9,27 @@ coverage:
       default:
         target:auto
 
+comment:
+  layout: "header, reach, diff, flags, files"
+  behavior: default
+  require_changes: no
+  require_base: no
+  require_head: yes
+  show_carryforward_flags: yes
 
+flag_management:
+  default_rules:
+    carryforward: false
+    statuses:
+      - type: project
+        target: auto
+      - type: patch
+        target: auto
+  individual_flags:
+    - name: keras_core
+      paths:
+        - keras_core
+    - name: keras_core.applications
+      paths:
+        - keras_core/applications
+      carryforward: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,10 +20,16 @@ exclude_lines =
     pragma: no cover
     @abstract
     raise NotImplementedError
-omit = *_test.py
+omit =
+    */*_test.py
+
+[coverage:run]
+omit =
+    */*_test.py
+
+branch = True
 
 [flake8]
-
 ignore =
     # Conflicts with black
     E203


### PR DESCRIPTION
Does three things:

1. Enables codecov flags (`keras_core` and `keras_core.applications`) so that those test coverages can be tracked and viewed in the UI separately.
2. Enables carryover coverage for `keras_core.applications` since the apps tests are not always run.
3. Tags each codecov upload with `PYTHON` and `KERAS_BACKEND` env vars