### PR TITLE
Add loss scaling technique to `BaseOptimizer`

### DIFF
--- a/keras_core/backend/tensorflow/trainer.py
+++ b/keras_core/backend/tensorflow/trainer.py
@@ -67,6 +67,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
             trainable_weights = self.trainable_weights
             gradients = tape.gradient(loss, trainable_weights)
 
+            # Update weights
             self.optimizer.apply_gradients(zip(gradients, trainable_weights))
         else:
             warnings.warn("The model does not have any trainable weights.")

--- a/keras_core/backend/tensorflow/trainer.py
+++ b/keras_core/backend/tensorflow/trainer.py
@@ -59,14 +59,14 @@ class TensorFlowTrainer(base_trainer.Trainer):
             loss = self.compute_loss(
                 x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
             )
-        self._loss_tracker.update_state(loss)
+            self._loss_tracker.update_state(tf.stop_gradient(loss))
+            loss = self.optimizer.scale_loss(loss)
 
         # Compute gradients
         if self.trainable_weights:
             trainable_weights = self.trainable_weights
             gradients = tape.gradient(loss, trainable_weights)
 
-            # Update weights
             self.optimizer.apply_gradients(zip(gradients, trainable_weights))
         else:
             warnings.warn("The model does not have any trainable weights.")

--- a/keras_core/backend/torch/trainer.py
+++ b/keras_core/backend/torch/trainer.py
@@ -40,6 +40,7 @@ class TorchTrainer(base_trainer.Trainer):
             x=x, y=y, y_pred=y_pred, sample_weight=sample_weight
         )
         self._loss_tracker.update_state(loss)
+        loss = self.optimizer.scale_loss(loss)
 
         # Compute gradients
         if self.trainable_weights:

--- a/keras_core/optimizers/base_optimizer.py
+++ b/keras_core/optimizers/base_optimizer.py
@@ -134,7 +134,7 @@ class BaseOptimizer:
             self._track_variable(learning_rate)
             self._learning_rate = learning_rate
 
-        # Create loss_scale_factor for mixed precision training
+        # Create variables for mixed precision training
         with backend.name_scope(self.name, caller=self):
             loss_scale_factor = backend.Variable(
                 loss_scale_factor,
@@ -142,8 +142,16 @@ class BaseOptimizer:
                 dtype=backend.floatx(),
                 trainable=False,
             )
+            loss_scale_good_steps = backend.Variable(
+                0,
+                name="loss_scale_good_steps",
+                dtype="int",
+                trainable=False,
+            )
         self._track_variable(loss_scale_factor)
         self._loss_scale_factor = loss_scale_factor
+        self._track_variable(loss_scale_good_steps)
+        self._loss_scale_good_steps = loss_scale_good_steps
 
     def _track_variable(self, variable):
         self._tracker.add_to_store("variables", variable)
@@ -162,16 +170,6 @@ class BaseOptimizer:
                         "average",
                     )
                 )
-        if self.use_loss_scale and self.loss_scale_dynamic:
-            with backend.name_scope(self.name, caller=self):
-                loss_scale_good_steps = backend.Variable(
-                    0,
-                    name="loss_scale_good_steps",
-                    dtype="int",
-                    trainable=False,
-                )
-            self._track_variable(loss_scale_good_steps)
-            self._loss_scale_good_steps = loss_scale_good_steps
 
         self._trainable_variables = variables[:]
         self.built = True

--- a/keras_core/optimizers/schedules/learning_rate_schedule_test.py
+++ b/keras_core/optimizers/schedules/learning_rate_schedule_test.py
@@ -28,7 +28,7 @@ class TestFitLRSchedulesFlow(testing.TestCase):
                 initial_learning_rate=0.05, decay_steps=1, decay_rate=0.9
             )
         )
-        self.assertEqual(len(optimizer.variables), 2)
+        self.assertEqual(len(optimizer.variables), 3)
         self.assertEqual(optimizer.variables[0], 0)
 
         model.compile(optimizer=optimizer, loss="mse")

--- a/keras_core/optimizers/schedules/learning_rate_schedule_test.py
+++ b/keras_core/optimizers/schedules/learning_rate_schedule_test.py
@@ -28,7 +28,7 @@ class TestFitLRSchedulesFlow(testing.TestCase):
                 initial_learning_rate=0.05, decay_steps=1, decay_rate=0.9
             )
         )
-        self.assertEqual(len(optimizer.variables), 1)
+        self.assertEqual(len(optimizer.variables), 2)
         self.assertEqual(optimizer.variables[0], 0)
 
         model.compile(optimizer=optimizer, loss="mse")

--- a/keras_core/optimizers/sgd_test.py
+++ b/keras_core/optimizers/sgd_test.py
@@ -20,7 +20,7 @@ class SGDTest(testing.TestCase):
 
     def test_single_step(self):
         optimizer = SGD(learning_rate=0.5)
-        self.assertEqual(len(optimizer.variables), 2)
+        self.assertEqual(len(optimizer.variables), 3)
         grads = ops.array([1.0, 6.0, 7.0, 2.0])
         vars = backend.Variable([1.0, 2.0, 3.0, 4.0])
         optimizer.build([vars])

--- a/keras_core/optimizers/sgd_test.py
+++ b/keras_core/optimizers/sgd_test.py
@@ -20,7 +20,7 @@ class SGDTest(testing.TestCase):
 
     def test_single_step(self):
         optimizer = SGD(learning_rate=0.5)
-        self.assertEqual(len(optimizer.variables), 3)
+        self.assertEqual(len(optimizer.variables), 4)
         grads = ops.array([1.0, 6.0, 7.0, 2.0])
         vars = backend.Variable([1.0, 2.0, 3.0, 4.0])
         optimizer.build([vars])

--- a/keras_core/optimizers/sgd_test.py
+++ b/keras_core/optimizers/sgd_test.py
@@ -26,7 +26,7 @@ class SGDTest(testing.TestCase):
         optimizer.build([vars])
         optimizer.apply_gradients(zip([grads], [vars]))
         self.assertAllClose(vars, [0.5, -1.0, -0.5, 3.0], rtol=1e-4, atol=1e-4)
-        self.assertEqual(len(optimizer.variables), 2)
+        self.assertEqual(len(optimizer.variables), 4)
         self.assertEqual(optimizer.variables[0], 1)
         self.assertEqual(optimizer.variables[1], 0.5)
 

--- a/keras_core/trainers/trainer.py
+++ b/keras_core/trainers/trainer.py
@@ -3,6 +3,7 @@ import warnings
 
 from keras_core import backend
 from keras_core import metrics as metrics_module
+from keras_core import mixed_precision
 from keras_core import ops
 from keras_core import optimizers
 from keras_core.saving import serialization_lib
@@ -118,6 +119,11 @@ class Trainer:
                 the model supports it, and disabled otherwise.
         """
         self.optimizer = optimizers.get(optimizer)
+        if mixed_precision.dtype_policy().name in (
+            "mixed_float16",
+            "mixed_bfloat16",
+        ):
+            self.optimizer.use_loss_scale = True
         if hasattr(self, "output_names"):
             output_names = self.output_names
         else:


### PR DESCRIPTION
Related to #571 

I'm not sure if anyone is addressing this issue, or if it should not be handled externally.

I'm simply trying to implement a backend-agnostic solution.
Currently, only tf trainer has the ability to automatically enable the loss scaling when using mixed_float16 and mixed_bfloat16.
It should be straightforward to extend this to other backends.

In the colab, the training works well. However, it will fail if the loss scaling technique is not applied.
Colab: https://colab.research.google.com/drive/1T8DpRXu7CI52-67Poq5kKFvEM1P3UwT-?usp=sharing

cc @mattdangerw 

EDITED:
Now, this PR should work with tf and torch backend. However, jax does not support yet.
