### PR TITLE
Update the eager_build logic for jax trainer.

### DIFF
--- a/keras_core/backend/jax/trainer.py
+++ b/keras_core/backend/jax/trainer.py
@@ -53,7 +53,7 @@ class JAXTrainer(base_trainer.Trainer):
             and not self._compile_metrics.built
         )
         if model_unbuilt or compile_metrics_unbuilt:
-            data_spec = jax.tree_map(
+            data_spec = tree.map_structure(
                 lambda d: backend.KerasTensor(d.shape, d.dtype), data_batch
             )
             (

--- a/keras_core/backend/jax/trainer.py
+++ b/keras_core/backend/jax/trainer.py
@@ -53,20 +53,27 @@ class JAXTrainer(base_trainer.Trainer):
             and not self._compile_metrics.built
         )
         if model_unbuilt or compile_metrics_unbuilt:
-            # Build the model on one batch of data.
+            data_spec = jax.tree_map(
+                lambda d: backend.KerasTensor(d.shape, d.dtype), data_batch
+            )
             (
-                x,
-                y,
-                sample_weight,
-            ) = data_adapter_utils.unpack_x_y_sample_weight(data_batch)
-            # Build model
-            with backend.StatelessScope():
-                y_pred = self(x)
-                if compile_metrics_unbuilt:
-                    # Build metrics
-                    self.compute_metrics(
-                        x, y, y_pred, sample_weight=sample_weight
-                    )
+                x_spec,
+                y_spec,
+                sample_weight_spec,
+            ) = data_adapter_utils.unpack_x_y_sample_weight(data_spec)
+            # Note that this __call__ run the forward path and trigger variable
+            # creation.
+            y_pred_spec = backend.compute_output_spec(self.__call__, x_spec)
+            if compile_metrics_unbuilt:
+                # This will trigger the metric variable creation.
+                backend.compute_output_spec(
+                    self.compute_metrics,
+                    x_spec,
+                    y_spec,
+                    y_pred_spec,
+                    sample_weight=sample_weight_spec,
+                )
+
         if self.optimizer is not None and not self.optimizer.built:
             # Build optimizer
             self.optimizer.build(self.trainable_variables)

--- a/keras_core/backend/jax/trainer.py
+++ b/keras_core/backend/jax/trainer.py
@@ -53,9 +53,13 @@ class JAXTrainer(base_trainer.Trainer):
             and not self._compile_metrics.built
         )
         if model_unbuilt or compile_metrics_unbuilt:
-            data_spec = tree.map_structure(
-                lambda d: backend.KerasTensor(d.shape, d.dtype), data_batch
-            )
+
+            def _convert_data_to_spec(d):
+                if d is None:
+                    return None
+                return backend.KerasTensor(d.shape, d.dtype)
+
+            data_spec = tree.map_structure(_convert_data_to_spec, data_batch)
             (
                 x_spec,
                 y_spec,


### PR DESCRIPTION
The current eager_build will use eager tensor to run the forward path of the model to trigger variable creation, but this will bring non-trivial memory consumption from the forward path, and will cause OOM when the model are large, and designed for distribution computation.

This PR will use the kerasTensor instead, which doesn't consume any memory.

Verified with local colab for memory consumption.