### PR TITLE
Update minimum python version to 3.9 to align with TF/JAX

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
         backend: [tensorflow, jax, torch, numpy]
     name: Run tests
     runs-on: ubuntu-latest
@@ -73,10 +73,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,10 @@ setup(
         "dm-tree",
     ],
     # Supported Python versions
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Currently the tests are running with `JAX==0.4.13` which was the last version that supported Python 3.8.  The latest `jax` version is `0.4.14`.  TensorFlow also has dropped python 3.8 in the upcoming `2.14` release.  Numpy has already dropped it.  So updating `keras-core` to use Python 3.9 as the minimum version.