### PR TITLE
fixes #550: move torch tensors to cpu before to numpy array

### DIFF
--- a/keras_core/trainers/data_adapters/torch_data_adapter.py
+++ b/keras_core/trainers/data_adapters/torch_data_adapter.py
@@ -22,7 +22,7 @@ class TorchDataLoaderAdapter(DataAdapter):
 
     def get_numpy_iterator(self):
         for batch in self._dataloader:
-            yield tuple(tree.map_structure(lambda x: x.numpy(), batch))
+            yield tuple(tree.map_structure(lambda x: x.cpu().numpy(), batch))
 
     def get_torch_dataloader(self):
         return self._dataloader


### PR DESCRIPTION
As mentioned in #550, one remaining change from #750 is to first move the torch tensor to the CPU before passing it to a numpy array. 

This is relevant for the Metal GPU case. While calling `.cpu()` is harmless on a torch tensor already in the CPU, in my observation directly moving the tensor from Metal to numpy returns an error, hence the need to move it first.