### PR TITLE
Add support for Tensorflow SparseTensors: core layers.

### DIFF
--- a/keras_core/layers/core/embedding_test.py
+++ b/keras_core/layers/core/embedding_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from keras_core import backend
 from keras_core import layers
 from keras_core.testing import test_case
 
@@ -33,12 +34,54 @@ class EmbeddingTest(test_case.TestCase):
             supports_masking=True,
         )
 
+    @pytest.mark.skipif(
+        not backend.SUPPORTS_SPARSE_TENSORS,
+        reason="Backend does not support sparse tensors.",
+    )
+    def test_sparse(self):
+        self.run_layer_test(
+            layers.Embedding,
+            {"input_dim": 5, "output_dim": 4},
+            input_shape=(2, 3),
+            input_dtype="int32",
+            input_sparse=True,
+            expected_output_shape=(2, 3, 4),
+            expected_num_trainable_weights=1,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=0,
+            expected_num_losses=0,
+            supports_masking=False,
+        )
+
     def test_correctness(self):
         layer = layers.Embedding(input_dim=3, output_dim=2)
         layer.build()
         layer.embeddings.assign(np.array([[0.0, 0.0], [2.0, 2.0], [3.0, 3.0]]))
-        out = layer(np.array(([2, 1, 0])))
+        out = layer(np.array([2, 1, 0]))
         self.assertAllClose(out, np.array([[3.0, 3.0], [2.0, 2.0], [0.0, 0.0]]))
+
+    @pytest.mark.skipif(
+        not backend.SUPPORTS_SPARSE_TENSORS,
+        reason="Backend does not support sparse tensors.",
+    )
+    def test_correctness_sparse(self):
+        import tensorflow as tf
+
+        layer = layers.Embedding(input_dim=3, output_dim=2)
+        layer.build()
+        layer.embeddings.assign(np.array([[0.0, 0.0], [2.0, 2.0], [3.0, 3.0]]))
+        x = tf.SparseTensor(
+            indices=[[0, 0], [1, 2]], values=[2, 1], dense_shape=(2, 3)
+        )
+        self.assertAllClose(
+            layer(x),
+            np.array(
+                [
+                    [[3.0, 3.0], [0.0, 0.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [0.0, 0.0], [2.0, 2.0]],
+                ]
+            ),
+        )
 
     def test_masking(self):
         layer = layers.Embedding(input_dim=3, output_dim=2, mask_zero=True)

--- a/keras_core/layers/core/identity.py
+++ b/keras_core/layers/core/identity.py
@@ -1,4 +1,7 @@
+import tree
+
 from keras_core.api_export import keras_core_export
+from keras_core.backend.common.keras_tensor import KerasTensor
 from keras_core.layers.layer import Layer
 
 
@@ -16,3 +19,11 @@ class Identity(Layer):
 
     def call(self, inputs):
         return inputs
+
+    def compute_output_spec(self, inputs):
+        return tree.map_structure(
+            lambda input: KerasTensor(
+                shape=input.shape, dtype=input.dtype, sparse=input.sparse
+            ),
+            inputs,
+        )

--- a/keras_core/layers/core/identity_test.py
+++ b/keras_core/layers/core/identity_test.py
@@ -1,20 +1,33 @@
 import pytest
+from absl.testing import parameterized
 
+from keras_core import backend
 from keras_core import layers
 from keras_core import testing
 
 
-class IdentityTest(testing.TestCase):
+class IdentityTest(testing.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(
+        [
+            {"testcase_name": "dense", "sparse": False},
+            {"testcase_name": "sparse", "sparse": True},
+        ]
+    )
     @pytest.mark.requires_trainable_backend
-    def test_identity_basics(self):
+    def test_identity_basics(self, sparse):
+        if sparse and not backend.SUPPORTS_SPARSE_TENSORS:
+            pytest.skip("Backend does not support sparse tensors.")
         self.run_layer_test(
             layers.Identity,
             init_kwargs={},
             input_shape=(2, 3),
+            input_sparse=sparse,
             expected_output_shape=(2, 3),
+            expected_output_sparse=sparse,
             expected_num_trainable_weights=0,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
             expected_num_losses=0,
+            run_training_check=not sparse,
             supports_masking=True,
         )


### PR DESCRIPTION
Added `tf.SparseTensor` support for ops:
- matmul
- take

Added `tf.SparseTensor` support for core layers:
- Dense
- Embedding
- Identity