### PR TITLE
Draft PR for Backend Agnostic MLM with BERT port to Keras-Core

### DIFF
--- a/examples/keras_io/nlp/end_to_end_mlm_with_bert.py
+++ b/examples/keras_io/nlp/end_to_end_mlm_with_bert.py
@@ -1,0 +1,532 @@
+"""
+Title: End-to-end Masked Language Modeling with BERT
+Author: [Ankur Singh](https://twitter.com/ankur310794)
+Converted to Keras-Core: [Mrutyunjay Biswal](https://twitter.com/LearnStochastic)
+Date created: 2020/09/18
+Last modified: 2023/09/06
+Description: Implement a Masked Language Model (MLM) with BERT and fine-tune it on the IMDB Reviews dataset.
+Accelerator: GPU
+"""
+"""
+## Introduction
+
+Masked Language Modeling is a fill-in-the-blank task,
+where a model uses the context words surrounding a mask token to try to predict what the
+masked word should be.
+
+For an input that contains one or more mask tokens,
+the model will generate the most likely substitution for each.
+
+Example:
+
+- Input: "I have watched this [MASK] and it was awesome."
+- Output: "I have watched this movie and it was awesome."
+
+Masked language modeling is a great way to train a language
+model in a self-supervised setting (without human-annotated labels).
+Such a model can then be fine-tuned to accomplish various supervised
+NLP tasks.
+
+This example teaches you how to build a BERT model from scratch,
+train it with the masked language modeling task,
+and then fine-tune this model on a sentiment classification task.
+
+We will use the Keras-Core `TextVectorization` and `MultiHeadAttention` layers
+to create a BERT Transformer-Encoder network architecture.
+
+Note: This is only tensorflow backend compatible.
+"""
+
+"""
+## Setup
+"""
+
+import os
+os.environ["KERAS_BACKEND"] = "tensorflow"
+
+import re
+import glob
+import pandas as pd
+from pathlib import Path
+from dataclasses import dataclass
+
+from tensorflow import strings as tf_strings
+from tensorflow import data as tf_data
+import keras_core as keras
+import keras_core.ops as ops
+from keras_core import layers
+
+"""
+## Configuration
+"""
+
+@dataclass
+class Config:
+    MAX_LEN = 256
+    BATCH_SIZE = 32
+    LR = 0.001
+    VOCAB_SIZE = 30000
+    EMBED_DIM = 128
+    NUM_HEAD = 8  # used in bert model
+    FF_DIM = 128  # used in bert model
+    NUM_LAYERS = 1
+    NUM_EPOCHS = 1
+    STEPS_PER_EPOCH = 2
+
+
+config = Config()
+
+"""
+## Download the Data: IMDB Movie Review Sentiment Classification
+
+Download the IMDB data and load into a Pandas DataFrame.
+"""
+
+fpath = keras.utils.get_file(
+    origin="https://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz"
+)
+dirpath = Path(fpath).parent.absolute()
+os.system(f"tar -xf {fpath} -C {dirpath}")
+
+"""
+The `aclImdb` folder contains a `train` and `test` subfolder:
+"""
+
+os.system(f"ls {dirpath}/aclImdb")
+os.system(f"ls {dirpath}/aclImdb/train")
+os.system(f"ls {dirpath}/aclImdb/test")
+
+"""
+We are only interested in the `pos` and `neg` subfolders, so let's delete the rest:
+"""
+
+os.system(f"rm -r {dirpath}/aclImdb/train/unsup")
+os.system(f"rm -r {dirpath}/aclImdb/train/*.feat")
+os.system(f"rm -r {dirpath}/aclImdb/train/*.txt")
+os.system(f"rm -r {dirpath}/aclImdb/test/*.feat")
+os.system(f"rm -r {dirpath}/aclImdb/test/*.txt")
+
+"""
+Let's read the dataset from the text files to a DataFrame.
+"""
+
+def get_text_list_from_files(files):
+    text_list = []
+    for name in files:
+        with open(name) as f:
+            for line in f:
+                text_list.append(line)
+    return text_list
+
+
+def get_data_from_text_files(folder_name):
+
+    pos_files = glob.glob(f"{dirpath}/aclImdb/" + folder_name + "/pos/*.txt")
+    pos_texts = get_text_list_from_files(pos_files)
+    neg_files = glob.glob(f"{dirpath}/aclImdb/" + folder_name + "/neg/*.txt")
+    neg_texts = get_text_list_from_files(neg_files)
+    df = pd.DataFrame(
+        {
+            "review": pos_texts + neg_texts,
+            "sentiment": [0] * len(pos_texts) + [1] * len(neg_texts),
+        }
+    )
+    df = df.sample(len(df)).reset_index(drop=True)
+    return df
+
+train_df = get_data_from_text_files("train")
+test_df = get_data_from_text_files("test")
+
+all_data = pd.concat([train_df, test_df], axis=0).reset_index(drop=True)
+assert len(all_data) != 0, f'{all_data} is empty'
+
+"""
+## Dataset preparation
+
+We will use the `TextVectorization` layer to vectorize the text into integer token ids.
+It transforms a batch of strings into either
+a sequence of token indices (one sample = 1D array of integer token indices, in order)
+or a dense representation (one sample = 1D array of float values encoding an unordered set of tokens).
+
+Below, we define 3 preprocessing functions.
+
+1.  The `get_vectorize_layer` function builds the `TextVectorization` layer.
+2.  The `encode` function encodes raw text into integer token ids.
+3.  The `get_masked_input_and_labels` function will mask input token ids. It masks 15% of all input tokens in each sequence at random.
+"""
+
+def custom_standardization(input_data):
+    lowercase = tf_strings.lower(input_data)
+    stripped_html = tf_strings.regex_replace(lowercase, "<br />", " ")
+    return tf_strings.regex_replace(
+        stripped_html, "[%s]" % re.escape("!#$%&'()*+,-./:;<=>?@\^_`{|}~"), ""
+    )
+
+
+def get_vectorize_layer(texts, vocab_size, max_seq, special_tokens=["[MASK]"]):
+    """Build Text vectorization layer
+
+    Args:
+      texts (list): List of string i.e input texts
+      vocab_size (int): vocab size
+      max_seq (int): Maximum sequence lenght.
+      special_tokens (list, optional): List of special tokens. Defaults to ['[MASK]'].
+
+    Returns:
+        layers.Layer: Return TextVectorization Keras Layer
+    """
+    vectorize_layer = layers.TextVectorization(
+        max_tokens=vocab_size,
+        output_mode="int",
+        standardize=custom_standardization,
+        output_sequence_length=max_seq,
+    )
+    vectorize_layer.adapt(texts)
+
+    # Insert mask token in vocabulary
+    vocab = vectorize_layer.get_vocabulary()
+    vocab = vocab[2 : vocab_size - len(special_tokens)] + ["[mask]"]
+    vectorize_layer.set_vocabulary(vocab)
+    return vectorize_layer
+
+
+vectorize_layer = get_vectorize_layer(
+    all_data.review.values.tolist(),
+    config.VOCAB_SIZE,
+    config.MAX_LEN,
+    special_tokens=["[mask]"],
+)
+
+# Get mask token id for masked language model
+mask_token_id = ops.convert_to_numpy(vectorize_layer(["[mask]"]))[0][0]
+
+
+def encode(texts):
+    encoded_texts = vectorize_layer(texts)
+    return ops.convert_to_numpy(encoded_texts)
+
+
+def get_masked_input_and_labels(encoded_texts):
+    # 15% BERT masking
+    inp_mask = ops.convert_to_numpy(keras.random.uniform(encoded_texts.shape) < 0.15)
+    # Do not mask special tokens
+    inp_mask[encoded_texts <= 2] = False
+    # Set targets to -1 by default, it means ignore
+    labels = -1 * ops.convert_to_numpy(ops.cast(ops.ones(encoded_texts.shape), "int"))
+    # Set labels for masked tokens
+    labels[inp_mask] = encoded_texts[inp_mask]
+
+    # Prepare input
+    encoded_texts_masked = ops.convert_to_numpy(ops.copy(encoded_texts))
+    # Set input to [MASK] which is the last token for the 90% of tokens
+    # This means leaving 10% unchanged
+    inp_mask_2mask = inp_mask & ops.convert_to_numpy(keras.random.uniform(encoded_texts.shape) < 0.90)
+    encoded_texts_masked[
+        inp_mask_2mask
+    ] = mask_token_id  # mask token is the last in the dict
+
+    # Set 10% to a random token
+    inp_mask_2random = inp_mask_2mask & ops.convert_to_numpy(keras.random.uniform(encoded_texts.shape) < 1 / 9)
+    encoded_texts_masked[inp_mask_2random] = keras.random.randint(
+        shape=(inp_mask_2random.sum(), ), minval=3, maxval=mask_token_id
+    )
+
+    # Prepare sample_weights to pass to .fit() method
+    sample_weights = ops.convert_to_numpy(ops.ones(labels.shape))
+    sample_weights[labels == -1] = 0
+
+    # y_labels would be same as encoded_texts i.e input tokens
+    y_labels = ops.convert_to_numpy(ops.copy(encoded_texts))
+
+    return encoded_texts_masked, y_labels, sample_weights
+
+
+# We have 25000 examples for training
+x_train = encode(train_df.review.values)  # encode reviews with vectorizer
+y_train = train_df.sentiment.values
+train_classifier_ds = (
+    tf_data.Dataset.from_tensor_slices((x_train, y_train))
+    .shuffle(1000)
+    .batch(config.BATCH_SIZE)
+)
+
+# We have 25000 examples for testing
+x_test = encode(test_df.review.values)
+y_test = test_df.sentiment.values
+test_classifier_ds = tf_data.Dataset.from_tensor_slices((x_test, y_test)).batch(
+    config.BATCH_SIZE
+)
+
+# Build dataset for end to end model input (will be used at the end)
+test_raw_classifier_ds = tf_data.Dataset.from_tensor_slices(
+    (test_df.review.values, y_test)
+).batch(config.BATCH_SIZE)
+
+# Prepare data for masked language model
+x_all_review = encode(all_data.review.values)
+x_masked_train, y_masked_labels, sample_weights = get_masked_input_and_labels(
+    x_all_review
+)
+
+mlm_ds = tf_data.Dataset.from_tensor_slices(
+    (x_masked_train, y_masked_labels, sample_weights)
+)
+mlm_ds = mlm_ds.shuffle(1000).batch(config.BATCH_SIZE)
+
+id2token = dict(enumerate(vectorize_layer.get_vocabulary()))
+token2id = {y: x for x, y in id2token.items()}
+
+class MaskedTextGenerator(keras.callbacks.Callback):
+    def __init__(self, sample_tokens, top_k=5):
+        self.sample_tokens = sample_tokens
+        self.k = top_k
+
+    def decode(self, tokens):
+        return " ".join([id2token[t] for t in tokens if t != 0])
+
+    def convert_ids_to_tokens(self, id):
+        return id2token[id]
+
+    def on_epoch_end(self, epoch, logs=None):
+        prediction = self.model.predict(self.sample_tokens)
+
+        masked_index = ops.where(self.sample_tokens == mask_token_id)
+        masked_index = masked_index[1]
+        mask_prediction = prediction[0][masked_index]
+
+        top_indices = mask_prediction[0].argsort()[-self.k :][::-1]
+        values = mask_prediction[0][top_indices]
+
+        for i in range(len(top_indices)):
+            p = top_indices[i]
+            v = values[i]
+            tokens = ops.convert_to_numpy(ops.copy(self.sample_tokens[0]))
+            tokens[masked_index[0]] = p
+            result = {
+                "input_text": self.decode(ops.convert_to_numpy(self.sample_tokens[0])),
+                "prediction": self.decode(tokens),
+                "probability": v,
+                "predicted mask token": self.convert_ids_to_tokens(p),
+            }
+
+sample_tokens = vectorize_layer(["I have watched this [mask] and it was awesome"])
+generator_callback = MaskedTextGenerator(sample_tokens)
+
+"""
+## Create BERT model (Pretraining Model) for masked language modeling
+
+We will create a BERT-like pretraining model architecture
+using the `MultiHeadAttention` layer.
+It will take token ids as inputs (including masked tokens)
+and it will predict the correct ids for the masked input tokens.
+"""
+
+def bert_module(query, key, value, layer_num):
+    # Multi headed self-attention
+    attention_output = layers.MultiHeadAttention(
+        num_heads=config.NUM_HEAD,
+        key_dim=config.EMBED_DIM // config.NUM_HEAD,
+        name=f"encoder_{layer_num}_multiheadattention",
+    )(query, key, value)
+    attention_output = layers.Dropout(0.1, name=f"encoder_{layer_num}_att_dropout")(
+        attention_output
+    )
+    attention_output = layers.LayerNormalization(
+        epsilon=1e-6, name=f"encoder_{layer_num}_att_layernormalization"
+    )(query + attention_output)
+
+    # Feed-forward layer
+    ffn = keras.Sequential(
+        [
+            layers.Dense(config.FF_DIM, activation="relu"),
+            layers.Dense(config.EMBED_DIM),
+        ],
+        name=f"encoder_{layer_num}_ffn",
+    )
+    ffn_output = ffn(attention_output)
+    ffn_output = layers.Dropout(0.1, name=f"encoder_{layer_num}_ffn_dropout")(
+        ffn_output
+    )
+    sequence_output = layers.LayerNormalization(
+        epsilon=1e-6, name=f"encoder_{layer_num}_ffn_layernormalization"
+    )(attention_output + ffn_output)
+    return sequence_output
+
+
+def get_pos_encoding_matrix(max_len, d_emb):
+    pos_enc = ops.convert_to_numpy(
+        [
+            [pos / ops.power(10000, 2 * (j // 2) / d_emb) for j in range(d_emb)]
+            if pos != 0
+            else ops.convert_to_numpy(ops.zeros(d_emb))
+            for pos in range(max_len)
+        ]
+    )
+    pos_enc[1:, 0::2] = ops.sin(pos_enc[1:, 0::2])  # dim 2i
+    pos_enc[1:, 1::2] = ops.cos(pos_enc[1:, 1::2])  # dim 2i+1
+    return pos_enc
+
+
+loss_fn = keras.losses.SparseCategoricalCrossentropy(from_logits=False)
+# loss_fn = keras.losses.SparseCategoricalCrossentropy(
+#     reduction=None
+# )
+# loss_tracker = keras.metrics.Mean(name="loss")
+
+
+# class MaskedLanguageModel(keras.Model):
+#     def train_step(self, inputs):
+#         if len(inputs) == 3:
+#             features, labels, sample_weight = inputs
+#         else:
+#             features, labels = inputs
+#             sample_weight = None
+
+#         with tf.GradientTape() as tape:
+#             predictions = self(features, training=True)
+#             loss = loss_fn(labels, predictions, sample_weight=sample_weight)
+
+#         # Compute gradients
+#         trainable_vars = self.trainable_variables
+#         gradients = tape.gradient(loss, trainable_vars)
+
+#         # Update weights
+#         self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+
+#         # Compute our own metrics
+#         loss_tracker.update_state(loss, sample_weight=sample_weight)
+
+#         # Return a dict mapping metric names to current value
+#         return {"loss": loss_tracker.result()}
+
+#     @property
+#     def metrics(self):
+#         # We list our `Metric` objects here so that `reset_states()` can be
+#         # called automatically at the start of each epoch
+#         # or at the start of `evaluate()`.
+#         # If you don't implement this property, you have to call
+#         # `reset_states()` yourself at the time of your choosing.
+#         return [loss_tracker]
+
+
+def create_masked_language_bert_model():
+    inputs = layers.Input((config.MAX_LEN,), dtype="int32")
+
+    word_embeddings = layers.Embedding(
+        config.VOCAB_SIZE, config.EMBED_DIM, name="word_embedding"
+    )(inputs)
+    
+    position_embeddings = layers.Embedding(
+        input_dim=config.MAX_LEN,
+        output_dim=config.EMBED_DIM,
+        embeddings_initializer=keras.initializers.Constant(get_pos_encoding_matrix(config.MAX_LEN, config.EMBED_DIM)),
+        name="position_embedding",
+    )(ops.arange(start=0, stop=config.MAX_LEN, step=1))
+    
+    embeddings = word_embeddings + position_embeddings
+
+    encoder_output = embeddings
+    for i in range(config.NUM_LAYERS):
+        encoder_output = bert_module(encoder_output, encoder_output, encoder_output, i)
+
+    mlm_output = layers.Dense(config.VOCAB_SIZE, name="mlm_cls", activation="softmax")(
+        encoder_output
+    )
+    mlm_model = keras.Model(inputs, mlm_output, name="masked_bert_model")
+
+    optimizer = keras.optimizers.Adam(learning_rate=config.LR)
+    mlm_model.compile(optimizer=optimizer, loss=loss_fn)
+    return mlm_model
+
+bert_masked_model = create_masked_language_bert_model()
+bert_masked_model.summary()
+
+"""
+## Train and Save
+"""
+
+bert_masked_model.fit(mlm_ds, epochs=Config.NUM_EPOCHS, steps_per_epoch=Config.STEPS_PER_EPOCH, callbacks=[generator_callback])
+bert_masked_model.save("bert_mlm_imdb.keras")
+
+"""
+## Fine-tune a sentiment classification model
+
+We will fine-tune our self-supervised model on a downstream task of sentiment classification.
+To do this, let's create a classifier by adding a pooling layer and a `Dense` layer on top of the
+pretrained BERT features.
+"""
+
+# Load pretrained bert model
+mlm_model = keras.models.load_model(
+    "bert_mlm_imdb.keras", custom_objects={"MaskedLanguageModel": bert_masked_model}
+)
+pretrained_bert_model = keras.Model(
+    mlm_model.input, mlm_model.get_layer("encoder_0_ffn_layernormalization").output
+)
+
+# Freeze it
+pretrained_bert_model.trainable = False
+
+
+def create_classifier_bert_model():
+    inputs = layers.Input((config.MAX_LEN,), dtype="int32")
+    sequence_output = pretrained_bert_model(inputs)
+    pooled_output = layers.GlobalMaxPooling1D()(sequence_output)
+    hidden_layer = layers.Dense(64, activation="relu")(pooled_output)
+    outputs = layers.Dense(1, activation="sigmoid")(hidden_layer)
+    classifer_model = keras.Model(inputs, outputs, name="classification")
+    optimizer = keras.optimizers.Adam()
+    classifer_model.compile(
+        optimizer=optimizer, loss="binary_crossentropy", metrics=["accuracy"]
+    )
+    return classifer_model
+
+
+classifer_model = create_classifier_bert_model()
+classifer_model.summary()
+
+# Train the classifier with frozen BERT stage
+classifer_model.fit(
+    train_classifier_ds,
+    epochs=Config.NUM_EPOCHS,
+    steps_per_epoch=Config.STEPS_PER_EPOCH,
+    validation_data=test_classifier_ds,
+)
+
+# Unfreeze the BERT model for fine-tuning
+pretrained_bert_model.trainable = True
+optimizer = keras.optimizers.Adam()
+classifer_model.compile(
+    optimizer=optimizer, loss="binary_crossentropy", metrics=["accuracy"]
+)
+classifer_model.fit(
+    train_classifier_ds,
+    epochs=Config.NUM_EPOCHS,
+    steps_per_epoch=Config.STEPS_PER_EPOCH,
+    validation_data=test_classifier_ds,
+)
+
+"""
+## Create an end-to-end model and evaluate it
+
+When you want to deploy a model, it's best if it already includes its preprocessing
+pipeline, so that you don't have to reimplement the preprocessing logic in your
+production environment. Let's create an end-to-end model that incorporates
+the `TextVectorization` layer, and let's evaluate. Our model will accept raw strings
+as input.
+"""
+
+def get_end_to_end(model):
+    inputs_string = keras.Input(shape=(1,), dtype="string")
+    indices = vectorize_layer(inputs_string)
+    outputs = model(indices)
+    end_to_end_model = keras.Model(inputs_string, outputs, name="end_to_end_model")
+    optimizer = keras.optimizers.Adam(learning_rate=config.LR)
+    end_to_end_model.compile(
+        optimizer=optimizer, loss="binary_crossentropy", metrics=["accuracy"]
+    )
+    return end_to_end_model
+
+
+end_to_end_classification_model = get_end_to_end(classifer_model)
+end_to_end_classification_model.evaluate(test_raw_classifier_ds)


### PR DESCRIPTION
Backend Agnostic Port for MLM with BERt to keras-core Draft PR

With keras-team/keras-core#843 merged to keras-core that supports `tensorflow` backend, I tried to fully port the pipeline to keras-core making it backend agnostic. Doing so, I faced with following issues mentioned keras-team/keras#18410 and below:

While training with `torch` backend, it throws the below error traceback:

```md
 Total params: 7,809,584 (29.79 MB)
 Trainable params: 7,809,584 (29.79 MB)
 Non-trainable params: 0 (0.00 B)
1/2 ━━━━━━━━━━━━━━━━━━━━ 6s 6s/step - loss: 0.8220Traceback (most recent call last):
  File "/Users/mrutyunjaybiswal/Documents/oss/tfjax/keras-core/examples/keras_io/nlp/end_to_end_mlm_with_bert.py", line 448, in <module>
    bert_masked_model.fit(mlm_ds, epochs=Config.NUM_EPOCHS, steps_per_epoch=Config.STEPS_PER_EPOCH, callbacks=[generator_callback])
  File "/Users/mrutyunjaybiswal/Documents/oss/tfjax/keras-core/kscore/lib/python3.10/site-packages/keras_core/src/utils/traceback_utils.py", line 123, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/Users/mrutyunjaybiswal/Documents/oss/tfjax/keras-core/kscore/lib/python3.10/site-packages/torch/_tensor.py", line 487, in backward
    torch.autograd.backward(
  File "/Users/mrutyunjaybiswal/Documents/oss/tfjax/keras-core/kscore/lib/python3.10/site-packages/torch/autograd/__init__.py", line 200, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
RuntimeError: Trying to backward through the graph a second time (or directly access saved tensors after they have already been freed). Saved intermediate values of the graph are freed when you call .backward() or autograd.grad(). Specify retain_graph=True if you need to backward through the graph a second time or if you need to access saved tensors after calling backward.
```

Note that this pipeline works seamless with tensorflow backend, where as having issues with JAX and torch as mentioned above. Here's the diff for `tensorflow-backend` port and `backend-agnostic` port:

```diff
diff --git a/examples/keras_io/tensorflow/nlp/end_to_end_mlm_with_bert.py b/examples/keras_io/nlp/end_to_end_mlm_with_bert.py
index 1598b48..8305ff2 100644
--- a/examples/keras_io/tensorflow/nlp/end_to_end_mlm_with_bert.py
+++ b/examples/keras_io/nlp/end_to_end_mlm_with_bert.py
@@ -42,15 +42,18 @@ Note: This is only tensorflow backend compatible.
 """
 
 import os
+os.environ["KERAS_BACKEND"] = "tensorflow"
+
 import re
 import glob
-import numpy as np
 import pandas as pd
 from pathlib import Path
 from dataclasses import dataclass
 
-import tensorflow as tf
+from tensorflow import strings as tf_strings
+from tensorflow import data as tf_data
 import keras_core as keras
+import keras_core.ops as ops
 from keras_core import layers
 
 """
@@ -153,9 +156,9 @@ Below, we define 3 preprocessing functions.
 """
 
 def custom_standardization(input_data):
-    lowercase = tf.strings.lower(input_data)
-    stripped_html = tf.strings.regex_replace(lowercase, "<br />", " ")
-    return tf.strings.regex_replace(
+    lowercase = tf_strings.lower(input_data)
+    stripped_html = tf_strings.regex_replace(lowercase, "<br />", " ")
+    return tf_strings.regex_replace(
         stripped_html, "[%s]" % re.escape("!#$%&'()*+,-./:;<=>?@\^_`{|}~"), ""
     )
 
@@ -195,45 +198,45 @@ vectorize_layer = get_vectorize_layer(
 )
 
 # Get mask token id for masked language model
-mask_token_id = vectorize_layer(["[mask]"]).numpy()[0][0]
+mask_token_id = ops.convert_to_numpy(vectorize_layer(["[mask]"]))[0][0]
 
 
 def encode(texts):
     encoded_texts = vectorize_layer(texts)
-    return encoded_texts.numpy()
+    return ops.convert_to_numpy(encoded_texts)
 
 
 def get_masked_input_and_labels(encoded_texts):
     # 15% BERT masking
-    inp_mask = np.random.rand(*encoded_texts.shape) < 0.15
+    inp_mask = ops.convert_to_numpy(keras.random.uniform(encoded_texts.shape) < 0.15)
     # Do not mask special tokens
     inp_mask[encoded_texts <= 2] = False
     # Set targets to -1 by default, it means ignore
-    labels = -1 * np.ones(encoded_texts.shape, dtype=int)
+    labels = -1 * ops.convert_to_numpy(ops.cast(ops.ones(encoded_texts.shape), "int"))
     # Set labels for masked tokens
     labels[inp_mask] = encoded_texts[inp_mask]
 
     # Prepare input
-    encoded_texts_masked = np.copy(encoded_texts)
+    encoded_texts_masked = ops.convert_to_numpy(ops.copy(encoded_texts))
     # Set input to [MASK] which is the last token for the 90% of tokens
     # This means leaving 10% unchanged
-    inp_mask_2mask = inp_mask & (np.random.rand(*encoded_texts.shape) < 0.90)
+    inp_mask_2mask = inp_mask & ops.convert_to_numpy(keras.random.uniform(encoded_texts.shape) < 0.90)
     encoded_texts_masked[
         inp_mask_2mask
     ] = mask_token_id  # mask token is the last in the dict
 
     # Set 10% to a random token
-    inp_mask_2random = inp_mask_2mask & (np.random.rand(*encoded_texts.shape) < 1 / 9)
-    encoded_texts_masked[inp_mask_2random] = np.random.randint(
-        3, mask_token_id, inp_mask_2random.sum()
+    inp_mask_2random = inp_mask_2mask & ops.convert_to_numpy(keras.random.uniform(encoded_texts.shape) < 1 / 9)
+    encoded_texts_masked[inp_mask_2random] = keras.random.randint(
+        shape=(inp_mask_2random.sum(), ), minval=3, maxval=mask_token_id
     )
 
     # Prepare sample_weights to pass to .fit() method
-    sample_weights = np.ones(labels.shape)
+    sample_weights = ops.convert_to_numpy(ops.ones(labels.shape))
     sample_weights[labels == -1] = 0
 
     # y_labels would be same as encoded_texts i.e input tokens
-    y_labels = np.copy(encoded_texts)
+    y_labels = ops.convert_to_numpy(ops.copy(encoded_texts))
 
     return encoded_texts_masked, y_labels, sample_weights
 
@@ -242,7 +245,7 @@ def get_masked_input_and_labels(encoded_texts):
 x_train = encode(train_df.review.values)  # encode reviews with vectorizer
 y_train = train_df.sentiment.values
 train_classifier_ds = (
-    tf.data.Dataset.from_tensor_slices((x_train, y_train))
+    tf_data.Dataset.from_tensor_slices((x_train, y_train))
     .shuffle(1000)
     .batch(config.BATCH_SIZE)
 )
@@ -250,12 +253,12 @@ train_classifier_ds = (
 # We have 25000 examples for testing
 x_test = encode(test_df.review.values)
 y_test = test_df.sentiment.values
-test_classifier_ds = tf.data.Dataset.from_tensor_slices((x_test, y_test)).batch(
+test_classifier_ds = tf_data.Dataset.from_tensor_slices((x_test, y_test)).batch(
     config.BATCH_SIZE
 )
 
 # Build dataset for end to end model input (will be used at the end)
-test_raw_classifier_ds = tf.data.Dataset.from_tensor_slices(
+test_raw_classifier_ds = tf_data.Dataset.from_tensor_slices(
     (test_df.review.values, y_test)
 ).batch(config.BATCH_SIZE)
 
@@ -265,7 +268,7 @@ x_masked_train, y_masked_labels, sample_weights = get_masked_input_and_labels(
     x_all_review
 )
 
-mlm_ds = tf.data.Dataset.from_tensor_slices(
+mlm_ds = tf_data.Dataset.from_tensor_slices(
     (x_masked_train, y_masked_labels, sample_weights)
 )
 mlm_ds = mlm_ds.shuffle(1000).batch(config.BATCH_SIZE)
@@ -287,7 +290,7 @@ class MaskedTextGenerator(keras.callbacks.Callback):
     def on_epoch_end(self, epoch, logs=None):
         prediction = self.model.predict(self.sample_tokens)
 
-        masked_index = np.where(self.sample_tokens == mask_token_id)
+        masked_index = ops.where(self.sample_tokens == mask_token_id)
         masked_index = masked_index[1]
         mask_prediction = prediction[0][masked_index]
 
@@ -297,17 +300,17 @@ class MaskedTextGenerator(keras.callbacks.Callback):
         for i in range(len(top_indices)):
             p = top_indices[i]
             v = values[i]
-            tokens = np.copy(self.sample_tokens[0])
+            tokens = ops.convert_to_numpy(ops.copy(self.sample_tokens[0]))
             tokens[masked_index[0]] = p
             result = {
-                "input_text": self.decode(self.sample_tokens[0]),
+                "input_text": self.decode(ops.convert_to_numpy(self.sample_tokens[0])),
                 "prediction": self.decode(tokens),
                 "probability": v,
                 "predicted mask token": self.convert_ids_to_tokens(p),
             }
 
 sample_tokens = vectorize_layer(["I have watched this [mask] and it was awesome"])
-generator_callback = MaskedTextGenerator(sample_tokens.numpy())
+generator_callback = MaskedTextGenerator(sample_tokens)
 
 """
 ## Create BERT model (Pretraining Model) for masked language modeling
@@ -351,62 +354,63 @@ def bert_module(query, key, value, layer_num):
 
 
 def get_pos_encoding_matrix(max_len, d_emb):
-    pos_enc = np.array(
+    pos_enc = ops.convert_to_numpy(
         [
-            [pos / np.power(10000, 2 * (j // 2) / d_emb) for j in range(d_emb)]
+            [pos / ops.power(10000, 2 * (j // 2) / d_emb) for j in range(d_emb)]
             if pos != 0
-            else np.zeros(d_emb)
+            else ops.convert_to_numpy(ops.zeros(d_emb))
             for pos in range(max_len)
         ]
     )
-    pos_enc[1:, 0::2] = np.sin(pos_enc[1:, 0::2])  # dim 2i
-    pos_enc[1:, 1::2] = np.cos(pos_enc[1:, 1::2])  # dim 2i+1
+    pos_enc[1:, 0::2] = ops.sin(pos_enc[1:, 0::2])  # dim 2i
+    pos_enc[1:, 1::2] = ops.cos(pos_enc[1:, 1::2])  # dim 2i+1
     return pos_enc
 
 
-loss_fn = keras.losses.SparseCategoricalCrossentropy(
-    reduction=None
-)
-loss_tracker = keras.metrics.Mean(name="loss")
+loss_fn = keras.losses.SparseCategoricalCrossentropy(from_logits=False)
+# loss_fn = keras.losses.SparseCategoricalCrossentropy(
+#     reduction=None
+# )
+# loss_tracker = keras.metrics.Mean(name="loss")
 
 
-class MaskedLanguageModel(keras.Model):
-    def train_step(self, inputs):
-        if len(inputs) == 3:
-            features, labels, sample_weight = inputs
-        else:
-            features, labels = inputs
-            sample_weight = None
+# class MaskedLanguageModel(keras.Model):
+#     def train_step(self, inputs):
+#         if len(inputs) == 3:
+#             features, labels, sample_weight = inputs
+#         else:
+#             features, labels = inputs
+#             sample_weight = None
 
-        with tf.GradientTape() as tape:
-            predictions = self(features, training=True)
-            loss = loss_fn(labels, predictions, sample_weight=sample_weight)
+#         with tf.GradientTape() as tape:
+#             predictions = self(features, training=True)
+#             loss = loss_fn(labels, predictions, sample_weight=sample_weight)
 
-        # Compute gradients
-        trainable_vars = self.trainable_variables
-        gradients = tape.gradient(loss, trainable_vars)
+#         # Compute gradients
+#         trainable_vars = self.trainable_variables
+#         gradients = tape.gradient(loss, trainable_vars)
 
-        # Update weights
-        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+#         # Update weights
+#         self.optimizer.apply_gradients(zip(gradients, trainable_vars))
 
-        # Compute our own metrics
-        loss_tracker.update_state(loss, sample_weight=sample_weight)
+#         # Compute our own metrics
+#         loss_tracker.update_state(loss, sample_weight=sample_weight)
 
-        # Return a dict mapping metric names to current value
-        return {"loss": loss_tracker.result()}
+#         # Return a dict mapping metric names to current value
+#         return {"loss": loss_tracker.result()}
 
-    @property
-    def metrics(self):
-        # We list our `Metric` objects here so that `reset_states()` can be
-        # called automatically at the start of each epoch
-        # or at the start of `evaluate()`.
-        # If you don't implement this property, you have to call
-        # `reset_states()` yourself at the time of your choosing.
-        return [loss_tracker]
+#     @property
+#     def metrics(self):
+#         # We list our `Metric` objects here so that `reset_states()` can be
+#         # called automatically at the start of each epoch
+#         # or at the start of `evaluate()`.
+#         # If you don't implement this property, you have to call
+#         # `reset_states()` yourself at the time of your choosing.
+#         return [loss_tracker]
 
 
 def create_masked_language_bert_model():
-    inputs = layers.Input((config.MAX_LEN,), dtype=tf.int64)
+    inputs = layers.Input((config.MAX_LEN,), dtype="int32")
 
     word_embeddings = layers.Embedding(
         config.VOCAB_SIZE, config.EMBED_DIM, name="word_embedding"
@@ -417,7 +421,7 @@ def create_masked_language_bert_model():
         output_dim=config.EMBED_DIM,
         embeddings_initializer=keras.initializers.Constant(get_pos_encoding_matrix(config.MAX_LEN, config.EMBED_DIM)),
         name="position_embedding",
-    )(tf.range(start=0, limit=config.MAX_LEN, delta=1))
+    )(ops.arange(start=0, stop=config.MAX_LEN, step=1))
     
     embeddings = word_embeddings + position_embeddings
 
@@ -428,10 +432,10 @@ def create_masked_language_bert_model():
     mlm_output = layers.Dense(config.VOCAB_SIZE, name="mlm_cls", activation="softmax")(
         encoder_output
     )
-    mlm_model = MaskedLanguageModel(inputs, mlm_output, name="masked_bert_model")
+    mlm_model = keras.Model(inputs, mlm_output, name="masked_bert_model")
 
     optimizer = keras.optimizers.Adam(learning_rate=config.LR)
-    mlm_model.compile(optimizer=optimizer)
+    mlm_model.compile(optimizer=optimizer, loss=loss_fn)
     return mlm_model
 
 bert_masked_model = create_masked_language_bert_model()
@@ -454,7 +458,7 @@ pretrained BERT features.
 
 # Load pretrained bert model
 mlm_model = keras.models.load_model(
-    "bert_mlm_imdb.keras", custom_objects={"MaskedLanguageModel": MaskedLanguageModel}
+    "bert_mlm_imdb.keras", custom_objects={"MaskedLanguageModel": bert_masked_model}
 )
 pretrained_bert_model = keras.Model(
     mlm_model.input, mlm_model.get_layer("encoder_0_ffn_layernormalization").output
@@ -465,7 +469,7 @@ pretrained_bert_model.trainable = False
 
 
 def create_classifier_bert_model():
-    inputs = layers.Input((config.MAX_LEN,), dtype=tf.int64)
+    inputs = layers.Input((config.MAX_LEN,), dtype="int32")
     sequence_output = pretrained_bert_model(inputs)
     pooled_output = layers.GlobalMaxPooling1D()(sequence_output)
     hidden_layer = layers.Dense(64, activation="relu")(pooled_output)
```

Not sure what am I missing exactly, will take a deeper look. Let me know of the needed changes.

cc: @fchollet 