### PR TITLE
Add a note in README.md regarding pre-import of backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ os.environ["KERAS_BACKEND"] = "jax"
 
 import keras_core as keras
 ```
-
+**Note:** The backend must be configured before importing keras_core, and the backend cannot be changed after 
+the package has been imported.
 ## Backwards compatibility
 
 Keras Core is intended to work as a drop-in replacement for `tf.keras` (when using the TensorFlow backend). Just take your


### PR DESCRIPTION
With `keras_core` users has to import the **backend** first before importing `keras_core`. It has to be documented in **README.md** for better visibility and reach to the community.

Fixes #833