### PR TITLE
Add support for Tensorflow SparseTensors: reshaping layers.

### DIFF
--- a/keras_core/backend/tensorflow/numpy.py
+++ b/keras_core/backend/tensorflow/numpy.py
@@ -524,6 +524,8 @@ def repeat(x, repeats, axis=None):
 
 
 def reshape(x, new_shape):
+    if isinstance(x, tf.SparseTensor):
+        return tf.sparse.reshape(x, new_shape)
     return tfnp.reshape(x, new_shape)
 
 
@@ -689,6 +691,8 @@ def squeeze(x, axis=None):
 
 
 def transpose(x, axes=None):
+    if isinstance(x, tf.SparseTensor):
+        return tf.sparse.transpose(x, perm=axes)
     return tfnp.transpose(x, axes=axes)
 
 

--- a/keras_core/layers/reshaping/flatten.py
+++ b/keras_core/layers/reshaping/flatten.py
@@ -3,6 +3,7 @@ import math
 from keras_core import backend
 from keras_core import ops
 from keras_core.api_export import keras_core_export
+from keras_core.backend.common.keras_tensor import KerasTensor
 from keras_core.layers.input_spec import InputSpec
 from keras_core.layers.layer import Layer
 
@@ -61,6 +62,12 @@ class Flatten(Layer):
         else:
             flattened_dim = math.prod(non_batch_dims)
         return (input_shape[0], flattened_dim)
+
+    def compute_output_spec(self, inputs):
+        output_shape = self.compute_output_shape(inputs.shape)
+        return KerasTensor(
+            shape=output_shape, dtype=inputs.dtype, sparse=inputs.sparse
+        )
 
     def get_config(self):
         config = {"data_format": self.data_format}

--- a/keras_core/layers/reshaping/flatten_test.py
+++ b/keras_core/layers/reshaping/flatten_test.py
@@ -1,42 +1,74 @@
 import numpy as np
 import pytest
+from absl.testing import parameterized
 
+from keras_core import backend
 from keras_core import layers
 from keras_core import ops
 from keras_core import testing
 
 
-class FlattenTest(testing.TestCase):
+class FlattenTest(testing.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(
+        [
+            {"testcase_name": "dense", "sparse": False},
+            {"testcase_name": "sparse", "sparse": True},
+        ]
+    )
     @pytest.mark.requires_trainable_backend
-    def test_flatten(self):
-        inputs = np.random.random((10, 3, 5, 5)).astype("float32")
+    def test_flatten(self, sparse):
+        if sparse and not backend.SUPPORTS_SPARSE_TENSORS:
+            pytest.skip("Backend does not support sparse tensors.")
 
-        # Test default data_format and channels_last
-        expected_output = ops.convert_to_tensor(
+        inputs = np.random.random((10, 3, 5, 5)).astype("float32")
+        # Make the ndarray relatively sparse
+        inputs = np.multiply(inputs, inputs >= 0.8)
+        expected_output_channels_last = ops.convert_to_tensor(
             np.reshape(inputs, (-1, 5 * 5 * 3))
         )
+        expected_output_channels_first = ops.convert_to_tensor(
+            np.reshape(np.transpose(inputs, (0, 2, 3, 1)), (-1, 5 * 5 * 3))
+        )
+        if sparse:
+            import tensorflow as tf
+
+            inputs = tf.sparse.from_dense(inputs)
+            expected_output_channels_last = tf.sparse.from_dense(
+                expected_output_channels_last
+            )
+            expected_output_channels_first = tf.sparse.from_dense(
+                expected_output_channels_first
+            )
+
+        # Test default data_format and channels_last
         self.run_layer_test(
             layers.Flatten,
             init_kwargs={},
             input_data=inputs,
-            expected_output=expected_output,
+            input_sparse=True,
+            expected_output=expected_output_channels_last,
+            expected_output_sparse=sparse,
+            run_training_check=not sparse,
         )
         self.run_layer_test(
             layers.Flatten,
             init_kwargs={"data_format": "channels_last"},
             input_data=inputs,
-            expected_output=expected_output,
+            input_sparse=True,
+            expected_output=expected_output_channels_last,
+            expected_output_sparse=sparse,
+            run_training_check=not sparse,
         )
 
         # Test channels_first
-        expected_output = ops.convert_to_tensor(
-            np.reshape(np.transpose(inputs, (0, 2, 3, 1)), (-1, 5 * 5 * 3))
-        )
         self.run_layer_test(
             layers.Flatten,
             init_kwargs={"data_format": "channels_first"},
             input_data=inputs,
-            expected_output=expected_output,
+            input_sparse=True,
+            expected_output=expected_output_channels_first,
+            expected_output_sparse=sparse,
+            run_training_check=not sparse,
         )
 
     @pytest.mark.requires_trainable_backend

--- a/keras_core/layers/reshaping/permute.py
+++ b/keras_core/layers/reshaping/permute.py
@@ -1,5 +1,6 @@
 from keras_core import ops
 from keras_core.api_export import keras_core_export
+from keras_core.backend.common.keras_tensor import KerasTensor
 from keras_core.layers.input_spec import InputSpec
 from keras_core.layers.layer import Layer
 
@@ -47,6 +48,12 @@ class Permute(Layer):
         for dim in self.dims:
             output_shape.append(input_shape[dim])
         return tuple(output_shape)
+
+    def compute_output_spec(self, inputs):
+        output_shape = self.compute_output_shape(inputs.shape)
+        return KerasTensor(
+            shape=output_shape, dtype=inputs.dtype, sparse=inputs.sparse
+        )
 
     def call(self, inputs):
         return ops.transpose(inputs, axes=(0,) + self.dims)

--- a/keras_core/layers/reshaping/reshape.py
+++ b/keras_core/layers/reshaping/reshape.py
@@ -1,5 +1,6 @@
 from keras_core import ops
 from keras_core.api_export import keras_core_export
+from keras_core.backend.common.keras_tensor import KerasTensor
 from keras_core.layers.layer import Layer
 from keras_core.ops import operation_utils
 
@@ -44,6 +45,12 @@ class Reshape(Layer):
             *operation_utils.compute_reshape_output_shape(
                 input_shape[1:], self.target_shape, "target_shape"
             ),
+        )
+
+    def compute_output_spec(self, inputs):
+        output_shape = self.compute_output_shape(inputs.shape)
+        return KerasTensor(
+            shape=output_shape, dtype=inputs.dtype, sparse=inputs.sparse
         )
 
     def call(self, inputs):

--- a/keras_core/layers/reshaping/reshape_test.py
+++ b/keras_core/layers/reshaping/reshape_test.py
@@ -1,58 +1,90 @@
 import pytest
+from absl.testing import parameterized
 
+from keras_core import backend
 from keras_core import layers
 from keras_core import testing
 
 
-class ReshapeTest(testing.TestCase):
+class ReshapeTest(testing.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(
+        [
+            {"testcase_name": "dense", "sparse": False},
+            {"testcase_name": "sparse", "sparse": True},
+        ]
+    )
     @pytest.mark.requires_trainable_backend
-    def test_reshape(self):
+    def test_reshape(self, sparse):
+        if sparse and not backend.SUPPORTS_SPARSE_TENSORS:
+            pytest.skip("Backend does not support sparse tensors.")
+
         self.run_layer_test(
             layers.Reshape,
             init_kwargs={"target_shape": (8, 1)},
             input_shape=(3, 2, 4),
+            input_sparse=sparse,
             expected_output_shape=(3, 8, 1),
+            expected_output_sparse=sparse,
+            run_training_check=not sparse,
         )
 
         self.run_layer_test(
             layers.Reshape,
             init_kwargs={"target_shape": (8,)},
             input_shape=(3, 2, 4),
+            input_sparse=sparse,
             expected_output_shape=(3, 8),
+            expected_output_sparse=sparse,
+            run_training_check=not sparse,
         )
 
         self.run_layer_test(
             layers.Reshape,
             init_kwargs={"target_shape": (2, 4)},
             input_shape=(3, 8),
+            input_sparse=sparse,
             expected_output_shape=(3, 2, 4),
+            expected_output_sparse=sparse,
+            run_training_check=not sparse,
         )
         self.run_layer_test(
             layers.Reshape,
             init_kwargs={"target_shape": (-1, 1)},
             input_shape=(3, 2, 4),
+            input_sparse=sparse,
             expected_output_shape=(3, 8, 1),
+            expected_output_sparse=sparse,
+            run_training_check=not sparse,
         )
 
         self.run_layer_test(
             layers.Reshape,
             init_kwargs={"target_shape": (1, -1)},
             input_shape=(3, 2, 4),
+            input_sparse=sparse,
             expected_output_shape=(3, 1, 8),
+            expected_output_sparse=sparse,
+            run_training_check=not sparse,
         )
 
         self.run_layer_test(
             layers.Reshape,
             init_kwargs={"target_shape": (-1,)},
             input_shape=(3, 2, 4),
+            input_sparse=sparse,
             expected_output_shape=(3, 8),
+            expected_output_sparse=sparse,
+            run_training_check=not sparse,
         )
 
         self.run_layer_test(
             layers.Reshape,
             init_kwargs={"target_shape": (2, -1)},
             input_shape=(3, 2, 4),
+            input_sparse=sparse,
             expected_output_shape=(3, 2, 4),
+            expected_output_sparse=sparse,
+            run_training_check=not sparse,
         )
 
     def test_reshape_with_dynamic_batch_size(self):

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -4163,7 +4163,7 @@ class Reshape(Operation):
         output_shape = operation_utils.compute_reshape_output_shape(
             x.shape, self.new_shape, "new_shape"
         )
-        return KerasTensor(output_shape, dtype=x.dtype)
+        return KerasTensor(output_shape, dtype=x.dtype, sparse=x.sparse)
 
 
 @keras_core_export(["keras_core.ops.reshape", "keras_core.ops.numpy.reshape"])
@@ -5328,7 +5328,7 @@ class Transpose(Operation):
     def compute_output_spec(self, x):
         x_shape = x.shape
         if self.axes is None:
-            return KerasTensor(x_shape[::-1])
+            return KerasTensor(x_shape[::-1], dtype=x.dtype, sparse=x.sparse)
 
         if len(self.axes) != len(x_shape):
             raise ValueError(
@@ -5338,7 +5338,7 @@ class Transpose(Operation):
         output_shape = []
         for ax in self.axes:
             output_shape.append(x_shape[ax])
-        return KerasTensor(output_shape, dtype=x.dtype)
+        return KerasTensor(output_shape, dtype=x.dtype, sparse=x.sparse)
 
 
 @keras_core_export(

--- a/keras_core/testing/test_case.py
+++ b/keras_core/testing/test_case.py
@@ -112,8 +112,8 @@ class TestCase(unittest.TestCase):
         init_kwargs,
         input_shape=None,
         input_dtype="float32",
-        input_data=None,
         input_sparse=False,
+        input_data=None,
         call_kwargs=None,
         expected_output_shape=None,
         expected_output_dtype=None,
@@ -139,6 +139,8 @@ class TestCase(unittest.TestCase):
             input_shape: Shape tuple (or list/dict of shape tuples)
                 to call the layer on.
             input_dtype: Corresponding input dtype.
+            input_sparse: Whether the input is a sparse tensor (this requires
+                the backend to support sparse tensors).
             input_data: Tensor (or list/dict of tensors)
                 to call the layer on.
             call_kwargs: Dict of arguments to use when calling the
@@ -147,6 +149,8 @@ class TestCase(unittest.TestCase):
                 (or list/dict of shape tuples)
                 expected as output.
             expected_output_dtype: dtype expected as output.
+            expected_output_sparse: Whether the output is expected to be sparse
+                (this requires the backend to support sparse tensors).
             expected_output: Expected output tensor -- only
                 to be specified if input_data is provided.
             expected_num_trainable_weights: Expected number


### PR DESCRIPTION
Added `tf.SparseTensor` support for ops:
- reshape
- transpose

Added `tf.SparseTensor` support for reshaping layers:
- Flatten
- Permute
- Reshape