### PR TITLE
Add `ops.nn.moments` and speed-up normalization layers

### DIFF
--- a/keras_core/backend/jax/nn.py
+++ b/keras_core/backend/jax/nn.py
@@ -490,22 +490,21 @@ def binary_crossentropy(target, output, from_logits=False):
 
 
 def moments(x, axes, keepdims=False):
-    # The dynamic range of fp16 is too limited to support the collection of
-    # sufficient statistics. As a workaround we simply perform the operations
-    # on 32-bit floats before converting the mean and variance back to fp16
+    # The dynamic range of float16 is too limited for statistics. As a
+    # workaround, we simply perform the operations on float32 and convert back
+    # to float16
     need_cast = False
     ori_dtype = standardize_dtype(x.dtype)
     if ori_dtype == "float16":
         need_cast = True
         x = cast(x, "float32")
 
-    # Compute true mean while keeping the dims for proper broadcasting
     mean = jnp.mean(x, axes, keepdims=True)
 
-    # Sample variance, not unbiased variance
-    # Note: stop_gradient does not change the gradient that gets
-    #       backpropagated to the mean from the variance calculation,
-    #       because that gradient is zero
+    # The variance is computed using $Var = E[|x|^2] - |E[x]|^2$, It is faster
+    # but less numerically stable.
+    # Note: stop_gradient does not change the gradient to the mean, because that
+    # gradient is zero.
     variance = jnp.mean(jnp.square(x), axis=axes, keepdims=True) - jnp.square(
         jax.lax.stop_gradient(mean)
     )
@@ -514,6 +513,13 @@ def moments(x, axes, keepdims=False):
         mean = jnp.squeeze(mean, axes)
         variance = jnp.squeeze(variance, axes)
     if need_cast:
+        # avoid overflow and underflow when casting from float16 to float32
+        mean = jnp.clip(
+            mean, jnp.finfo(jnp.float16).min, jnp.finfo(jnp.float16).max
+        )
+        variance = jnp.clip(
+            variance, jnp.finfo(jnp.float16).min, jnp.finfo(jnp.float16).max
+        )
         mean = cast(mean, ori_dtype)
         variance = cast(variance, ori_dtype)
     return mean, variance

--- a/keras_core/backend/jax/nn.py
+++ b/keras_core/backend/jax/nn.py
@@ -506,10 +506,8 @@ def moments(x, axes, keepdims=False):
     # Note: stop_gradient does not change the gradient that gets
     #       backpropagated to the mean from the variance calculation,
     #       because that gradient is zero
-    variance = jnp.mean(
-        jnp.square(x - jax.lax.stop_gradient(mean)),
-        axis=axes,
-        keepdims=True,
+    variance = jnp.mean(jnp.square(x), axis=axes, keepdims=True) - jnp.square(
+        jax.lax.stop_gradient(mean)
     )
 
     if not keepdims:

--- a/keras_core/backend/numpy/nn.py
+++ b/keras_core/backend/numpy/nn.py
@@ -537,7 +537,7 @@ def moments(x, axes, keepdims=False):
     mean = np.mean(x, axes, keepdims=True)
 
     # Sample variance, not unbiased variance
-    variance = np.mean(np.square(x - mean), axis=axes, keepdims=True)
+    variance = np.mean(np.square(x), axis=axes, keepdims=True) - np.square(mean)
 
     if not keepdims:
         mean = np.squeeze(mean, axes)

--- a/keras_core/backend/tensorflow/nn.py
+++ b/keras_core/backend/tensorflow/nn.py
@@ -3,6 +3,7 @@ import warnings
 import tensorflow as tf
 
 from keras_core.backend import standardize_data_format
+from keras_core.backend import standardize_dtype
 from keras_core.backend.common.backend_utils import (
     compute_conv_transpose_output_shape,
 )
@@ -649,4 +650,30 @@ def binary_crossentropy(target, output, from_logits=False):
 
 
 def moments(x, axes, keepdims=False):
-    return tf.nn.moments(x, axes, keepdims=keepdims)
+    # The dynamic range of fp16 is too limited to support the collection of
+    # sufficient statistics. As a workaround we simply perform the operations
+    # on 32-bit floats before converting the mean and variance back to fp16
+    need_cast = False
+    ori_dtype = standardize_dtype(x.dtype)
+    if ori_dtype == "float16":
+        need_cast = True
+        x = cast(x, "float32")
+
+    # Compute true mean while keeping the dims for proper broadcasting
+    mean = tf.reduce_mean(x, axes, keepdims=True)
+
+    # Sample variance, not unbiased variance
+    # Note: stop_gradient does not change the gradient that gets
+    #       backpropagated to the mean from the variance calculation,
+    #       because that gradient is zero
+    variance = tf.reduce_mean(
+        tf.square(x), axis=axes, keepdims=True
+    ) - tf.square(tf.stop_gradient(mean))
+
+    if not keepdims:
+        mean = tf.squeeze(mean, axes)
+        variance = tf.squeeze(variance, axes)
+    if need_cast:
+        mean = cast(mean, ori_dtype)
+        variance = cast(variance, ori_dtype)
+    return mean, variance

--- a/keras_core/backend/tensorflow/nn.py
+++ b/keras_core/backend/tensorflow/nn.py
@@ -646,3 +646,7 @@ def binary_crossentropy(target, output, from_logits=False):
     bce = target * tf.math.log(output)
     bce += (1 - target) * tf.math.log(1 - output)
     return -bce
+
+
+def moments(x, axes, keepdims=False):
+    return tf.nn.moments(x, axes, keepdims=keepdims)

--- a/keras_core/backend/torch/nn.py
+++ b/keras_core/backend/torch/nn.py
@@ -631,10 +631,8 @@ def moments(x, axes, keepdims=False):
     #       backpropagated to the mean from the variance calculation,
     #       because that gradient is zero
     variance = torch.mean(
-        torch.square(x - mean.detach()),
-        dim=axes,
-        keepdim=True,
-    )
+        torch.square(x), dim=axes, keepdim=True
+    ) - torch.square(mean.detach())
 
     if not keepdims:
         mean = torch.squeeze(mean, axes)

--- a/keras_core/layers/normalization/batch_normalization.py
+++ b/keras_core/layers/normalization/batch_normalization.py
@@ -198,10 +198,9 @@ class BatchNormalization(Layer):
         broadcast_shape = [1] * len(inputs.shape)
         broadcast_shape[self.axis] = inputs.shape[self.axis]
         if training and self.trainable:
-            mean = ops.mean(inputs, axis=self._reduction_axes, keepdims=True)
-            variance = ops.mean(
-                ops.square(inputs), axis=self._reduction_axes, keepdims=True
-            ) - ops.square(mean)
+            mean, variance = ops.moments(
+                inputs, axes=self._reduction_axes, keepdims=True
+            )
             outputs = (inputs - mean) / ops.sqrt(variance + self.epsilon)
             mean = ops.squeeze(mean, self._reduction_axes)
             variance = ops.squeeze(variance, self._reduction_axes)

--- a/keras_core/layers/normalization/group_normalization.py
+++ b/keras_core/layers/normalization/group_normalization.py
@@ -171,11 +171,8 @@ class GroupNormalization(Layer):
         axis = -2 if self.axis == -1 else self.axis - 1
         group_reduction_axes.pop(axis)
 
-        mean = ops.mean(
-            reshaped_inputs, axis=group_reduction_axes, keepdims=True
-        )
-        variance = ops.var(
-            reshaped_inputs, axis=group_reduction_axes, keepdims=True
+        mean, variance = ops.moments(
+            reshaped_inputs, axes=group_reduction_axes, keepdims=True
         )
         gamma, beta = self._get_reshaped_weights(input_shape)
 

--- a/keras_core/ops/nn.py
+++ b/keras_core/ops/nn.py
@@ -10,6 +10,7 @@ from keras_core.backend.common.backend_utils import (
 )
 from keras_core.ops import operation_utils
 from keras_core.ops.operation import Operation
+from keras_core.ops.operation_utils import reduce_shape
 
 
 class Relu(Operation):
@@ -1563,3 +1564,61 @@ def multi_hot(inputs, num_tokens, axis=-1, dtype=None):
         return MultiHot(num_tokens, axis, dtype).symbolic_call(inputs)
 
     return backend.nn.multi_hot(inputs, num_tokens, axis, dtype)
+
+
+class Moments(Operation):
+    def __init__(self, axes, keepdims=False, name=None):
+        super().__init__(name)
+        self.axes = axes
+        self.keepdims = keepdims
+
+    def call(self, x):
+        return backend.nn.moments(x, axes=self.axes, keepdims=self.keepdims)
+
+    def compute_output_spec(self, x):
+        return (
+            KerasTensor(
+                reduce_shape(x.shape, axis=self.axes, keepdims=self.keepdims),
+                dtype=x.dtype,
+            ),
+            KerasTensor(
+                reduce_shape(x.shape, axis=self.axes, keepdims=self.keepdims),
+                dtype=x.dtype,
+            ),
+        )
+
+
+@keras_core_export(
+    [
+        "keras_core.ops.moments",
+        "keras_core.ops.nn.moments",
+    ]
+)
+def moments(x, axes, keepdims=False):
+    """Calculates the mean and variance of `x`.
+
+    The mean and variance are calculated by aggregating the contents of `x`
+    across `axes`. If `x` is 1-D and `axes = [0]` this is just the mean and
+    variance of a vector.
+
+    Args:
+        x: Input tensor.
+        axes: A list of axes which to compute mean and variance.
+        keepdims: If this is set to `True`, the axes which are reduced are left
+            in the result as dimensions with size one.
+
+    Returns:
+        A tuple containing two tensors - mean and variance.
+
+
+    Example:
+
+    >>> x = keras_core.ops.convert_to_tensor([0, 1, 2, 3, 100], dtype="float32")
+    >>> keras_core.ops.moments(x, axes=[0])
+    (array(21.2, dtype=float32), array(1553.3601, dtype=float32))
+
+    """
+    if any_symbolic_tensors((x,)):
+        return Moments(axes, keepdims).symbolic_call(x)
+
+    return backend.nn.moments(x, axes, keepdims)

--- a/keras_core/ops/nn.py
+++ b/keras_core/ops/nn.py
@@ -1552,7 +1552,6 @@ def multi_hot(inputs, num_tokens, axis=-1, dtype=None):
     Returns:
         Tensor: The multi-hot encoded tensor.
 
-
     Example:
 
     >>> data = keras_core.ops.convert_to_tensor([0, 4])
@@ -1609,7 +1608,6 @@ def moments(x, axes, keepdims=False):
 
     Returns:
         A tuple containing two tensors - mean and variance.
-
 
     Example:
 

--- a/keras_core/ops/nn_test.py
+++ b/keras_core/ops/nn_test.py
@@ -298,6 +298,20 @@ class NNOpsDynamicShapeTest(testing.TestCase, parameterized.TestCase):
         out = knn.one_hot(x, 5, axis=0, dtype=dtype)
         self.assertEqual(backend.standardize_dtype(out.dtype), dtype)
 
+    def test_moments(self):
+        x = KerasTensor([None, 3, 4])
+        self.assertEqual(knn.moments(x, axes=[0])[0].shape, (3, 4))
+        self.assertEqual(knn.moments(x, axes=[0, 1])[0].shape, (4,))
+        self.assertEqual(
+            knn.moments(x, axes=[0, 1], keepdims=True)[0].shape, (1, 1, 4)
+        )
+
+        self.assertEqual(knn.moments(x, axes=[1])[0].shape, (None, 4))
+        self.assertEqual(knn.moments(x, axes=[1, 2])[0].shape, (None,))
+        self.assertEqual(
+            knn.moments(x, axes=[1, 2], keepdims=True)[0].shape, (None, 1, 1)
+        )
+
 
 class NNOpsStaticShapeTest(testing.TestCase):
     def test_relu(self):
@@ -589,6 +603,14 @@ class NNOpsStaticShapeTest(testing.TestCase):
         x2 = KerasTensor([2, 3, 4])
         self.assertEqual(
             knn.sparse_categorical_crossentropy(x1, x2).shape, (2, 3)
+        )
+
+    def test_moments(self):
+        x = KerasTensor([2, 3, 4])
+        self.assertEqual(knn.moments(x, axes=[0])[0].shape, (3, 4))
+        self.assertEqual(knn.moments(x, axes=[0, 1])[0].shape, (4,))
+        self.assertEqual(
+            knn.moments(x, axes=[0, 1], keepdims=True)[0].shape, (1, 1, 4)
         )
 
 
@@ -1156,3 +1178,38 @@ class NNOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         indices_1d = np.array([0, -1, -1, 3])
         expected_output_1d = np.array([1, 0, 0, 1])
         self.assertAllClose(knn.multi_hot(indices_1d, 4), expected_output_1d)
+
+    def test_moments(self):
+        # Test 1D moments
+        x = np.array([0, 1, 2, 3, 4, 100, -200]).astype(np.float32)
+        mean, variance = knn.moments(x, axes=[0])
+        self.assertAllClose(mean, np.mean(x))
+        self.assertAllClose(variance, np.var(x))
+
+        # Test batch statics for 4D moments (batch, height, width, channels)
+        x = np.random.uniform(size=(2, 28, 28, 3))
+        mean, variance = knn.moments(x, axes=[0])
+        self.assertAllClose(mean, np.mean(x, axis=0))
+        self.assertAllClose(variance, np.var(x, axis=0))
+
+        # Test global statics for 4D moments (batch, height, width, channels)
+        x = np.random.uniform(size=(2, 28, 28, 3))
+        mean, variance = knn.moments(x, axes=[0, 1, 2])
+        self.assertAllClose(mean, np.mean(x, axis=(0, 1, 2)))
+        self.assertAllClose(variance, np.var(x, axis=(0, 1, 2)))
+
+        # Test keepdims
+        x = np.random.uniform(size=(2, 28, 28, 3))
+        mean, variance = knn.moments(x, axes=[0, 1, 2], keepdims=True)
+        self.assertAllClose(mean, np.mean(x, axis=(0, 1, 2), keepdims=True))
+        self.assertAllClose(variance, np.var(x, axis=(0, 1, 2), keepdims=True))
+
+        # Test float16
+        x = np.random.uniform(size=(2, 28, 28, 3)).astype(np.float16)
+        mean, variance = knn.moments(x, axes=[0])
+        expected_mean = np.mean(x.astype(np.float32), axis=0).astype(np.float16)
+        expected_variance = np.var(x.astype(np.float32), axis=0).astype(
+            np.float16
+        )
+        self.assertAllClose(mean, expected_mean)
+        self.assertAllClose(variance, expected_variance)


### PR DESCRIPTION
EDITED:
This PR adds `ops.nn.moments` and improves some normalization layers by fast mean and variance computation.
This PR also addresses the overflow & underflow issue when the input tensor is float16.

There are two approaches to compute variance:
- $Var = E[|x - E[x]|^2])$ (stable but slower)
- $Var = E[|x|^2] - |E[x]|^2$ (fast but unstable)

|backend|layer|manual implementation (before this PR)|`ops.nn.moments` (fast but unstable, this PR)|`ops.nn.moments` (stable but slower)|
|-|-|-|-|-|
|tensorflow|BatchNormalization|58ms|58ms|69ms|
|jax|BatchNormalization|63ms|63ms|75ms|
|torch|BatchNormalization|73ms|72ms|74ms|
|tensorflow|GroupNormalization|89ms|61ms|73ms|
|jax|GroupNormalization|96ms|72ms|83ms|
|torch|GroupNormalization|72ms|74ms|76ms|
|tensorflow|LayerNormalization|52ms|47ms|48ms|
|jax|LayerNormalization|68ms|59ms|60ms|
|torch|LayerNormalization|88ms|90ms|91ms|

References:
- tensorflow: `tf.nn.moments` using stable but slower version ([link](https://github.com/tensorflow/tensorflow/blob/3d1802023778a164d35c79536990b35b701e8018/tensorflow/python/ops/nn_impl.py#L1264C5-L1268C25))
- flax: defaults to `use_fast_variance` ([link](https://github.com/google/flax/blob/ca3ea06f78834137dfb49dc6c1a0c26fb962003a/flax/linen/normalization.py#L108-L120))
- torch: should be stable but slower version ([link](https://github.com/pytorch/pytorch/blob/48e6ffbe308e915b67c5b4f9532f794d6706c903/aten/src/ATen/native/cpu/batch_norm_kernel.cpp#L200-L209))