### PR TITLE
Don't convert int array input to floatx

### DIFF
--- a/keras_core/trainers/data_adapters/array_data_adapter.py
+++ b/keras_core/trainers/data_adapters/array_data_adapter.py
@@ -276,7 +276,7 @@ def can_convert_arrays(arrays):
     )
 
 
-def convert_to_arrays(arrays, dtype=None):
+def convert_to_arrays(arrays):
     """Process array-like inputs.
 
     This function:
@@ -291,26 +291,31 @@ def convert_to_arrays(arrays, dtype=None):
     Returns:
         Structure of NumPy `ndarray`s.
     """
-    dtype = dtype or backend.floatx()
 
     def convert_single_array(x):
         if x is None:
             return x
         if pandas is not None:
             if isinstance(x, pandas.Series):
-                x = np.expand_dims(x.to_numpy(dtype=dtype), axis=-1)
+                x = np.expand_dims(x.to_numpy(), axis=-1)
             elif isinstance(x, pandas.DataFrame):
-                x = x.to_numpy(dtype=dtype)
+                x = x.to_numpy()
         if is_tf_ragged_tensor(x):
             from keras_core.utils.module_utils import tensorflow as tf
 
-            return tf.cast(x, dtype=dtype)
+            # Convert floats to floatx.
+            if (
+                backend.is_float_dtype(x.dtype)
+                and not backend.standardize_dtype(x.dtype) == backend.floatx()
+            ):
+                return tf.cast(x, backend.floatx())
+            return x
         if not isinstance(x, np.ndarray):
             # Using `__array__` should handle `tf.Tensor`, `jax.np.ndarray`,
             # `torch.Tensor`, as well as any other tensor-like object that has
             # added numpy support.
             if hasattr(x, "__array__"):
-                x = backend.convert_to_numpy(x).astype(dtype)
+                x = backend.convert_to_numpy(x)
             else:
                 raise ValueError(
                     "Expected a NumPy array, tf.Tensor, tf.RaggedTensor, "
@@ -320,8 +325,12 @@ def convert_to_arrays(arrays, dtype=None):
                 )
         if x.dtype == object:
             return x
-        if not x.dtype == dtype:
-            x = x.astype(dtype)
+        # Convert floats to floatx.
+        if (
+            backend.is_float_dtype(x.dtype)
+            and not backend.standardize_dtype(x.dtype) == backend.floatx()
+        ):
+            x = x.astype(backend.floatx())
         return x
 
     arrays = tree.map_structure(convert_single_array, arrays)

--- a/keras_core/trainers/data_adapters/array_data_adapter.py
+++ b/keras_core/trainers/data_adapters/array_data_adapter.py
@@ -308,7 +308,7 @@ def convert_to_arrays(arrays):
                 backend.is_float_dtype(x.dtype)
                 and not backend.standardize_dtype(x.dtype) == backend.floatx()
             ):
-                return tf.cast(x, backend.floatx())
+                x = tf.cast(x, backend.floatx())
             return x
         if not isinstance(x, np.ndarray):
             # Using `__array__` should handle `tf.Tensor`, `jax.np.ndarray`,

--- a/keras_core/trainers/data_adapters/array_data_adapter_test.py
+++ b/keras_core/trainers/data_adapters/array_data_adapter_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
@@ -203,3 +204,53 @@ class TestArrayDataAdapter(testing.TestCase, parameterized.TestCase):
         (x1, x2), y = next(adapter.get_numpy_iterator())
         self.assertEqual(x1.dtype, backend.floatx())
         self.assertEqual(x2.dtype, "int32")
+
+    def test_pandas_series(self):
+        x = pandas.Series(np.ones((10,)))
+        y = np.ones((10,))
+
+        adapter = array_data_adapter.ArrayDataAdapter(
+            x,
+            y=y,
+            sample_weight=None,
+            batch_size=4,
+            steps=None,
+            shuffle=False,
+        )
+
+        self.assertEqual(adapter.num_batches, 3)
+        self.assertEqual(adapter.batch_size, 4)
+        self.assertEqual(adapter.has_partial_batch, True)
+        self.assertEqual(adapter.partial_batch_size, 2)
+
+        x, y = next(adapter.get_numpy_iterator())
+        self.assertEqual(x.dtype, backend.floatx())
+        self.assertIsInstance(x, np.ndarray)
+        self.assertEqual(x.shape, (4, 1))
+
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow",
+        reason="Only tensorflow supports raggeds",
+    )
+    def test_tf_ragged(self):
+        x = tf.ragged.constant([[1, 2], [1, 2, 3], [1, 2], [1], []], "float64")
+        y = np.ones((5,))
+
+        adapter = array_data_adapter.ArrayDataAdapter(
+            x,
+            y=y,
+            sample_weight=None,
+            batch_size=2,
+            steps=None,
+            shuffle=False,
+        )
+
+        self.assertEqual(adapter.num_batches, 3)
+        self.assertEqual(adapter.batch_size, 2)
+        self.assertEqual(adapter.has_partial_batch, True)
+        self.assertEqual(adapter.partial_batch_size, 1)
+
+        x, y = next(adapter.get_numpy_iterator())
+        self.assertEqual(x.dtype, backend.floatx())
+        self.assertIsInstance(x, tf.RaggedTensor)
+        self.assertEqual(x.shape, (2, None))

--- a/keras_core/trainers/data_adapters/data_adapter_utils.py
+++ b/keras_core/trainers/data_adapters/data_adapter_utils.py
@@ -205,7 +205,7 @@ def train_validation_split(arrays, validation_split):
 
 
 def class_weight_to_sample_weights(y, class_weight):
-    sample_weight = np.ones(shape=(y.shape[0],), dtype=y.dtype)
+    sample_weight = np.ones(shape=(y.shape[0],), dtype=backend.floatx())
     if len(y.shape) > 1:
         if y.shape[-1] != 1:
             y = np.argmax(y, axis=-1)


### PR DESCRIPTION
In tf.keras, int array input is not converted to floatx. In keras-core, all array input is converted to flaotx.

This feels both like a regression compatibility wise, and quite surprising generally for subclass models. There are plenty of valid reasons to pass some int input to a model.

https://colab.research.google.com/gist/mattdangerw/2a030f1b14ec4fa3347711e84541e6d7/array-conversion-discrepency.ipynb