### PR TITLE
`run_layer_test` also runs symbolic calls when `input_data` is provided.

### DIFF
--- a/keras_core/layers/normalization/spectral_normalization_test.py
+++ b/keras_core/layers/normalization/spectral_normalization_test.py
@@ -12,11 +12,10 @@ class SpectralNormalizationTest(testing.TestCase):
         self.run_layer_test(
             layers.SpectralNormalization,
             init_kwargs={"layer": layers.Dense(2)},
-            input_shape=None,
             input_data=np.random.uniform(size=(10, 3, 4)),
             expected_output_shape=(10, 3, 2),
             expected_num_trainable_weights=2,
-            expected_num_non_trainable_weights=2,
+            expected_num_non_trainable_weights=1,
             expected_num_seed_generators=0,
             expected_num_losses=0,
             supports_masking=False,

--- a/keras_core/layers/preprocessing/hashed_crossing.py
+++ b/keras_core/layers/preprocessing/hashed_crossing.py
@@ -131,9 +131,9 @@ class HashedCrossing(Layer):
             return input_shape[0]
 
         if self.output_mode == "one_hot" and input_shape[0][-1] != 1:
-            output_shape = tuple(input_shape[0]) + (self.num_bins,)
-        output_shape = tuple(input_shape[0])[:-1] + (self.num_bins,)
-        return output_shape
+            return tuple(input_shape[0]) + (self.num_bins,)
+
+        return tuple(input_shape[0])[:-1] + (self.num_bins,)
 
     def call(self, inputs):
         self._check_at_least_two_inputs(inputs)

--- a/keras_core/layers/preprocessing/hashed_crossing_test.py
+++ b/keras_core/layers/preprocessing/hashed_crossing_test.py
@@ -15,7 +15,7 @@ class HashedCrossingTest(testing.TestCase):
                 "num_bins": 3,
                 "output_mode": "int",
             },
-            input_data=([1, 2], [4, 5]),
+            input_data=(np.array([1, 2]), np.array([4, 5])),
             expected_output_shape=(2,),
             expected_num_trainable_weights=0,
             expected_num_non_trainable_weights=0,
@@ -29,7 +29,7 @@ class HashedCrossingTest(testing.TestCase):
         self.run_layer_test(
             layers.HashedCrossing,
             init_kwargs={"num_bins": 4, "output_mode": "one_hot"},
-            input_data=([1, 2], [4, 5]),
+            input_data=(np.array([1, 2]), np.array([4, 5])),
             expected_output_shape=(2, 4),
             expected_num_trainable_weights=0,
             expected_num_non_trainable_weights=0,


### PR DESCRIPTION
This uncovered an issue in one layer and an issue in a test.