### PR TITLE
Fix `stop_gradient` in np

### DIFF
--- a/keras_core/backend/numpy/core.py
+++ b/keras_core/backend/numpy/core.py
@@ -212,7 +212,7 @@ def fori_loop(lower, upper, body_fun, init_val):
 
 
 def stop_gradient(x):
-    pass
+    return x
 
 
 def unstack(x, num=None, axis=0):

--- a/keras_core/ops/core_test.py
+++ b/keras_core/ops/core_test.py
@@ -264,6 +264,11 @@ class CoreOpsCorrectnessTest(testing.TestCase):
         self.assertEqual(model.layers[0].w.numpy(), 0.0)
         self.assertNotEqual(model.layers[0].b.numpy(), 0.0)
 
+    def test_stop_gradient_return(self):
+        x = ops.random.uniform(shape=(2, 4), dtype="float32")
+        y = ops.stop_gradient(x)
+        self.assertAllClose(x, y)
+
     def test_shape(self):
         x = np.ones((2, 3, 7, 1))
         self.assertAllEqual(core.shape(x), (2, 3, 7, 1))


### PR DESCRIPTION
We should return `x` instead of `None` in numpy's `stop_gradient`.

A unit test has been added to verify the return value.
