### PR TITLE
Set actions.yml to run with read-only permissions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   release:
     types: [created]
+
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras-core/issues/881.

This PR ensures all the jobs in the `actions.yml` workflow run with read-only permissions instead of the default `write-all`.