### PR TITLE
Don't show optimizer params if not optimizer or not built

### DIFF
--- a/keras_core/utils/summary_utils.py
+++ b/keras_core/utils/summary_utils.py
@@ -311,9 +311,11 @@ def print_summary(
     if model.compiled and model.optimizer and model.optimizer.built:
         optimizer_weight_count = count_params(model.optimizer.variables)
         optimizer_memory_size = weight_memory_size(model.optimizer.variables)
+        optimizer_built = True
     else:
         optimizer_weight_count = 0
         optimizer_memory_size = 0
+        optimizer_built = False
 
     total_count = trainable_count + non_trainable_count + optimizer_weight_count
     total_memory_size = (
@@ -349,11 +351,12 @@ def print_summary(
         + highlight_number(f"{non_trainable_count:,}")
         + f" ({readable_memory_size(non_trainable_memory_size)})"
     )
-    console.print(
-        bold_text(" Optimizer params: ")
-        + highlight_number(f"{optimizer_weight_count:,}")
-        + f" ({readable_memory_size(optimizer_memory_size)})"
-    )
+    if optimizer_built:
+        console.print(
+            bold_text(" Optimizer params: ")
+            + highlight_number(f"{optimizer_weight_count:,}")
+            + f" ({readable_memory_size(optimizer_memory_size)})"
+        )
 
     # Output captured summary for non-interactive logging.
     if print_fn:

--- a/keras_core/utils/summary_utils_test.py
+++ b/keras_core/utils/summary_utils_test.py
@@ -37,5 +37,6 @@ class SummaryUtilsTest(testing.TestCase, parameterized.TestCase):
                 self.assertIn("Total params: 9", summary_content)
                 self.assertIn("Trainable params: 9", summary_content)
                 self.assertIn("Non-trainable params: 0", summary_content)
+                self.assertNotIn("Optimizer params", summary_content)
         except ImportError:
             pass


### PR DESCRIPTION
Most people will call `summary()` before `fit()`. Doing so will usually mean the optimizer would show up as 0 parameters, which is misleading.