### PR TITLE
Export dtype utils in `keras_core.backend`

### DIFF
--- a/keras_core/backend/common/variables.py
+++ b/keras_core/backend/common/variables.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from keras_core.api_export import keras_core_export
 from keras_core.backend import config
 from keras_core.backend.common import global_state
 from keras_core.backend.common.name_scope import current_path
@@ -398,6 +399,7 @@ PYTHON_DTYPES_MAP = {
 }
 
 
+@keras_core_export("keras_core.backend.standardize_dtype")
 def standardize_dtype(dtype):
     if dtype is None:
         return config.floatx()
@@ -454,11 +456,13 @@ def shape_equal(a, b):
     return True
 
 
+@keras_core_export("keras_core.backend.is_float_dtype")
 def is_float_dtype(dtype):
     dtype = standardize_dtype(dtype)
     return dtype.startswith("float") or dtype.startswith("bfloat")
 
 
+@keras_core_export("keras_core.backend.is_int_dtype")
 def is_int_dtype(dtype):
     dtype = standardize_dtype(dtype)
     return dtype.startswith("int") or dtype.startswith("uint")


### PR DESCRIPTION
Making multi backend dtype comparisons for code based on keras-core is tricky. Torch has dtype classes such that
`torch_tensor.dtype is string_dtype` will always be false.

We use `standardize_dtype` extensively in our own code and should expose it to clients. `is_float_dtype` and `is_int_dtype` we can include as useful helpers.