### PR TITLE
Separate the metrics variables from non-trainable variables.

### DIFF
--- a/keras_core/layers/layer.py
+++ b/keras_core/layers/layer.py
@@ -514,10 +514,13 @@ class Layer(BackendLayer, Operation):
 
     @property
     def variables(self):
-        """List of all layer state, including metric variables and random seeds.
+        """List of all layer state, including random seeds.
 
         This extends `layer.weights` to include all state used by the layer
-        including state for metrics and `SeedGenerator`s.
+        including `SeedGenerator`s.
+
+        Note that metrics variables are not included here, use
+        `metrics_variables` to visit all the metric variables.
         """
         # Return all `Variables` associate with the layer including metrics
         # and random seeds. Also deduplicate them.
@@ -527,8 +530,6 @@ class Layer(BackendLayer, Operation):
             if id(v) not in seen_ids:
                 variables.append(v)
                 seen_ids.add(id(v))
-        for m in self._metrics:
-            variables.extend(m.variables)
         for sg in self._seed_generators:
             variables.append(sg.state)
         for layer in self._layers:
@@ -601,6 +602,17 @@ class Layer(BackendLayer, Operation):
         if not self.trainable:
             return self.weights
         return [v for v in self.weights if not v.trainable]
+
+    @property
+    def metrics_variables(self):
+        """List of all metric variables."""
+        vars = []
+        for metric in self._metrics:
+            vars.extend(metric.variables)
+        for layer in self._layers:
+            for metric in layer._metrics:
+                vars.extend(metric.variables)
+        return vars
 
     def get_weights(self):
         """Return the values of `layer.weights` as a list of NumPy arrays."""

--- a/keras_core/trainers/trainer_test.py
+++ b/keras_core/trainers/trainer_test.py
@@ -29,7 +29,7 @@ else:
 
 
 # A model is just a layer mixed in with a Trainer.
-class ExampleModel(layers.Dense, Trainer):
+class ExampleModel(Trainer, layers.Dense):
     def __init__(self, units):
         layers.Dense.__init__(
             self,
@@ -40,7 +40,7 @@ class ExampleModel(layers.Dense, Trainer):
         Trainer.__init__(self)
 
 
-class StructModel(layers.Layer, Trainer):
+class StructModel(Trainer, layers.Layer):
     def __init__(self, units):
         layers.Layer.__init__(self)
         Trainer.__init__(self)
@@ -62,7 +62,7 @@ class StructModel(layers.Layer, Trainer):
         }
 
 
-class ListModel(layers.Layer, Trainer):
+class ListModel(Trainer, layers.Layer):
     def __init__(self, units):
         layers.Layer.__init__(self)
         Trainer.__init__(self)
@@ -82,7 +82,7 @@ class ListModel(layers.Layer, Trainer):
         return self.dense_1(x[0]) + self.dense_2(x[1])
 
 
-class TrainingTestingLayer(layers.Layer, Trainer):
+class TrainingTestingLayer(Trainer, layers.Layer):
     def __init__(self, **kwargs):
         layers.Layer.__init__(self, **kwargs)
         Trainer.__init__(self)
@@ -362,7 +362,7 @@ class TestTrainer(testing.TestCase, parameterized.TestCase):
         reason="half precision unsupported on torch CPU.",
     )
     def test_loss_scaling_prevents_underflow(self):
-        class DeepModel(layers.Layer, Trainer):
+        class DeepModel(Trainer, layers.Layer):
             def __init__(self):
                 layers.Layer.__init__(self, dtype="mixed_float16")
                 Trainer.__init__(self)

--- a/keras_core/trainers/trainer_test.py
+++ b/keras_core/trainers/trainer_test.py
@@ -96,7 +96,7 @@ class TrainingTestingLayer(layers.Layer, Trainer):
 class TestTrainer(testing.TestCase, parameterized.TestCase):
     @pytest.mark.requires_trainable_backend
     def test_metric_tracking(self):
-        class ModelWithMetric(layers.Dense, Trainer):
+        class ModelWithMetric(Trainer, layers.Dense):
             def __init__(self, units):
                 layers.Dense.__init__(
                     self,
@@ -132,6 +132,7 @@ class TestTrainer(testing.TestCase, parameterized.TestCase):
 
         # And those weights are tracked at the model level
         self.assertEqual(len(model.metrics_variables), 6)
+        self.assertLen(model.non_trainable_variables, 0)
 
         # Models with only weighted_metrics should have the same 3 metrics
         model_weighted = ModelWithMetric(units=3)


### PR DESCRIPTION
As discussed in https://github.com/keras-team/keras-core/pull/897, we separate the metrics related variables from non-trainable variables, so that we can properly leverage the jax memory donation.

This will also allow us to skip the saving for metrics variables during checkpoint/savemodel