### PR TITLE
Make jax2tf import conditional

### DIFF
--- a/keras_core/export/export_lib.py
+++ b/keras_core/export/export_lib.py
@@ -1,7 +1,5 @@
 """Library for exporting inference-only Keras models/layers."""
 
-from jax.experimental import jax2tf
-
 from keras_core import backend
 from keras_core.api_export import keras_core_export
 from keras_core.layers import Layer
@@ -441,6 +439,8 @@ class ExportArchive:
                         self._tf_trackable._misc_assets.append(trackable)
 
     def _convert_jax2tf_function(self, fn, input_signature):
+        from jax.experimental import jax2tf
+
         shapes = []
         for spec in input_signature:
             shapes.append(self._spec_to_poly_shape(spec))


### PR DESCRIPTION
@mattdangerw @fchollet 
This prevents a hard dependency on JAX by moving the import for JAX2TF into the function where it is used.
Thanks!

