### PR TITLE
[GHA] fix several codecov issues 

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -61,6 +61,7 @@ jobs:
           env_vars: PYTHON,KERAS_BACKEND
           flags: keras_core.applications,keras_core.applications-${{ matrix.backend }}
           files: apps-coverage.xml
+          fail_ci_if_error: true
       - name: Test with pytest
         run: |
           pytest keras_core --ignore keras_core/applications --cov=keras_core
@@ -71,6 +72,7 @@ jobs:
           env_vars: PYTHON,KERAS_BACKEND
           flags: keras_core,keras_core-${{ matrix.backend }}
           files: core-coverage.xml
+          fail_ci_if_error: true
 
   format:
     name: Check the code format

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -59,7 +59,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           env_vars: PYTHON,KERAS_BACKEND
-          flags: keras_core.applications
+          flags: keras_core.applications,keras_core.applications-${{ matrix.backend }}
           files: apps-coverage.xml
       - name: Test with pytest
         run: |
@@ -69,7 +69,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           env_vars: PYTHON,KERAS_BACKEND
-          flags: keras_core
+          flags: keras_core,keras_core-${{ matrix.backend }}
           files: core-coverage.xml
 
   format:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,39 @@ known_first_party = ["keras_core", "tests"]
 default_section = "THIRDPARTY"
 line_length = 80
 extend_skip_glob=["examples/*", "guides/*"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+    "ignore::DeprecationWarning",
+    "ignore::ImportWarning",
+    "ignore::RuntimeWarning",
+    "ignore::PendingDeprecationWarning",
+    "ignore::FutureWarning",
+    "ignore::UserWarning",
+    # Ignore a spurious warning on tf-nightly related to save model changes.
+    "ignore:Custom mask layers require a config",
+]
+addopts = "-vv"
+
+# Do not run tests in the `build` folders
+norecursedirs = ["build"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "@abstract",
+    "raise NotImplementedError",
+]
+omit = [
+    "*/*_test.py",
+    "keras_core/legacy/*",
+]
+
+[tool.coverage.run]
+branch = true
+omit = [
+    "*/*_test.py",
+    "keras_core/legacy/*",
+]
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,34 +1,3 @@
-[tool:pytest]
-filterwarnings =
-    error
-    ignore::DeprecationWarning
-    ignore::ImportWarning
-    ignore::RuntimeWarning
-    ignore::PendingDeprecationWarning
-    ignore::FutureWarning
-    ignore::UserWarning
-    # Ignore a spurious warning on tf-nightly related to save model changes.
-    ignore:Custom mask layers require a config
-
-addopts=-vv
-
-# Do not run tests in the `build` folders
-norecursedirs = build
-
-[coverage:report]
-exclude_lines =
-    pragma: no cover
-    @abstract
-    raise NotImplementedError
-omit =
-    */*_test.py
-
-[coverage:run]
-omit =
-    */*_test.py
-
-branch = True
-
 [flake8]
 ignore =
     # Conflicts with black


### PR DESCRIPTION
This PR does a few things:

1. Excludes `keras_core/legacy` from coverage metrics since this module there for BC reasons
2. Adds the test backend (jax, tensorflow, torch, numpy) to flags to allow tracking coverage metrics per backend. Note that each backend's coverage will be lower than the aggregate (e.g. `keras_core` will have higher coverage than `keras_core-jax`), so this flag should be used to track trends rather than impose thresholds.
3. Moves `coverage` and `pytest` configuration from `setup.cfg` to `pyproject.toml` to keep all project configs in toml vs cfg (unfortuantely `flake8` configs need to stay in `setup.cfg` since flake8 doesn't support `pyproject.toml` yet: https://github.com/PyCQA/flake8/issues/234)
4. Adds `fail_ci_if_error: true` to codecov upload steps to fail the CI (and force the author to retry the workflow) on transient codecov upload failures of the form 
    ```
     Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found
    ```
    This happens when we hit codecov API rate limits since we don't use `CODECOV_TOKEN` (see https://github.com/codecov/codecov-action/issues/837). We could circumvent the issue by adding the token as a secret but GH secrets are not visible from forks, implying that contributors will not be able to get coverage diffs for their PRs. To allow this, the only option seems to be to hardcode the token (which seems ok since the token can be setup with limited permissions) but hardcoding tokens is just sketchy...