### PR TITLE
Update test_case.py

### DIFF
--- a/keras_core/testing/test_case.py
+++ b/keras_core/testing/test_case.py
@@ -261,10 +261,8 @@ class TestCase(unittest.TestCase):
                     self.assertIsInstance(output, list)
                     self.assertEqual(
                         len(output),
-                        len(
-                            expected_output_shape,
-                            msg="Unexpected number of outputs",
-                        ),
+                        len(expected_output_shape),
+                        msg="Unexpected number of outputs",
                     )
                     output_shape = [v.shape for v in expected_output_shape]
                     self.assertEqual(


### PR DESCRIPTION
Fixed closing brackets for assert in `run_output_asserts` in 'test_case.py'. Although this test cast is not used, just wanted to fix the type.