### PR TITLE
[*.py] Standardise docstring usage of "Default to"

### DIFF
--- a/examples/keras_io/tensorflow/nlp/end_to_end_mlm_with_bert.py
+++ b/examples/keras_io/tensorflow/nlp/end_to_end_mlm_with_bert.py
@@ -167,7 +167,7 @@ def get_vectorize_layer(texts, vocab_size, max_seq, special_tokens=["[MASK]"]):
       texts (list): List of string i.e input texts
       vocab_size (int): vocab size
       max_seq (int): Maximum sequence lenght.
-      special_tokens (list, optional): List of special tokens. Defaults to ['[MASK]'].
+      special_tokens (list, optional): List of special tokens. Defaults to `['[MASK]']`.
 
     Returns:
         layers.Layer: Return TextVectorization Keras Layer

--- a/examples/keras_io/tensorflow/vision/shiftvit.py
+++ b/examples/keras_io/tensorflow/vision/shiftvit.py
@@ -315,9 +315,9 @@ class ShiftViTBlock(layers.Layer):
     """A unit ShiftViT Block
 
     Args:
-        shift_pixel (int): The number of pixels to shift. Default to 1.
+        shift_pixel (int): The number of pixels to shift. Defaults to `1`.
         mlp_expand_ratio (int): The ratio with which MLP features are
-            expanded. Default to 2.
+            expanded. Defaults to `2`.
         mlp_dropout_rate (float): The dropout rate used in MLP.
         num_div (int): The number of divisions of the feature map's channel.
             Totally, 4/num_div of channels will be shifted. Defaults to 12.
@@ -493,10 +493,10 @@ class StackedShiftBlocks(layers.Layer):
         stochastic_depth_rate (float): The maximum drop path rate chosen.
         is_merge (boolean): A flag that determines the use of the Patch Merge
             layer after the shift vit blocks.
-        num_div (int): The division of channels of the feature map. Defaults to 12.
-        shift_pixel (int): The number of pixels to shift. Defaults to 1.
+        num_div (int): The division of channels of the feature map. Defaults to `12`.
+        shift_pixel (int): The number of pixels to shift. Defaults to `1`.
         mlp_expand_ratio (int): The ratio with which the initial dense layer of
-            the MLP is expanded Defaults to 2.
+            the MLP is expanded Defaults to `2`.
     """
 
     def __init__(
@@ -578,10 +578,10 @@ class ShiftViTModel(keras.Model):
         mlp_dropout_rate (float): The dropout rate used in the MLP block.
         stochastic_depth_rate (float): The maximum drop rate probability.
         num_div (int): The number of divisions of the channesl of the feature
-            map. Defaults to 12.
-        shift_pixel (int): The number of pixel to shift. Default to 1.
+            map. Defaults to `12`.
+        shift_pixel (int): The number of pixel to shift. Defaults to `1`.
         mlp_expand_ratio (int): The ratio with which the initial mlp dense layer
-            is expanded to. Defaults to 2.
+            is expanded to. Defaults to `2`.
     """
 
     def __init__(

--- a/keras_core/applications/efficientnet.py
+++ b/keras_core/applications/efficientnet.py
@@ -192,7 +192,7 @@ Args:
     classifier_activation: A `str` or callable. The activation function to use
         on the "top" layer. Ignored unless `include_top=True`. Set
         `classifier_activation=None` to return the logits of the "top" layer.
-        Defaults to 'softmax'.
+        Defaults to `'softmax'`.
         When loading pretrained weights, `classifier_activation` can only
         be `None` or `"softmax"`.
 

--- a/keras_core/applications/imagenet_utils.py
+++ b/keras_core/applications/imagenet_utils.py
@@ -62,7 +62,7 @@ PREPROCESS_INPUT_MODE_DOC = """
       - torch: will scale pixels between 0 and 1 and then
           will normalize each channel with respect to the
           ImageNet dataset.
-      Defaults to "caffe".
+      Defaults to `"caffe"`.
   """
 
 PREPROCESS_INPUT_DEFAULT_ERROR_DOC = """
@@ -119,7 +119,7 @@ def decode_predictions(preds, top=5):
 
     Args:
         preds: NumPy array encoding a batch of predictions.
-        top: Integer, how many top-guesses to return. Defaults to 5.
+        top: Integer, how many top-guesses to return. Defaults to `5`.
 
     Returns:
         A list of lists of top class prediction tuples

--- a/keras_core/applications/resnet.py
+++ b/keras_core/applications/resnet.py
@@ -222,8 +222,8 @@ def residual_block_v1(
     Args:
         x: Input tensor.
         filters: No of filters in the bottleneck layer.
-        kernel_size: Kernel size of the bottleneck layer. Defaults to 3
-        stride: Stride of the first layer. Defaults to 1
+        kernel_size: Kernel size of the bottleneck layer. Defaults to `3`.
+        stride: Stride of the first layer. Defaults to `1`.
         conv_shortcut: Use convolution shortcut if `True`, otherwise
             use identity shortcut. Defaults to `True`
         name(optional): Name of the block
@@ -278,7 +278,7 @@ def stack_residual_blocks_v1(x, filters, blocks, stride1=2, name=None):
         x: Input tensor.
         filters: Number of filters in the bottleneck layer in a block.
         blocks: Number of blocks in the stacked blocks.
-        stride1: Stride of the first layer in the first block. Defaults to 2.
+        stride1: Stride of the first layer in the first block. Defaults to `2`.
         name: Stack label.
 
     Returns:
@@ -301,8 +301,8 @@ def residual_block_v2(
     Args:
         x: Input tensor.
         filters: No of filters in the bottleneck layer.
-        kernel_size: Kernel size of the bottleneck layer. Defaults to 3
-        stride: Stride of the first layer. Defaults to 1
+        kernel_size: Kernel size of the bottleneck layer. Defaults to `3`.
+        stride: Stride of the first layer. Defaults to `1`.
         conv_shortcut: Use convolution shortcut if `True`, otherwise
             use identity shortcut. Defaults to `True`
         name(optional): Name of the block
@@ -363,7 +363,7 @@ def stack_residual_blocks_v2(x, filters, blocks, stride1=2, name=None):
         x: Input tensor.
         filters: Number of filters in the bottleneck layer in a block.
         blocks: Number of blocks in the stacked blocks.
-        stride1: Stride of the first layer in the first block. Defaults to 2.
+        stride1: Stride of the first layer in the first block. Defaults to `2`.
         name: Stack label.
 
     Returns:

--- a/keras_core/backend/jax/distribution_lib.py
+++ b/keras_core/backend/jax/distribution_lib.py
@@ -14,9 +14,9 @@ def list_devices(device_type=None):
     Note that this should return the global devices in a distributed setting.
 
     Args:
-        device_type: string of `"cpu"`, `"gpu"` or `"tpu"`. Defaults to `gpu` or
-            `tpu` if available when device_type is not provided. Otherwise
-            will return the `cpu` devices.
+        device_type: string of `"cpu"`, `"gpu"` or `"tpu"`. Defaults to `"gpu"`
+            or `"tpu"` if available when device_type is not provided. Otherwise
+            will return the `"cpu"` devices.
 
     Return:
         List of devices that are available for distribute computation.

--- a/keras_core/backend/jax/distribution_lib.py
+++ b/keras_core/backend/jax/distribution_lib.py
@@ -14,7 +14,7 @@ def list_devices(device_type=None):
     Note that this should return the global devices in a distributed setting.
 
     Args:
-        device_type: string of `"cpu"`, `"gpu"` or `"tpu"`. Default to `gpu` or
+        device_type: string of `"cpu"`, `"gpu"` or `"tpu"`. Defaults to `gpu` or
             `tpu` if available when device_type is not provided. Otherwise
             will return the `cpu` devices.
 

--- a/keras_core/distribution/distribution_lib.py
+++ b/keras_core/distribution/distribution_lib.py
@@ -29,7 +29,7 @@ def list_devices(device_type=None):
 
     Args:
         device_type: string, one of `"cpu"`, `"gpu"` or `"tpu"`.
-            Default to `"gpu"` or `"tpu"` if available when
+            Defaults to `"gpu"` or `"tpu"` if available when
             `device_type` is not provided. Otherwise
             will return the `"cpu"` devices.
 
@@ -60,7 +60,7 @@ class DeviceMesh:
             the rank of the `shape`. The `axis_names` will be used to
             match/create the `TensorLayout` when distribute the data and
             variables.
-        devices: Optional list of devices. Default to all the available
+        devices: Optional list of devices. Defaults to all the available
             devices locally from `keras_core.distribution.list_devices()`.
     """
 

--- a/keras_core/layers/activations/elu.py
+++ b/keras_core/layers/activations/elu.py
@@ -15,7 +15,7 @@ class ELU(Layer):
     ```
 
     Args:
-        alpha: float, slope of negative section. Defaults to 1.0.
+        alpha: float, slope of negative section. Defaults to `1.0`.
         **kwargs: Base layer keyword arguments, such as `name` and `dtype`.
     """
 

--- a/keras_core/layers/activations/leaky_relu.py
+++ b/keras_core/layers/activations/leaky_relu.py
@@ -29,7 +29,7 @@ class LeakyReLU(Layer):
 
     Args:
         negative_slope: Float >= 0.0. Negative slope coefficient.
-          Defaults to 0.3.
+          Defaults to `0.3`.
         **kwargs: Base layer keyword arguments, such as
             `name` and `dtype`.
 

--- a/keras_core/layers/activations/relu.py
+++ b/keras_core/layers/activations/relu.py
@@ -30,9 +30,10 @@ class ReLU(Layer):
     Args:
         max_value: Float >= 0. Maximum activation value. None means unlimited.
             Defaults to `None`.
-        negative_slope: Float >= 0. Negative slope coefficient. Defaults to 0.0.
+        negative_slope: Float >= 0. Negative slope coefficient.
+            Defaults to `0.0`.
         threshold: Float >= 0. Threshold value for thresholded activation.
-            Defaults to 0.0.
+            Defaults to `0.0`.
         **kwargs: Base layer keyword arguments, such as `name` and `dtype`.
     """
 

--- a/keras_core/layers/attention/additive_attention.py
+++ b/keras_core/layers/attention/additive_attention.py
@@ -26,7 +26,7 @@ class AdditiveAttention(Attention):
         use_scale: If `True`, will create a scalar variable to scale the
             attention scores.
         dropout: Float between 0 and 1. Fraction of the units to drop for the
-            attention scores. Defaults to 0.0.
+            attention scores. Defaults to `0.0`.
 
     Call Args:
         inputs: List of the following tensors:

--- a/keras_core/layers/attention/attention.py
+++ b/keras_core/layers/attention/attention.py
@@ -26,7 +26,7 @@ class Attention(Layer):
         use_scale: If `True`, will create a scalar variable to scale the
             attention scores.
         dropout: Float between 0 and 1. Fraction of the units to drop for the
-            attention scores. Defaults to 0.0.
+            attention scores. Defaults to `0.0`.
         score_mode: Function to use to compute attention scores, one of
             `{"dot", "concat"}`. `"dot"` refers to the dot product between the
             query and key vectors. `"concat"` refers to the hyperbolic tangent

--- a/keras_core/layers/layer.py
+++ b/keras_core/layers/layer.py
@@ -80,7 +80,7 @@ class Layer(BackendLayer, Operation):
         dtype: The dtype of the layer's computations and weights. Can also be a
             `keras_core.mixed_precision.DTypePolicy`,
             which allows the computation and
-            weight dtype to differ. Default of `None` means to use
+            weight dtype to differ. Defaults to `None`. `None` means to use
             `keras_core.mixed_precision.dtype_policy()`,
             which is a `float32` policy unless set to different value
             (via `keras_core.mixed_precision.set_dtype_policy()`).

--- a/keras_core/layers/normalization/group_normalization.py
+++ b/keras_core/layers/normalization/group_normalization.py
@@ -34,7 +34,7 @@ class GroupNormalization(Layer):
         axis: Integer or List/Tuple. The axis or axes to normalize across.
             Typically, this is the features axis/axes. The left-out axes are
             typically the batch axis/axes. -1 is the last dimension in the
-            input. Defaults to -1.
+            input. Defaults to `-1`.
         epsilon: Small float added to variance to avoid dividing by zero.
             Defaults to 1e-3.
         center: If `True`, add offset of `beta` to normalized tensor.

--- a/keras_core/layers/preprocessing/integer_lookup.py
+++ b/keras_core/layers/preprocessing/integer_lookup.py
@@ -61,7 +61,7 @@ class IntegerLookup(IndexLookup):
             If this value is more than 1, OOV inputs are modulated to
             determine their OOV value.
             If this value is 0, OOV inputs will cause an error when calling
-            the layer. Defaults to 1.
+            the layer. Defaults to `1`.
         mask_token: An integer token that represents masked inputs. When
             `output_mode` is `"int"`, the token is included in vocabulary
             and mapped to index 0. In other output modes,
@@ -69,7 +69,7 @@ class IntegerLookup(IndexLookup):
             of the mask token in the input will be dropped.
             If set to None, no mask term will be added. Defaults to `None`.
         oov_token: Only used when `invert` is `True`. The token to return
-            for OOV indices. Defaults to -1.
+            for OOV indices. Defaults to `-1`.
         vocabulary: Optional. Either an array of integers or a string path to a
             text file. If passing an array, can pass a tuple, list,
             1D NumPy array, or 1D tensor containing the integer vocbulary terms.

--- a/keras_core/layers/preprocessing/string_lookup.py
+++ b/keras_core/layers/preprocessing/string_lookup.py
@@ -60,7 +60,7 @@ class StringLookup(IndexLookup):
             If this value is more than 1, OOV inputs are modulated to
             determine their OOV value.
             If this value is 0, OOV inputs will cause an error when calling
-            the layer. Defaults to 1.
+            the layer. Defaults to `1`.
         mask_token: A token that represents masked inputs. When `output_mode` is
             `"int"`, the token is included in vocabulary and mapped to index 0.
             In other output modes, the token will not appear

--- a/keras_core/layers/rnn/conv_lstm.py
+++ b/keras_core/layers/rnn/conv_lstm.py
@@ -34,7 +34,7 @@ class ConvLSTMCell(Layer, DropoutRNNCell):
             `channels_first`. When unspecified, uses
             `image_data_format` value found in your Keras config file at
             `~/.keras/keras.json` (if exists) else 'channels_last'.
-            Defaults to 'channels_last'.
+            Defaults to `'channels_last'`.
         dilation_rate: An integer or tuple/list of n integers, specifying the
             dilation rate to use for dilated convolution.
             Currently, specifying any `dilation_rate` value != 1 is
@@ -405,7 +405,7 @@ class ConvLSTM(RNN):
             When unspecified, uses
             `image_data_format` value found in your Keras config file at
             `~/.keras/keras.json` (if exists) else 'channels_last'.
-            Defaults to 'channels_last'.
+            Defaults to `'channels_last'`.
         dilation_rate: An integer or tuple/list of n integers, specifying
             the dilation rate to use for dilated convolution.
             Currently, specifying any `dilation_rate` value != 1 is

--- a/keras_core/losses/losses.py
+++ b/keras_core/losses/losses.py
@@ -165,7 +165,7 @@ class CosineSimilarity(LossFunctionWrapper):
 
     Args:
         axis: The axis along which the cosine similarity is computed
-            (the features axis). Defaults to -1.
+            (the features axis). Defaults to `-1`.
         reduction: Type of reduction to apply to the loss. In almost all cases
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
@@ -395,7 +395,7 @@ class BinaryCrossentropy(LossFunctionWrapper):
             squeezes the labels towards 0.5. Larger values of
             `label_smoothing` correspond to heavier smoothing.
         axis: The axis along which to compute crossentropy (the features axis).
-            Defaults to -1.
+            Defaults to `-1`.
         reduction: Type of reduction to apply to the loss. In almost all cases
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
@@ -676,7 +676,7 @@ class CategoricalCrossentropy(LossFunctionWrapper):
             `0.1`, use `0.1 / num_classes` for non-target labels and
             `0.9 + 0.1 / num_classes` for target labels.
         axis: The axis along which to compute crossentropy (the features
-            axis). Defaults to -1.
+            axis). Defaults to `-1`.
         reduction: Type of reduction to apply to the loss. In almost all cases
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
@@ -807,7 +807,7 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
             `0.1`, use `0.1 / num_classes` for non-target labels and
             `0.9 + 0.1 / num_classes` for target labels.
         axis: The axis along which to compute crossentropy (the features
-            axis). Defaults to -1.
+            axis). Defaults to `-1`.
         reduction: Type of reduction to apply to the loss. In almost all cases
             this should be `"sum_over_batch_size"`.
             Supported options are `"sum"`, `"sum_over_batch_size"` or `None`.
@@ -1295,7 +1295,7 @@ def cosine_similarity(y_true, y_pred, axis=-1):
     Args:
         y_true: Tensor of true targets.
         y_pred: Tensor of predicted targets.
-        axis: Axis along which to determine similarity. Defaults to -1.
+        axis: Axis along which to determine similarity. Defaults to `-1`.
 
     Returns:
         Cosine similarity tensor.
@@ -1343,7 +1343,7 @@ def huber(y_true, y_pred, delta=1.0):
         y_true: tensor of true targets.
         y_pred: tensor of predicted targets.
         delta: A float, the point where the Huber loss function changes from a
-            quadratic to linear. Defaults to 1.
+            quadratic to linear. Defaults to `1.0`.
 
     Returns:
         Tensor with one scalar loss entry per sample.
@@ -1517,7 +1517,7 @@ def categorical_crossentropy(
         label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
             example, if `0.1`, use `0.1 / num_classes` for non-target labels
             and `0.9 + 0.1 / num_classes` for target labels.
-        axis: Defaults to -1. The dimension along which the entropy is
+        axis: Defaults to `-1`. The dimension along which the entropy is
             computed.
 
     Returns:
@@ -1595,7 +1595,7 @@ def categorical_focal_crossentropy(
         label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
             example, if `0.1`, use `0.1 / num_classes` for non-target labels
             and `0.9 + 0.1 / num_classes` for target labels.
-        axis: Defaults to -1. The dimension along which the entropy is
+        axis: Defaults to `-1`. The dimension along which the entropy is
             computed.
 
     Returns:
@@ -1678,7 +1678,7 @@ def sparse_categorical_crossentropy(
             problems featuring a "void" class (commonly -1 or 255) in
             segmentation maps. By default (`ignore_class=None`), all classes are
             considered.
-        axis: Defaults to -1. The dimension along which the entropy is
+        axis: Defaults to `-1`. The dimension along which the entropy is
             computed.
 
     Returns:
@@ -1741,7 +1741,7 @@ def binary_crossentropy(
             squeezing them towards 0.5, that is,
             using `1. - 0.5 * label_smoothing` for the target class
             and `0.5 * label_smoothing` for the non-target class.
-        axis: The axis along which the mean is computed. Defaults to -1.
+        axis: The axis along which the mean is computed. Defaults to `-1`.
 
     Returns:
         Binary crossentropy loss value. shape = `[batch_size, d0, .. dN-1]`.

--- a/keras_core/metrics/accuracy_metrics.py
+++ b/keras_core/metrics/accuracy_metrics.py
@@ -326,7 +326,7 @@ class TopKCategoricalAccuracy(reduction_metrics.MeanMetricWrapper):
 
     Args:
         k: (Optional) Number of top elements to look at for computing accuracy.
-            Defaults to 5.
+            Defaults to `5`.
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 
@@ -402,7 +402,7 @@ class SparseTopKCategoricalAccuracy(reduction_metrics.MeanMetricWrapper):
 
     Args:
         k: (Optional) Number of top elements to look at for computing accuracy.
-            Defaults to 5.
+            Defaults to `5`.
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
 

--- a/keras_core/metrics/confusion_metrics.py
+++ b/keras_core/metrics/confusion_metrics.py
@@ -16,11 +16,11 @@ class _ConfusionMatrixConditionCount(Metric):
     Args:
         confusion_matrix_cond: One of `metrics_utils.ConfusionMatrix`
             conditions.
-        thresholds: (Optional) Defaults to 0.5. A float value or a python list /
-            tuple of float threshold values in `[0, 1]`. A threshold is compared
-            with prediction values to determine the truth value of predictions
-            (i.e., above the threshold is `True`, below is `False`). One metric
-            value is generated for each threshold value.
+        thresholds: (Optional) Defaults to `0.5`. A float value or a python list
+            / tuple of float threshold values in `[0, 1]`. A threshold is
+            compared with prediction values to determine the truth value of
+            predictions (i.e., above the threshold is `True`, below is `False`).
+            One metric value is generated for each threshold value.
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
     """
@@ -49,7 +49,7 @@ class _ConfusionMatrixConditionCount(Metric):
         Args:
             y_true: The ground truth values.
             y_pred: The predicted values.
-            sample_weight: Optional weighting of each example. Defaults to 1.
+            sample_weight: Optional weighting of each example. Defaults to `1`.
                 Can be a tensor whose rank is either 0, or the same rank as
                 `y_true`, and must be broadcastable to `y_true`.
         """
@@ -87,7 +87,7 @@ class FalsePositives(_ConfusionMatrixConditionCount):
     Use `sample_weight` of 0 to mask values.
 
     Args:
-        thresholds: (Optional) Defaults to 0.5. A float value, or a Python
+        thresholds: (Optional) Defaults to `0.5`. A float value, or a Python
             list/tuple of float threshold values in `[0, 1]`. A threshold is
             compared with prediction values to determine the truth value of
             predictions (i.e., above the threshold is `True`, below is `False`).
@@ -131,7 +131,7 @@ class FalseNegatives(_ConfusionMatrixConditionCount):
     Use `sample_weight` of 0 to mask values.
 
     Args:
-        thresholds: (Optional) Defaults to 0.5. A float value, or a Python
+        thresholds: (Optional) Defaults to `0.5`. A float value, or a Python
             list/tuple of float threshold values in `[0, 1]`. A threshold is
             compared with prediction values to determine the truth value of
             predictions (i.e., above the threshold is `True`, below is `False`).
@@ -175,7 +175,7 @@ class TrueNegatives(_ConfusionMatrixConditionCount):
     Use `sample_weight` of 0 to mask values.
 
     Args:
-        thresholds: (Optional) Defaults to 0.5. A float value, or a Python
+        thresholds: (Optional) Defaults to `0.5`. A float value, or a Python
             list/tuple of float threshold values in `[0, 1]`. A threshold is
             compared with prediction values to determine the truth value of
             predictions (i.e., above the threshold is `True`, below is `False`).
@@ -219,7 +219,7 @@ class TruePositives(_ConfusionMatrixConditionCount):
     Use `sample_weight` of 0 to mask values.
 
     Args:
-        thresholds: (Optional) Defaults to 0.5. A float value, or a Python
+        thresholds: (Optional) Defaults to `0.5`. A float value, or a Python
             list/tuple of float threshold values in `[0, 1]`. A threshold is
             compared with prediction values to determine the truth value of
             predictions (i.e., above the threshold is `True`, below is `False`).
@@ -368,7 +368,7 @@ class Precision(Metric):
                 `y_pred`. Will be cast to `bool`.
             y_pred: The predicted values. Each element must be in the range
                 `[0, 1]`.
-            sample_weight: Optional weighting of each example. Defaults to 1.
+            sample_weight: Optional weighting of each example. Defaults to `1`.
                 Can be a tensor whose rank is either 0, or the same rank as
                 `y_true`, and must be broadcastable to `y_true`.
         """
@@ -509,7 +509,7 @@ class Recall(Metric):
                 `y_pred`. Will be cast to `bool`.
             y_pred: The predicted values. Each element must be in the range
                 `[0, 1]`.
-            sample_weight: Optional weighting of each example. Defaults to 1.
+            sample_weight: Optional weighting of each example. Defaults to `1`.
                 Can be a tensor whose rank is either 0, or the same rank as
                 `y_true`, and must be broadcastable to `y_true`.
         """
@@ -607,7 +607,7 @@ class SensitivitySpecificityBase(Metric):
         Args:
             y_true: The ground truth values.
             y_pred: The predicted values.
-            sample_weight: Optional weighting of each example. Defaults to 1.
+            sample_weight: Optional weighting of each example. Defaults to `1`.
                 Can be a tensor whose rank is either 0, or the same rank as
                 `y_true`, and must be broadcastable to `y_true`.
         """

--- a/keras_core/metrics/f_score_metrics.py
+++ b/keras_core/metrics/f_score_metrics.py
@@ -23,7 +23,7 @@ class FBetaScore(Metric):
         average: Type of averaging to be performed across per-class results
             in the multi-class case.
             Acceptable values are `None`, `"micro"`, `"macro"` and
-            `"weighted"`. Default value is `None`.
+            `"weighted"`. Defaults to `None`.
             If `None`, no averaging is performed and `result()` will return
             the score for each class.
             If `"micro"`, compute metrics globally by counting the total
@@ -38,7 +38,7 @@ class FBetaScore(Metric):
             It can result in an score that is not between precision and recall.
         beta: Determines the weight of given to recall
             in the harmonic mean between precision and recall (see pseudocode
-            equation above). Default value is 1.
+            equation above). Defaults to `1`.
         threshold: Elements of `y_pred` greater than `threshold` are
             converted to be 1, and the rest 0. If `threshold` is
             `None`, the argmax of `y_pred` is converted to 1, and the rest to 0.
@@ -261,7 +261,7 @@ class F1Score(FBetaScore):
     Args:
         average: Type of averaging to be performed on data.
             Acceptable values are `None`, `"micro"`, `"macro"`
-            and `"weighted"`. Default value is `None`.
+            and `"weighted"`. Defaults to `None`.
             If `None`, no averaging is performed and `result()` will return
             the score for each class.
             If `"micro"`, compute metrics globally by counting the total

--- a/keras_core/metrics/probabilistic_metrics.py
+++ b/keras_core/metrics/probabilistic_metrics.py
@@ -186,7 +186,7 @@ class CategoricalCrossentropy(reduction_metrics.MeanMetricWrapper):
             on label values are relaxed. e.g. `label_smoothing=0.2` means
             that we will use a value of 0.1 for label
             "0" and 0.9 for label "1".
-        axis: (Optional) Defaults to -1.
+        axis: (Optional) Defaults to `-1`.
             The dimension along which entropy is computed.
 
     Examples:
@@ -271,7 +271,7 @@ class SparseCategoricalCrossentropy(reduction_metrics.MeanMetricWrapper):
         from_logits: (Optional) Whether output is expected
             to be a logits tensor. By default, we consider that output
             encodes a probability distribution.
-        axis: (Optional) Defaults to -1.
+        axis: (Optional) Defaults to `-1`.
             The dimension along which entropy is computed.
 
     Examples:

--- a/keras_core/metrics/regression_metrics.py
+++ b/keras_core/metrics/regression_metrics.py
@@ -259,7 +259,7 @@ class CosineSimilarity(reduction_metrics.MeanMetricWrapper):
     Args:
         name: (Optional) string name of the metric instance.
         dtype: (Optional) data type of the metric result.
-        axis: (Optional) Defaults to -1. The dimension along which the cosine
+        axis: (Optional) Defaults to `-1`. The dimension along which the cosine
             similarity is computed.
 
     Examples:
@@ -581,7 +581,7 @@ def cosine_similarity(y_true, y_pred, axis=-1):
     Args:
         y_true: Tensor of true targets.
         y_pred: Tensor of predicted targets.
-        axis: Axis along which to determine similarity. Defaults to -1.
+        axis: Axis along which to determine similarity. Defaults to `-1`.
 
     Returns:
         Cosine similarity tensor.

--- a/keras_core/ops/math.py
+++ b/keras_core/ops/math.py
@@ -40,7 +40,7 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
             segments. If not specified, it is inferred from the maximum
             value in `segment_ids`.
         sorted: A boolean indicating whether `segment_ids` is sorted.
-            Default is `False`.
+            Defaults to`False`.
 
     Returns:
         A tensor containing the sum of segments, where each element
@@ -93,7 +93,7 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
             segments. If not specified, it is inferred from the maximum
             value in `segment_ids`.
         sorted: A boolean indicating whether `segment_ids` is sorted.
-            Default is `False`.
+            Defaults to`False`.
 
     Returns:
         A tensor containing the max of segments, where each element
@@ -141,7 +141,7 @@ def top_k(x, k, sorted=True):
         x: Input tensor.
         k: An integer representing the number of top elements to retrieve.
         sorted: A boolean indicating whether to sort the output in
-        descending order. Default is `True`.
+        descending order. Defaults to`True`.
 
     Returns:
         A tuple containing two tensors. The first tensor contains the
@@ -225,9 +225,9 @@ def logsumexp(x, axis=None, keepdims=False):
         x: Input tensor.
         axis: An integer or a tuple of integers specifying the axis/axes
             along which to compute the sum. If `None`, the sum is computed
-            over all elements. Default is `None`.
+            over all elements. Defaults to`None`.
         keepdims: A boolean indicating whether to keep the dimensions of
-            the input tensor when computing the sum. Default is `False`.
+            the input tensor when computing the sum. Defaults to`False`.
 
     Returns:
         A tensor containing the logarithm of the sum of exponentials of

--- a/keras_core/ops/nn.py
+++ b/keras_core/ops/nn.py
@@ -1231,8 +1231,8 @@ def one_hot(x, num_classes, axis=-1, dtype=None):
         x : Integer tensor to be encoded. The shape can be
             arbitrary, but the dtype should be integer.
         num_classes: Number of classes for the one-hot encoding.
-        axis: Axis along which the encoding is performed. Default is
-            -1, which represents the last axis.
+        axis: Axis along which the encoding is performed. Defaults to
+            `-1`, which represents the last axis.
         dtype: (Optional) Data type of the output tensor. If not
             provided, it defaults to the default data type of the backend.
 
@@ -1302,7 +1302,7 @@ def binary_crossentropy(target, output, from_logits=False):
             probabilities.
             Set it to `True` if `output` represents logits; otherwise,
             set it to `False` if `output` represents probabilities.
-            Default is `False`.
+            Defaults to`False`.
 
     Returns:
         Integer tensor: The computed binary cross-entropy loss between
@@ -1377,10 +1377,10 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
             probabilities.
             Set it to `True` if `output` represents logits; otherwise,
             set it to `False` if `output` represents probabilities.
-            Default is `False`.
+            Defaults to`False`.
         axis: (optional) The axis along which the categorical cross-entropy
             is computed.
-            Default is -1, which corresponds to the last dimension of
+            Defaults to `-1`, which corresponds to the last dimension of
             the tensors.
 
     Returns:
@@ -1465,10 +1465,10 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
             or probabilities.
             Set it to `True` if `output` represents logits; otherwise,
             set it to `False` if `output` represents probabilities.
-            Default is `False`.
+            Defaults to`False`.
         axis: (optional) The axis along which the sparse categorical
             cross-entropy is computed.
-            Default is -1, which corresponds to the last dimension
+            Defaults to `-1`, which corresponds to the last dimension
             of the tensors.
 
     Returns:
@@ -1545,7 +1545,7 @@ def multi_hot(inputs, num_tokens, axis=-1, dtype=None):
         inputs: Tensor of integer labels to be converted to multi-hot vectors.
         num_tokens: Integer, the total number of unique tokens or classes.
         axis: (optional) Axis along which the multi-hot encoding should be
-            added. Default is -1, which corresponds to the last dimension.
+            added. Defaults to `-1`, which corresponds to the last dimension.
         dtype: (optional) The data type of the resulting tensor. Default
             is backend's float type.
 

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -203,10 +203,10 @@ def shape_equal(shape1, shape2, axis=None, allow_none=True):
         shape1: A list or tuple of integers for first shape to be compared.
         shape2: A list or tuple of integers for second shape to be compared.
         axis: An integer, list, or tuple of integers (optional):
-            Axes to ignore during comparison. Default is `None`.
+            Axes to ignore during comparison. Defaults to `None`.
         allow_none (bool, optional): If `True`, allows `None` in a shape
             to match any value in the corresponding position of the other shape.
-            Default is `True`.
+            Defaults to `True`.
 
     Returns:
         bool: `True` if shapes are considered equal based on the criteria,
@@ -378,7 +378,7 @@ def all(x, axis=None, keepdims=False):
             for the last to the first axis.
         keepdims: If `True`, axes which are reduced are left in the result as
             dimensions with size one. With this option, the result will
-            broadcast correctly against the input array. Default is `False`.
+            broadcast correctly against the input array. Defaults to`False`.
 
     Returns:
         The tensor containing the logical AND reduction over the `axis`.
@@ -442,7 +442,7 @@ def any(x, axis=None, keepdims=False):
             for the last to the first axis.
         keepdims: If `True`, axes which are reduced are left in the result as
             dimensions with size one. With this option, the result will
-            broadcast correctly against the input array. Default is `False`.
+            broadcast correctly against the input array. Defaults to`False`.
 
     Returns:
         The tensor containing the logical OR reduction over the `axis`.
@@ -1047,7 +1047,7 @@ def argsort(x, axis=-1):
 
     Args:
         x: Input tensor.
-        axis: Axis along which to sort. Default is `-1` (the last axis). If
+        axis: Axis along which to sort. Defaults to`-1` (the last axis). If
             `None`, the flattened tensor is used.
 
     Returns:
@@ -1416,7 +1416,7 @@ def concatenate(xs, axis=0):
 
     Args:
         xs: The sequence of tensors to concatenate.
-        axis: The axis along which the tensors will be joined. Defaults to 0.
+        axis: The axis along which the tensors will be joined. Defaults to `0`.
 
     Returns:
         The concatenated tensor.
@@ -1652,8 +1652,8 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
     Args:
         x1: Components of the first vector(s).
         x2: Components of the second vector(s).
-        axisa: Axis of `x1` that defines the vector(s). Defaults to -1.
-        axisb: Axis of `x2` that defines the vector(s). Defaults to -1.
+        axisa: Axis of `x1` that defines the vector(s). Defaults to `-1`.
+        axisb: Axis of `x2` that defines the vector(s). Defaults to `-1`.
         axisc: Axis of the result containing the cross product vector(s).
             Ignored if both input vectors have dimension 2, as the return is
             scalar. By default, the last axis.
@@ -1796,7 +1796,7 @@ def diag(x, k=0):
     Args:
         x: Input tensor. If `x` is 2-D, returns the k-th diagonal of `x`.
             If `x` is 1-D, return a 2-D tensor with `x` on the k-th diagonal.
-        k: The diagonal to consider. Defaults to 0. Use `k > 0` for diagonals
+        k: The diagonal to consider. Defaults to `0`. Use `k > 0` for diagonals
             above the main diagonal, and `k < 0` for diagonals below
             the main diagonal.
 
@@ -1888,11 +1888,11 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
     Args:
         x: Input tensor.
         offset: Offset of the diagonal from the main diagonal.
-            Can be positive or negative. Defaults to 0 (main diagonal).
+            Can be positive or negative. Defaults to `0`.(main diagonal).
         axis1: Axis to be used as the first axis of the 2-D sub-arrays.
-            Defaults to 0 (first axis).
+            Defaults to `0`.(first axis).
         axis2: Axis to be used as the second axis of the 2-D sub-arrays.
-            Defaults to 1 (second axis).
+            Defaults to `1` (second axis).
 
     Returns:
         Tensor of diagonals.
@@ -2994,15 +2994,15 @@ def linspace(
             `False`. In that case, the sequence consists of all but the last
             of `num + 1` evenly spaced samples, so that `stop` is excluded.
             Note that the step size changes when `endpoint` is `False`.
-        num: Number of samples to generate. Default is 50. Must be
+        num: Number of samples to generate. Defaults to `50`. Must be
             non-negative.
         endpoint: If `True`, `stop` is the last sample. Otherwise, it is
-            not included. Default is `True`.
+            not included. Defaults to`True`.
         retstep: If `True`, return `(samples, step)`, where `step` is the
             spacing between samples.
         dtype: The type of the output tensor.
         axis: The axis in the result to store the samples. Relevant only if
-            start or stop are array-like. Default is 0.
+            start or stop are array-like. Defaults to `0`.
 
     Note:
         Torch backend does not support `axis` argument.
@@ -3304,10 +3304,10 @@ def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
             In that case, `num + 1` values are spaced over the interval in
             log-space, of which all but the last (a sequence of length `num`)
             are returned.
-        num: Number of samples to generate. Default is 50.
+        num: Number of samples to generate. Defaults to `50`.
         endpoint: If `True`, `stop` is the last sample. Otherwise, it is not
-            included. Default is `True`.
-        base: The base of the log space. Default is 10
+            included. Defaults to`True`.
+        base: The base of the log space. Defaults to `10`.
         dtype: The type of the output tensor.
         axis: The axis in the result to store the samples. Relevant only
             if start or stop are array-like.
@@ -3422,8 +3422,8 @@ def max(x, axis=None, keepdims=False, initial=None):
         axis: Axis or axes along which to operate. By default, flattened input
             is used.
         keepdims: If this is set to `True`, the axes which are reduced are left
-            in the result as dimensions with size one. Default is `False`.
-        initial: The minimum value of an output element. Default is `None`.
+            in the result as dimensions with size one. Defaults to`False`.
+        initial: The minimum value of an output element. Defaults to`None`.
 
     Returns:
         Maximum of `x`.
@@ -3561,8 +3561,8 @@ def min(x, axis=None, keepdims=False, initial=None):
         axis: Axis or axes along which to operate. By default, flattened input
             is used.
         keepdims: If this is set to `True`, the axes which are reduced are left
-            in the result as dimensions with size one. Default is `False`.
-        initial: The maximum value of an output element. Default is `None`.
+            in the result as dimensions with size one. Defaults to`False`.
+        initial: The maximum value of an output element. Defaults to`None`.
 
     Returns:
         Minimum of `x`.
@@ -3950,7 +3950,7 @@ def pad(x, pad_width, mode="constant"):
         mode: One of `"constant"`, `"edge"`, `"linear_ramp"`,
             `"maximum"`, `"mean"`, `"median"`, `"minimum"`,
             `"reflect"`, `"symmetric"`, `"wrap"`, `"empty"`,
-            `"circular"`. Default is `"constant"`.
+            `"circular"`. Defaults to`"constant"`.
 
     Note:
         Torch backend only supports modes `"constant"`, `"reflect"`,
@@ -4236,7 +4236,7 @@ def round(x, decimals=0):
 
     Args:
         x: Input tensor.
-        decimals: Number of decimal places to round to. Default is 0.
+        decimals: Number of decimal places to round to. Defaults to `0`.
 
     Returns:
         Output tensor.
@@ -4357,7 +4357,7 @@ def sort(x, axis=-1):
     Args:
         x: Input tensor.
         axis: Axis along which to sort. If `None`, the tensor is flattened
-            before sorting. Default is the last axis.
+            before sorting. Defaults to `-1`; the last axis.
 
     Returns:
         Sorted tensor.
@@ -4425,7 +4425,7 @@ def split(x, indices_or_sections, axis=0):
             equal sections along `axis`. If a 1-D array of sorted integers,
             the entries indicate indices at which the tensor will be split
             along `axis`.
-        axis: Axis along which to split. Default is 0.
+        axis: Axis along which to split. Defaults to `0`.
 
     Note:
         A split does not have to result in equal division when using
@@ -4477,7 +4477,7 @@ def stack(x, axis=0):
 
     Args:
         x: A sequence of tensors.
-        axis: Axis along which to stack. Default is 0.
+        axis: Axis along which to stack. Defaults to `0`.
 
     Returns:
         The stacked tensor.
@@ -4857,11 +4857,11 @@ def trace(x, offset=0, axis1=0, axis2=1):
     Args:
         x: Input tensor.
         offset: Offset of the diagonal from the main diagonal. Can be
-            both positive and negative. Defaults to 0.
+            both positive and negative. Defaults to `0`.
         axis1: Axis to be used as the first axis of the 2-D sub-arrays.
-            Defaults to 0 (first axis).
+            Defaults to `0`.(first axis).
         axis2: Axis to be used as the second axis of the 2-D sub-arrays.
-            Defaults to 1 (second axis).
+            Defaults to `1` (second axis).
 
     Returns:
         If `x` is 2-D, the sum of the diagonal is returned. If `x` has
@@ -4923,7 +4923,7 @@ def tril(x, k=0):
 
     Args:
         x: Input tensor.
-        k: Diagonal above which to zero elements. Defaults to 0, the
+        k: Diagonal above which to zero elements. Defaults to `0`. the
             main diagonal. `k < 0` is below it, and `k > 0` is above it.
 
     Returns:
@@ -4955,7 +4955,7 @@ def triu(x, k=0):
 
     Args:
         x: Input tensor.
-        k: Diagonal below which to zero elements. Defaults to 0, the
+        k: Diagonal below which to zero elements. Defaults to `0`. the
             main diagonal. `k < 0` is below it, and `k > 0` is above it.
 
     Returns:

--- a/keras_core/optimizers/adadelta.py
+++ b/keras_core/optimizers/adadelta.py
@@ -24,11 +24,11 @@ class Adadelta(optimizer.Optimizer):
         learning_rate: A float, a
             `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
             a callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.001. Note that `Adadelta`
+            use. The learning rate. Defaults to `0.001`. Note that `Adadelta`
             tends to benefit from higher initial learning rate values compared
             to other optimizers. To match the exact form in the original paper,
             use 1.0.
-        rho: A floating point value. The decay rate. Defaults to 0.95.
+        rho: A floating point value. The decay rate. Defaults to `0.95`.
         epsilon: Small floating point value for maintaining numerical stability.
         {{base_optimizer_keyword_args}}
 

--- a/keras_core/optimizers/adafactor.py
+++ b/keras_core/optimizers/adafactor.py
@@ -20,7 +20,7 @@ class Adafactor(optimizer.Optimizer):
         learning_rate: A float, a
             `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
             a callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.001.
+            use. The learning rate. Defaults to `0.001`.
         beta_2_decay: float, defaults to -0.8. The decay rate of `beta_2`.
         epsilon_1: float, defaults to 1e-30. A small offset to keep demoninator
             away from 0.

--- a/keras_core/optimizers/adagrad.py
+++ b/keras_core/optimizers/adagrad.py
@@ -17,10 +17,10 @@ class Adagrad(optimizer.Optimizer):
         learning_rate: A float, a
             `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
             a callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.001. Note that `Adagrad` tends
-            to benefit from higher initial learning rate values compared to
-            other optimizers. To match the exact form in the original paper,
-            use 1.0.
+            use. The learning rate. Defaults to `0.001`. Note that `Adagrad`
+            tends to benefit from higher initial learning rate values compared
+            to other optimizers. To match the exact form in the original paper,
+            use `1.0`.
         initial_accumulator_value: Floating point value. Starting value for the
             accumulators (per-parameter momentum values). Must be non-negative.
         epsilon: Small floating point value for maintaining numerical stability.

--- a/keras_core/optimizers/adam.py
+++ b/keras_core/optimizers/adam.py
@@ -21,7 +21,7 @@ class Adam(optimizer.Optimizer):
         learning_rate: A float, a
             `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
             a callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.001.
+            use. The learning rate. Defaults to `0.001`.
         beta_1: A float value or a constant float tensor, or a callable
             that takes no arguments and returns the actual value to use. The
             exponential decay rate for the 1st moment estimates. Defaults to

--- a/keras_core/optimizers/adamax.py
+++ b/keras_core/optimizers/adamax.py
@@ -37,7 +37,7 @@ class Adamax(optimizer.Optimizer):
         learning_rate: A float, a
             `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
             a callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.001.
+            use. The learning rate. Defaults to `0.001`.
         beta_1: A float value or a constant float tensor. The exponential decay
             rate for the 1st moment estimates.
         beta_2: A float value or a constant float tensor. The exponential decay

--- a/keras_core/optimizers/adamw.py
+++ b/keras_core/optimizers/adamw.py
@@ -24,15 +24,15 @@ class AdamW(adam.Adam):
         learning_rate: A float, a
             `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
             a callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.001.
+            use. The learning rate. Defaults to `0.001`.
         beta_1: A float value or a constant float tensor, or a callable
             that takes no arguments and returns the actual value to use. The
             exponential decay rate for the 1st moment estimates.
-            Defaults to 0.9.
+            Defaults to `0.9`.
         beta_2: A float value or a constant float tensor, or a callable
             that takes no arguments and returns the actual value to use. The
             exponential decay rate for the 2nd moment estimates.
-            Defaults to 0.999.
+            Defaults to `0.999`.
         epsilon: A small constant for numerical stability. This epsilon is
             "epsilon hat" in the Kingma and Ba paper (in the formula just
             before Section 2.1), not the epsilon in Algorithm 1 of the paper.

--- a/keras_core/optimizers/ftrl.py
+++ b/keras_core/optimizers/ftrl.py
@@ -55,7 +55,7 @@ class Ftrl(optimizer.Optimizer):
         learning_rate: A float, a
             `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
             a callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.001.
+            use. The learning rate. Defaults to `0.001`.
         learning_rate_power: A float value, must be less or equal to zero.
             Controls how the learning rate decreases during training. Use zero
             for a fixed learning rate.
@@ -71,7 +71,7 @@ class Ftrl(optimizer.Optimizer):
             magnitude penalty. When input is sparse shrinkage will only happen
             on the active weights.
         beta: A float value, representing the beta value from the paper.
-            Defaults to 0.0.
+            Defaults to `0.0`.
         {{base_optimizer_keyword_args}}
     """
 

--- a/keras_core/optimizers/nadam.py
+++ b/keras_core/optimizers/nadam.py
@@ -15,7 +15,7 @@ class Nadam(optimizer.Optimizer):
         learning_rate: A float, a
             `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
             a callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.001.
+            use. The learning rate. Defaults to `0.001`.
         beta_1: A float value or a constant float tensor, or a callable
             that takes no arguments and returns the actual value to use. The
             exponential decay rate for the 1st moment estimates.

--- a/keras_core/optimizers/rmsprop.py
+++ b/keras_core/optimizers/rmsprop.py
@@ -21,7 +21,7 @@ class RMSprop(optimizer.Optimizer):
         learning_rate: A float, a
             `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
             a callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.001.
+            use. The learning rate. Defaults to `0.001`.
         rho: float, defaults to 0.9. Discounting factor for the old gradients.
         momentum: float, defaults to 0.0. If not 0.0., the optimizer tracks the
             momentum value, with a decay rate equals to `1 - momentum`.

--- a/keras_core/optimizers/sgd.py
+++ b/keras_core/optimizers/sgd.py
@@ -31,10 +31,10 @@ class SGD(optimizer.Optimizer):
         learning_rate: A float, a
             `keras_core.optimizers.schedules.LearningRateSchedule` instance, or
             a callable that takes no arguments and returns the actual value to
-            use. The learning rate. Defaults to 0.01.
+            use. The learning rate. Defaults to `0.01`.
         momentum: float hyperparameter >= 0 that accelerates gradient descent in
-            the relevant direction and dampens oscillations. Defaults to 0,
-            i.e., vanilla gradient descent.
+            the relevant direction and dampens oscillations. 0 is vanilla
+            gradient descent. Defaults to `0.0`.
         nesterov: boolean. Whether to apply Nesterov momentum.
             Defaults to `False`.
         {{base_optimizer_keyword_args}}

--- a/keras_core/regularizers/regularizers.py
+++ b/keras_core/regularizers/regularizers.py
@@ -291,7 +291,7 @@ class OrthogonalRegularizer(Regularizer):
             will be proportional to `factor` times the mean of the dot products
             between the L2-normalized rows (if `mode="rows"`, or columns if
             `mode="columns"`) of the inputs, excluding the product of each
-            row/column with itself.  Defaults to 0.01.
+            row/column with itself.  Defaults to `0.01`.
         mode: String, one of `{"rows", "columns"}`. Defaults to `"rows"`. In
             rows mode, the regularization effect seeks to make the rows of the
             input orthogonal to each other. In columns mode, it seeks to make

--- a/keras_core/utils/image_utils.py
+++ b/keras_core/utils/image_utils.py
@@ -57,9 +57,9 @@ def array_to_img(x, data_format=None, scale=True, dtype=None):
             changed it, it defaults to `"channels_last"`).
         scale: Whether to rescale the image such that minimum and maximum values
             are 0 and 255 respectively. Defaults to `True`.
-        dtype: Dtype to use. Default to `None`, in which case the global setting
+        dtype: Dtype to use. `None` means the global setting
             `keras_core.backend.floatx()` is used (unless you changed it, it
-            defaults to `"float32"`).
+            defaults to `"float32"`). Defaults to `None`.
 
     Returns:
         A PIL Image instance.
@@ -131,7 +131,7 @@ def img_to_array(img, data_format=None, dtype=None):
             `"channels_last"`. Defaults to `None`, in which case the global
             setting `keras_core.backend.image_data_format()` is used (unless you
             changed it, it defaults to `"channels_last"`).
-        dtype: Dtype to use. Default to `None`, in which case the global setting
+        dtype: Dtype to use. `None` means the global setting
             `keras_core.backend.floatx()` is used (unless you changed it, it
             defaults to `"float32"`).
 


### PR DESCRIPTION
It's me again! - PS: I can split this into multiple PRs if you prefer.

---

I am trying to treat JAX, TensorFlow, PyTorch and Keras [amongst others] as data.

For example, translating the API hierarchy from Python to SQL; or generating type-safe help-text included CLIs. This will enable a number of new use-cases.

Unfortunately as it stands, your codebase lacks the type specificity for these use-cases. This is the first, probably of many, PRs to make your codebase consistent enough to be useful for these cases.

Additionally it'll generate better documentation for your primary use-cases; and make it clearer what types are being used where.

E.g., `Defaults to 1.` is ambiguous. Is `1` a float or an int?

Knowing the difference is then useful for continuous variable optimisation (e.g., Ray Tune or Google Vizier hyperparameter optimisation across the `int` or `float` domain). (as an aside; I am interesting in constraining the type numerical range more specifically also; like ASN.1 or Fortran allows)