### PR TITLE
Adds JAX version checking for Export

### DIFF
--- a/keras_core/export/export_lib.py
+++ b/keras_core/export/export_lib.py
@@ -92,8 +92,9 @@ class ExportArchive:
             )
 
         # TODO(nkovela): Make JAX version checking programatic.
-        if backend.backend()=="jax":
+        if backend.backend() == "jax":
             from jax import __version__ as jax_v
+
             if jax_v > "0.4.15":
                 raise ValueError(
                     "The export API is only compatible with JAX version 0.4.15 "

--- a/keras_core/export/export_lib.py
+++ b/keras_core/export/export_lib.py
@@ -91,6 +91,15 @@ class ExportArchive:
                 "The export API is only compatible with JAX and TF backends."
             )
 
+        # TODO(nkovela): Make JAX version checking programatic.
+        if backend.backend()=="jax":
+            from jax import __version__ as jax_v
+            if jax_v > "0.4.15":
+                raise ValueError(
+                    "The export API is only compatible with JAX version 0.4.15 "
+                    f"and prior. Your JAX version: {jax_v}"
+                )
+
     @property
     def variables(self):
         return self._tf_trackable.variables

--- a/keras_core/export/export_lib_test.py
+++ b/keras_core/export/export_lib_test.py
@@ -1,6 +1,7 @@
 """Tests for inference-only model/layer exporting utilities."""
 import os
 import sys
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -29,7 +30,7 @@ def get_model():
     reason="Export only currently supports the TF and JAX backends.",
 )
 @pytest.mark.skipif(
-    backend.backend()=="jax" and sys.modules["jax"].__version__ > "0.4.15",
+    backend.backend() == "jax" and sys.modules["jax"].__version__ > "0.4.15",
     reason="The export API is only compatible with JAX version <= 0.4.15.",
 )
 class ExportArchiveTest(testing.TestCase):

--- a/keras_core/export/export_lib_test.py
+++ b/keras_core/export/export_lib_test.py
@@ -1,6 +1,6 @@
 """Tests for inference-only model/layer exporting utilities."""
 import os
-
+import sys
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -27,6 +27,10 @@ def get_model():
 @pytest.mark.skipif(
     backend.backend() not in ("tensorflow", "jax"),
     reason="Export only currently supports the TF and JAX backends.",
+)
+@pytest.mark.skipif(
+    backend.backend()=="jax" and sys.modules["jax"].__version__ > "0.4.15",
+    reason="The export API is only compatible with JAX version <= 0.4.15.",
 )
 class ExportArchiveTest(testing.TestCase):
     def test_standard_model_export(self):

--- a/keras_core/export/export_lib_test.py
+++ b/keras_core/export/export_lib_test.py
@@ -543,6 +543,18 @@ class ExportArchiveTest(testing.TestCase):
 
 
 @pytest.mark.skipif(
+    backend.backend() != "jax" or sys.modules["jax"].__version__ <= "0.4.15",
+    reason="This test is for invalid JAX versions, i.e. versions > 0.4.15.",
+)
+class VersionTest(testing.TestCase):
+    def test_invalid_jax_version(self):
+        with self.assertRaisesRegex(
+            ValueError, "only compatible with JAX version"
+        ):
+            _ = export_lib.ExportArchive()
+
+
+@pytest.mark.skipif(
     backend.backend() != "tensorflow",
     reason="TFSM Layer reloading is only for the TF backend.",
 )


### PR DESCRIPTION
This PR is a temporary fix in response to the incompatibility between the latest JAX release and latest stable TF release, affecting the export API and its use of JAX2TF.