### PR TITLE
Fix JAX RNN backend issue.

### DIFF
--- a/keras_core/layers/__init__.py
+++ b/keras_core/layers/__init__.py
@@ -121,9 +121,12 @@ from keras_core.layers.rnn.conv_lstm1d import ConvLSTM1D
 from keras_core.layers.rnn.conv_lstm2d import ConvLSTM2D
 from keras_core.layers.rnn.conv_lstm3d import ConvLSTM3D
 from keras_core.layers.rnn.gru import GRU
+from keras_core.layers.rnn.gru import GRUCell
 from keras_core.layers.rnn.lstm import LSTM
+from keras_core.layers.rnn.lstm import LSTMCell
 from keras_core.layers.rnn.rnn import RNN
 from keras_core.layers.rnn.simple_rnn import SimpleRNN
+from keras_core.layers.rnn.simple_rnn import SimpleRNNCell
 from keras_core.layers.rnn.stacked_rnn_cells import StackedRNNCells
 from keras_core.layers.rnn.time_distributed import TimeDistributed
 from keras_core.saving import serialization_lib

--- a/keras_core/layers/rnn/stacked_rnn_cells.py
+++ b/keras_core/layers/rnn/stacked_rnn_cells.py
@@ -89,6 +89,7 @@ class StackedRNNCells(Layer):
         # Call the cells in order and store the returned states.
         new_states = []
         for cell, states in zip(self.cells, states):
+            state_is_list = tree.is_nested(states)
             states = list(states) if tree.is_nested(states) else [states]
             if isinstance(cell, Layer) and cell._call_has_training_arg:
                 kwargs["training"] = training
@@ -96,7 +97,7 @@ class StackedRNNCells(Layer):
                 kwargs.pop("training", None)
             cell_call_fn = cell.__call__ if callable(cell) else cell.call
             inputs, states = cell_call_fn(inputs, states, **kwargs)
-            if len(states) == 1:
+            if len(states) == 1 and not state_is_list:
                 states = states[0]
             new_states.append(states)
 

--- a/keras_core/layers/rnn/stacked_rnn_cells_test.py
+++ b/keras_core/layers/rnn/stacked_rnn_cells_test.py
@@ -81,6 +81,57 @@ class StackedRNNTest(testing.TestCase):
             supports_masking=True,
             custom_objects={"TwoStatesRNNCell": TwoStatesRNNCell},
         )
+        self.run_layer_test(
+            layers.RNN,
+            init_kwargs={
+                "cell": [
+                    layers.SimpleRNNCell(3, dropout=0.1, recurrent_dropout=0.1),
+                    layers.SimpleRNNCell(4, dropout=0.1, recurrent_dropout=0.1),
+                    layers.SimpleRNNCell(5, dropout=0.1, recurrent_dropout=0.1),
+                ],
+                "return_sequences": True,
+            },
+            input_shape=(2, 3, 4),
+            expected_output_shape=(2, 3, 5),
+            expected_num_trainable_weights=9,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=0,
+            supports_masking=True,
+        )
+        self.run_layer_test(
+            layers.RNN,
+            init_kwargs={
+                "cell": [
+                    layers.GRUCell(3, dropout=0.1, recurrent_dropout=0.1),
+                    layers.GRUCell(4, dropout=0.1, recurrent_dropout=0.1),
+                    layers.GRUCell(5, dropout=0.1, recurrent_dropout=0.1),
+                ],
+                "return_sequences": True,
+            },
+            input_shape=(2, 3, 4),
+            expected_output_shape=(2, 3, 5),
+            expected_num_trainable_weights=9,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=0,
+            supports_masking=True,
+        )
+        self.run_layer_test(
+            layers.RNN,
+            init_kwargs={
+                "cell": [
+                    layers.LSTMCell(3, dropout=0.1, recurrent_dropout=0.1),
+                    layers.LSTMCell(4, dropout=0.1, recurrent_dropout=0.1),
+                    layers.LSTMCell(5, dropout=0.1, recurrent_dropout=0.1),
+                ],
+                "return_sequences": True,
+            },
+            input_shape=(2, 3, 4),
+            expected_output_shape=(2, 3, 5),
+            expected_num_trainable_weights=9,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=0,
+            supports_masking=True,
+        )
 
     def test_correctness_single_state_stack(self):
         sequence = np.arange(24).reshape((2, 3, 4)).astype("float32")


### PR DESCRIPTION
This PR address several issues:

1. The existing RNN layer is not training properly due the usage of a fresh StatelessScope in the jax.lax.scan loop. This is causing all the trainable variables to miss the mapping to the actual value in the training loop. Update them to use the parent Stateless scope if it is there. This will address the training issue https://github.com/keras-team/keras-core/issues/322

2. The RNN layers with dropout will have a RNG seed update in the step function, which is not allowed by the jax.lax.scan. We noticed this issue since the updated seed is traced for non-trainable variable, and raise error when we try to put sharding constraint for distribution. Added a new method to pre-populate the dropout mask on the layer and make the inner_loop to be stateless.

3.  During the unit test, I noticed the stackRNNCell doesn't work with existing RNNCell, since it unwrap the list for the state, make the call function to keep the list if the input state is a list.

4. Expose the SimpleRNN|GRU|LSTM cells in the __init__.py since they are public API. 