### PR TITLE
Add support for Tensorflow SparseTensors: merging layers.

### DIFF
--- a/keras_core/backend/tensorflow/numpy.py
+++ b/keras_core/backend/tensorflow/numpy.py
@@ -1,3 +1,5 @@
+import builtins
+import functools
 import warnings
 
 import tensorflow as tf
@@ -7,6 +9,8 @@ from keras_core.backend.tensorflow.core import convert_to_tensor
 
 
 def add(x1, x2):
+    if isinstance(x1, tf.SparseTensor) or isinstance(x2, tf.SparseTensor):
+        return tf.sparse.add(x1, x2)
     return tfnp.add(x1, x2)
 
 
@@ -38,6 +42,11 @@ def einsum(subscripts, *operands, **kwargs):
 
 
 def subtract(x1, x2):
+    if isinstance(x1, tf.SparseTensor) or isinstance(x2, tf.SparseTensor):
+        if isinstance(x2, tf.SparseTensor):
+            return tf.sparse.add(x1, tf.sparse.map_values(tf.negative, x2))
+        else:
+            return tf.sparse.add(x1, tf.negative(x2))
     return tfnp.subtract(x1, x2)
 
 
@@ -62,6 +71,40 @@ def matmul(x1, x2):
 
 
 def multiply(x1, x2):
+    if isinstance(x1, tf.SparseTensor):
+        if isinstance(x2, tf.SparseTensor):
+            ones_like_int8 = functools.partial(tf.ones_like, dtype=tf.int8)
+            zeros_like_int8 = functools.partial(tf.zeros_like, dtype=tf.int8)
+
+            # compute the intersection of indices in the form of a sparse tensor
+            # containing ones as values
+            ones1 = tf.sparse.map_values(ones_like_int8, x1)
+            ones2 = tf.sparse.map_values(ones_like_int8, x2)
+            # tf.sets.intersection ignores the last dimension when comparing,
+            # so we need to add a dummy extra dimension and then remove it
+            intersection = tf.sparse.reshape(
+                tf.sets.intersection(
+                    tf.sparse.expand_dims(ones1, axis=-1),
+                    tf.sparse.expand_dims(ones2, axis=-1),
+                ),
+                x1.dense_shape,
+            )
+
+            # compute the masks to remove indices in x1 and x2 that are not part
+            # of the intersection, then trim x1 and x2
+            zeros1 = tf.sparse.map_values(zeros_like_int8, x1)
+            zeros2 = tf.sparse.map_values(zeros_like_int8, x2)
+            mask1 = tf.sparse.add(zeros1, intersection)
+            mask2 = tf.sparse.add(zeros2, intersection)
+            x1_trimmed = tf.sparse.retain(x1, tf.cast(mask1.values, tf.bool))
+            x2_trimmed = tf.sparse.retain(x2, tf.cast(mask2.values, tf.bool))
+
+            # now it is an element-wise multiplication on the values
+            return tf.sparse.map_values(tf.multiply, x1_trimmed, x2_trimmed)
+        else:
+            return x1 * x2
+    elif isinstance(x2, tf.SparseTensor):
+        return x2 * x1
     return tfnp.multiply(x1, x2)
 
 
@@ -202,6 +245,15 @@ def clip(x, x_min, x_max):
 
 
 def concatenate(xs, axis=0):
+    sparse_count = builtins.sum(isinstance(x, tf.SparseTensor) for x in xs)
+    if sparse_count:
+        if sparse_count == len(xs):
+            return tf.sparse.concat(axis=axis, sp_inputs=xs)
+        else:
+            xs = [
+                tf.sparse.to_dense(x) if isinstance(x, tf.SparseTensor) else x
+                for x in xs
+            ]
     return tfnp.concatenate(xs, axis=axis)
 
 
@@ -420,6 +472,13 @@ def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
 
 
 def maximum(x1, x2):
+    if isinstance(x1, tf.SparseTensor):
+        if isinstance(x2, tf.SparseTensor):
+            return tf.sparse.maximum(x1, x2)
+        else:
+            x1 = tf.sparse.to_dense(x1)
+    elif isinstance(x2, tf.SparseTensor):
+        x2 = tf.sparse.to_dense(x2)
     return tfnp.maximum(x1, x2)
 
 
@@ -449,6 +508,13 @@ def min(x, axis=None, keepdims=False, initial=None):
 
 
 def minimum(x1, x2):
+    if isinstance(x1, tf.SparseTensor):
+        if isinstance(x2, tf.SparseTensor):
+            return tf.sparse.minimum(x1, x2)
+        else:
+            x1 = tf.sparse.to_dense(x1)
+    elif isinstance(x2, tf.SparseTensor):
+        x2 = tf.sparse.to_dense(x2)
     return tfnp.minimum(x1, x2)
 
 

--- a/keras_core/layers/merging/add.py
+++ b/keras_core/layers/merging/add.py
@@ -1,3 +1,4 @@
+from keras_core import ops
 from keras_core.api_export import keras_core_export
 from keras_core.layers.merging.base_merge import Merge
 
@@ -32,7 +33,7 @@ class Add(Merge):
     def _merge_function(self, inputs):
         output = inputs[0]
         for i in range(1, len(inputs)):
-            output = output + inputs[i]
+            output = ops.add(output, inputs[i])
         return output
 
 

--- a/keras_core/layers/merging/average.py
+++ b/keras_core/layers/merging/average.py
@@ -1,3 +1,4 @@
+from keras_core import ops
 from keras_core.api_export import keras_core_export
 from keras_core.layers.merging.base_merge import Merge
 
@@ -32,7 +33,7 @@ class Average(Merge):
     def _merge_function(self, inputs):
         output = inputs[0]
         for i in range(1, len(inputs)):
-            output = output + inputs[i]
+            output = ops.add(output, inputs[i])
         return output / len(inputs)
 
 

--- a/keras_core/layers/merging/base_merge.py
+++ b/keras_core/layers/merging/base_merge.py
@@ -1,5 +1,6 @@
 from keras_core import backend
 from keras_core import ops
+from keras_core.backend.common.keras_tensor import KerasTensor
 from keras_core.layers.layer import Layer
 
 
@@ -207,6 +208,13 @@ class Merge(Layer):
         else:
             output_shape = (None,) + output_shape
         return output_shape
+
+    def compute_output_spec(self, inputs):
+        output_shape = self.compute_output_shape([x.shape for x in inputs])
+        output_sparse = all(x.sparse for x in inputs)
+        return KerasTensor(
+            output_shape, dtype=self.compute_dtype, sparse=output_sparse
+        )
 
     def compute_mask(self, inputs, mask=None):
         if mask is None:

--- a/keras_core/layers/merging/multiply.py
+++ b/keras_core/layers/merging/multiply.py
@@ -1,3 +1,4 @@
+from keras_core import ops
 from keras_core.api_export import keras_core_export
 from keras_core.layers.merging.base_merge import Merge
 
@@ -32,7 +33,7 @@ class Multiply(Merge):
     def _merge_function(self, inputs):
         output = inputs[0]
         for i in range(1, len(inputs)):
-            output = output * inputs[i]
+            output = ops.multiply(output, inputs[i])
         return output
 
 

--- a/keras_core/layers/merging/subtract.py
+++ b/keras_core/layers/merging/subtract.py
@@ -1,3 +1,4 @@
+from keras_core import ops
 from keras_core.api_export import keras_core_export
 from keras_core.layers.merging.base_merge import Merge
 
@@ -44,7 +45,7 @@ class Subtract(Merge):
                 "A `Subtract` layer should be called on exactly 2 inputs. "
                 f"Received: inputs={inputs}"
             )
-        return inputs[0] - inputs[1]
+        return ops.subtract(inputs[0], inputs[1])
 
 
 @keras_core_export("keras_core.layers.subtract")

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -303,7 +303,10 @@ class Add(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        x1_sparse = getattr(x1, "sparse", True)
+        x2_sparse = getattr(x2, "sparse", True)
+        output_sparse = x1_sparse and x2_sparse
+        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
 
 @keras_core_export(["keras_core.ops.add", "keras_core.ops.numpy.add"])
@@ -1386,6 +1389,7 @@ class Concatenate(Operation):
     def compute_output_spec(self, xs):
         first_shape = xs[0].shape
         total_size_on_axis = 0
+        all_sparse = True
         for x in xs:
             if not shape_equal(
                 x.shape, first_shape, axis=[self.axis], allow_none=True
@@ -1400,9 +1404,11 @@ class Concatenate(Operation):
                 total_size_on_axis = None
             else:
                 total_size_on_axis += x.shape[self.axis]
+            if not x.sparse:
+                all_sparse = False
         output_shape = list(first_shape)
         output_shape[self.axis] = total_size_on_axis
-        return KerasTensor(output_shape, dtype=x.dtype)
+        return KerasTensor(output_shape, dtype=x.dtype, sparse=all_sparse)
 
 
 @keras_core_export(
@@ -3443,7 +3449,10 @@ class Maximum(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        x1_sparse = getattr(x1, "sparse", True)
+        x2_sparse = getattr(x2, "sparse", True)
+        output_sparse = x1_sparse and x2_sparse
+        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
 
 @keras_core_export(["keras_core.ops.maximum", "keras_core.ops.numpy.maximum"])
@@ -3582,7 +3591,10 @@ class Minimum(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        x1_sparse = getattr(x1, "sparse", True)
+        x2_sparse = getattr(x2, "sparse", True)
+        output_sparse = x1_sparse and x2_sparse
+        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
 
 @keras_core_export(["keras_core.ops.minimum", "keras_core.ops.numpy.minimum"])
@@ -5080,7 +5092,10 @@ class Subtract(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        x1_sparse = getattr(x1, "sparse", True)
+        x2_sparse = getattr(x2, "sparse", True)
+        output_sparse = x1_sparse and x2_sparse
+        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
 
 @keras_core_export(["keras_core.ops.subtract", "keras_core.ops.numpy.subtract"])
@@ -5107,7 +5122,10 @@ class Multiply(Operation):
         x1_shape = getattr(x1, "shape", [])
         x2_shape = getattr(x2, "shape", [])
         output_shape = broadcast_shapes(x1_shape, x2_shape)
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        x1_sparse = getattr(x1, "sparse", True)
+        x2_sparse = getattr(x2, "sparse", True)
+        output_sparse = x1_sparse or x2_sparse
+        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
 
 @keras_core_export(["keras_core.ops.multiply", "keras_core.ops.numpy.multiply"])

--- a/keras_core/ops/numpy_test.py
+++ b/keras_core/ops/numpy_test.py
@@ -371,6 +371,25 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             y = KerasTensor([2, 3, 4])
             knp.add(x, y)
 
+    def test_add_sparse(self):
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3))
+        result = knp.add(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertFalse(result.sparse)
+
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.add(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertFalse(result.sparse)
+
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.add(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertTrue(result.sparse)
+
     def test_subtract(self):
         x = KerasTensor([2, 3])
         y = KerasTensor([2, 3])
@@ -384,6 +403,25 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             y = KerasTensor([2, 3, 4])
             knp.subtract(x, y)
 
+    def test_subtract_sparse(self):
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3))
+        result = knp.subtract(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertFalse(result.sparse)
+
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.subtract(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertFalse(result.sparse)
+
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.subtract(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertTrue(result.sparse)
+
     def test_multiply(self):
         x = KerasTensor([2, 3])
         y = KerasTensor([2, 3])
@@ -396,6 +434,25 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             x = KerasTensor([2, 3])
             y = KerasTensor([2, 3, 4])
             knp.multiply(x, y)
+
+    def test_multiply_sparse(self):
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3))
+        result = knp.multiply(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertTrue(result.sparse)
+
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.multiply(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertTrue(result.sparse)
+
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.multiply(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertTrue(result.sparse)
 
     def test_matmul(self):
         x = KerasTensor([2, 3])
@@ -650,6 +707,25 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             y = KerasTensor([2, 3, 4])
             knp.maximum(x, y)
 
+    def test_maximum_sparse(self):
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3))
+        result = knp.maximum(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertFalse(result.sparse)
+
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.maximum(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertFalse(result.sparse)
+
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.maximum(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertTrue(result.sparse)
+
     def test_minimum(self):
         x = KerasTensor([2, 3])
         y = KerasTensor([2, 3])
@@ -662,6 +738,25 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             x = KerasTensor([2, 3])
             y = KerasTensor([2, 3, 4])
             knp.minimum(x, y)
+
+    def test_minimum_sparse(self):
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3))
+        result = knp.minimum(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertFalse(result.sparse)
+
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.minimum(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertFalse(result.sparse)
+
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.minimum(x, y)
+        self.assertEqual(result.shape, (2, 3))
+        self.assertTrue(result.sparse)
 
     def test_mod(self):
         x = KerasTensor([2, 3])
@@ -965,6 +1060,25 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
             x = KerasTensor([None, 3, 5])
             y = KerasTensor([None, 4, 6])
             knp.concatenate([x, y], axis=1)
+
+    def test_concatenate_sparse(self):
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3))
+        result = knp.concatenate([x, y], axis=1)
+        self.assertEqual(result.shape, (2, 6))
+        self.assertFalse(result.sparse)
+
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.concatenate([x, y], axis=1)
+        self.assertEqual(result.shape, (2, 6))
+        self.assertFalse(result.sparse)
+
+        x = KerasTensor((2, 3), sparse=True)
+        y = KerasTensor((2, 3), sparse=True)
+        result = knp.concatenate([x, y], axis=1)
+        self.assertEqual(result.shape, (2, 6))
+        self.assertTrue(result.sparse)
 
     def test_conjugate(self):
         x = KerasTensor([None, 3])
@@ -2376,6 +2490,85 @@ class NumpyTwoInputOpsCorretnessTest(testing.TestCase, parameterized.TestCase):
             standardize_dtype(knp.Digitize()(x, bins).dtype) == "int32"
         )
 
+    @parameterized.named_parameters(
+        [
+            {
+                "testcase_name": "add",
+                "op_function": knp.add,
+                "op_class": knp.Add,
+                "np_op": np.add,
+            },
+            {
+                "testcase_name": "subtract",
+                "op_function": knp.subtract,
+                "op_class": knp.Subtract,
+                "np_op": np.subtract,
+            },
+            {
+                "testcase_name": "multiply",
+                "op_function": knp.multiply,
+                "op_class": knp.Multiply,
+                "np_op": np.multiply,
+                "mixed_inputs_produce_sparse_output": True,
+            },
+            {
+                "testcase_name": "minimum",
+                "op_function": knp.minimum,
+                "op_class": knp.Minimum,
+                "np_op": np.minimum,
+            },
+            {
+                "testcase_name": "maximum",
+                "op_function": knp.maximum,
+                "op_class": knp.Maximum,
+                "np_op": np.maximum,
+            },
+        ]
+    )
+    @pytest.mark.skipif(
+        not backend.SUPPORTS_SPARSE_TENSORS,
+        reason="Backend does not support sparse tensors.",
+    )
+    def test_sparse(
+        self,
+        op_function,
+        op_class,
+        np_op,
+        mixed_inputs_produce_sparse_output=False,
+    ):
+        import tensorflow as tf
+
+        x = tf.SparseTensor(
+            indices=[[0, 0], [1, 2]], values=[1.0, 2.0], dense_shape=(2, 3)
+        )
+        x_np = tf.sparse.to_dense(x).numpy()
+
+        y = tf.SparseTensor(
+            indices=[[0, 0], [1, 1]], values=[4.0, 5.0], dense_shape=(2, 3)
+        )
+        y_np = tf.sparse.to_dense(y).numpy()
+        z = np.random.rand(2, 3).astype("float32")
+
+        # sparse tensor and dense tensor as inputs
+        if mixed_inputs_produce_sparse_output:
+            self.assertIsInstance(op_function(x, z), tf.SparseTensor)
+            self.assertIsInstance(op_class()(x, z), tf.SparseTensor)
+        self.assertAllClose(op_function(x, z), np_op(x_np, z))
+        self.assertAllClose(op_class()(x, z), np_op(x_np, z))
+
+        # dense tensor and sparse tensor as inputs
+        if mixed_inputs_produce_sparse_output:
+            self.assertIsInstance(op_function(z, x), tf.SparseTensor)
+            self.assertIsInstance(op_class()(z, x), tf.SparseTensor)
+        self.assertAllClose(op_function(z, x), np_op(z, x_np))
+        self.assertAllClose(op_class()(z, x), np_op(z, x_np))
+
+        # sparse tensor and sparse tensor as inputs
+        self.assertIsInstance(op_function(x, y), tf.SparseTensor)
+        self.assertIsInstance(op_class()(x, y), tf.SparseTensor)
+        self.assertAllClose(op_function(x, y), np_op(x_np, y_np))
+        self.assertAllClose(op_class()(x, y), np_op(x_np, y_np))
+
 
 class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
     def test_mean(self):
@@ -2753,6 +2946,63 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         self.assertAllClose(
             knp.Concatenate(axis=1)([x, y]),
             np.concatenate([x, y], axis=1),
+        )
+
+    @parameterized.named_parameters(
+        [
+            {"testcase_name": "axis_0", "axis": 0},
+            {"testcase_name": "axis_1", "axis": 1},
+        ]
+    )
+    @pytest.mark.skipif(
+        not backend.SUPPORTS_SPARSE_TENSORS,
+        reason="Backend does not support sparse tensors.",
+    )
+    def test_concatenate_sparse(self, axis):
+        import tensorflow as tf
+
+        x = tf.SparseTensor(
+            indices=[[0, 0], [1, 2]], values=[1.0, 2.0], dense_shape=(2, 3)
+        )
+        x_np = tf.sparse.to_dense(x).numpy()
+
+        y = tf.SparseTensor(
+            indices=[[0, 0], [1, 1]], values=[4.0, 5.0], dense_shape=(2, 3)
+        )
+        y_np = tf.sparse.to_dense(y).numpy()
+        z = np.random.rand(2, 3).astype("float32")
+
+        self.assertAllClose(
+            knp.concatenate([x, z], axis=axis),
+            np.concatenate([x_np, z], axis=axis),
+        )
+        self.assertAllClose(
+            knp.concatenate([z, x], axis=axis),
+            np.concatenate([z, x_np], axis=axis),
+        )
+        self.assertAllClose(
+            knp.concatenate([x, y], axis=axis),
+            np.concatenate([x_np, y_np], axis=axis),
+        )
+
+        self.assertAllClose(
+            knp.Concatenate(axis=axis)([x, z]),
+            np.concatenate([x_np, z], axis=axis),
+        )
+        self.assertAllClose(
+            knp.Concatenate(axis=axis)([z, x]),
+            np.concatenate([z, x_np], axis=axis),
+        )
+        self.assertAllClose(
+            knp.Concatenate(axis=axis)([x, y]),
+            np.concatenate([x_np, y_np], axis=axis),
+        )
+
+        self.assertIsInstance(
+            knp.concatenate([x, y], axis=axis), tf.SparseTensor
+        )
+        self.assertIsInstance(
+            knp.Concatenate(axis=axis)([x, y]), tf.SparseTensor
         )
 
     def test_conjugate(self):


### PR DESCRIPTION
Added `tf.SparseTensor` support for ops:
- add
- concatenate
- maximum
- minimum
- multiply
- subtract

Added `tf.SparseTensor` support for merging layers:
- Add
- Average
- Concatenate
- Maximum
- Minimum
- Multiply
- Subtract

Note that the `Dot` merging layer will be addressed in a separate PR.