### PR TITLE
Slice serialization

### DIFF
--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -2547,6 +2547,8 @@ def full_like(x, fill_value, dtype=None):
 
 class GetItem(Operation):
     def call(self, x, key):
+        if isinstance(key, list):
+            key = tuple(key)
         return x[key]
 
     def compute_output_spec(self, x, key):

--- a/keras_core/saving/serialization_lib_test.py
+++ b/keras_core/saving/serialization_lib_test.py
@@ -75,6 +75,8 @@ class SerializationLibTest(testing.TestCase):
             ["hello", 0, "world", 1.0, True],
             {"1": "hello", "2": 0, "3": True},
             {"1": "hello", "2": [True, False]},
+            slice(None, 20, 1),
+            slice(None, np.array([0, 1]), 1),
         ]:
             serialized, _, reserialized = self.roundtrip(obj)
             self.assertEqual(serialized, reserialized)


### PR DESCRIPTION
Models that contain slicing cannot be serialized because of the missing handling of slices in the `(de)serialize_keras_object` functions.

Thus a simple functional as this one.
```python
x = inp = Input(...)
...
x = x[:, 1:-1, 1:-1]
...
fn = Functional(inp, x)
```
could not be serialized.

Now it's possible with this fix.