### PR TITLE
Add support for Tensorflow SparseTensors: Dot merging layer.

### DIFF
--- a/keras_core/layers/merging/merging_test.py
+++ b/keras_core/layers/merging/merging_test.py
@@ -237,9 +237,6 @@ class MergingLayersTest(testing.TestCase, parameterized.TestCase):
     ):
         import tensorflow as tf
 
-        if layer_class == layers.Dot:
-            pytest.skip("Dot layer does not support sparse tensors.")
-
         self.run_layer_test(
             layer_class,
             init_kwargs=init_kwargs,

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -2395,7 +2395,7 @@ class ExpandDims(Operation):
         else:
             axis = self.axis
         output_shape = x_shape[:axis] + [1] + x_shape[axis:]
-        return KerasTensor(output_shape, dtype=x.dtype)
+        return KerasTensor(output_shape, dtype=x.dtype, sparse=x.sparse)
 
 
 @keras_core_export(
@@ -3368,7 +3368,10 @@ class Matmul(Operation):
             del output_shape[-2]
         if len(x2.shape) == 1:
             del output_shape[-1]
-        return KerasTensor(output_shape, dtype=x1.dtype)
+        x1_sparse = getattr(x1, "sparse", True)
+        x2_sparse = getattr(x2, "sparse", True)
+        output_sparse = x1_sparse and x2_sparse
+        return KerasTensor(output_shape, dtype=x1.dtype, sparse=output_sparse)
 
 
 @keras_core_export(["keras_core.ops.matmul", "keras_core.ops.numpy.matmul"])
@@ -5309,7 +5312,7 @@ class Squeeze(Operation):
         input_shape = list(x.shape)
         if self.axis is None:
             output_shape = list(filter((1).__ne__, input_shape))
-            return KerasTensor(output_shape)
+            return KerasTensor(output_shape, dtype=x.dtype, sparse=x.sparse)
         else:
             if input_shape[self.axis] != 1:
                 raise ValueError(
@@ -5317,7 +5320,7 @@ class Squeeze(Operation):
                     "is not 1."
                 )
             del input_shape[self.axis]
-            return KerasTensor(input_shape, dtype=x.dtype)
+            return KerasTensor(input_shape, dtype=x.dtype, sparse=x.sparse)
 
 
 @keras_core_export(["keras_core.ops.squeeze", "keras_core.ops.numpy.squeeze"])


### PR DESCRIPTION
Added `tf.SparseTensor` support for ops:
- matmul (sparse support was very partial before this PR)
- squeeze
- expand_dims

Added `tf.SparseTensor` support for merging layer:
- Dot