### PR TITLE
Introduce dtype inference and improve dtype in `ops.numpy.*`

### DIFF
--- a/keras_core/backend/__init__.py
+++ b/keras_core/backend/__init__.py
@@ -6,6 +6,7 @@ if backend() == "torch":
     # upon import.
     import torch
 
+from keras_core.backend.common.dtypes import result_dtype
 from keras_core.backend.common.keras_tensor import KerasTensor
 from keras_core.backend.common.keras_tensor import any_symbolic_tensors
 from keras_core.backend.common.keras_tensor import is_keras_tensor

--- a/keras_core/backend/common/__init__.py
+++ b/keras_core/backend/common/__init__.py
@@ -1,4 +1,5 @@
 from keras_core.backend.common import backend_utils
+from keras_core.backend.common.dtypes import result_dtype
 from keras_core.backend.common.variables import AutocastScope
 from keras_core.backend.common.variables import KerasVariable
 from keras_core.backend.common.variables import get_autocast_scope

--- a/keras_core/backend/common/dtypes.py
+++ b/keras_core/backend/common/dtypes.py
@@ -1,0 +1,274 @@
+import functools
+
+from keras_core import backend
+from keras_core.api_export import keras_core_export
+from keras_core.backend.common.variables import ALLOWED_DTYPES
+
+# Default dtypes corresponding to Python scalars.
+PYTHON_SCALAR_DTYPES = {
+    bool: "bool",
+    int: "int64",
+    float: "float64",
+    # TODO: support complex dtypes
+    # complex: "complex128",
+}
+BIT64_TO_BIT16_DTYPE = {
+    "int32": "int16",
+    "int64": "int16",
+    "uint32": "uint16",
+    "uint64": "uint16",
+    "float32": "float16",
+    "float64": "float16",
+    # TODO: support complex dtypes
+    # "complex64": "complex32",
+    # "complex128": "complex32",
+}
+BIT64_TO_BIT32_DTYPE = {
+    "int64": "int32",
+    "uint64": "uint32",
+    "float64": "float32",
+    # TODO: support complex dtypes
+    # "complex128": "complex64",
+}
+
+
+@functools.lru_cache(maxsize=None)
+def canonicalize_dtype(float_type, dtype):
+    if float_type == "float16":
+        return BIT64_TO_BIT16_DTYPE.get(dtype, dtype)
+    elif float_type == "float32":
+        return BIT64_TO_BIT32_DTYPE.get(dtype, dtype)
+    elif float_type == "float64":
+        return dtype
+    else:
+        raise ValueError(
+            f"Invalid float_type: {float_type}, `float_type` must be one of"
+            f"('float16', 'float32', 'float64')."
+        )
+
+
+def dtype(x, *, canonicalize=False):
+    """Return the dtype object for a tensor or type."""
+    dtype = None
+    if x is None:
+        raise ValueError(f"Invalid argument to dtype: {x}.")
+    elif isinstance(x, type) and x in PYTHON_SCALAR_DTYPES:
+        dtype = PYTHON_SCALAR_DTYPES[x]
+    elif type(x) in PYTHON_SCALAR_DTYPES:
+        dtype = PYTHON_SCALAR_DTYPES[type(x)]
+    elif backend.is_tensor(x):
+        dtype = backend.standardize_dtype(x.shape)
+    elif x in ALLOWED_DTYPES:
+        dtype = x
+
+    if dtype is None or dtype not in ALLOWED_DTYPES:
+        raise ValueError(f"Invalid dtype: {x}")
+    return (
+        canonicalize_dtype(backend.floatx(), dtype) if canonicalize else dtype
+    )
+
+
+_bool_types = ["bool"]
+_int_types = [
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+]
+_float_types = ["bfloat16", "float16", "float32", "float64"]
+_complex_types = ["complex64", "complex128"]
+_weak_types = ["int", "float", "complex"]
+_weak_types_python = [int, float, complex]
+
+
+def _keras_core_type(dtype, weak_type):
+    """Return the keras core type for a dtype and weak type."""
+    if weak_type:
+        if dtype == "bool":
+            return dtype
+        if "float" in dtype:
+            return "float"
+        if "int" in dtype:
+            return "int"
+        # TODO: support complex types
+        # if "complex" in dtype:
+        #     return "complex"
+    return dtype
+
+
+def is_weakly_typed(x):
+    return type(x) in _weak_types_python
+
+
+def _dtype_and_weaktype(value):
+    """Return a (dtype, weak_type) tuple for the given input."""
+    return dtype(value), any(
+        value is typ for typ in _weak_types_python
+    ) or is_weakly_typed(value)
+
+
+def _type_promotion_lattice():
+    """
+    Return the type promotion lattice in the form of a DAG.
+    This DAG maps each type to its immediately higher type on the lattice.
+    """
+    (b1,) = _bool_types
+    (u1, u2, u4, u8, i1, i2, i4, i8) = _int_types
+    bf, f2, f4, f8 = _float_types
+    c4, c8 = _complex_types
+    i_, f_, c_ = _weak_types
+    out = {
+        b1: [i_],
+        u1: [i2, u2],
+        u2: [i4, u4],
+        u4: [i8, u8],
+        u8: [f_],
+        i_: [u1, i1],
+        i1: [i2],
+        i2: [i4],
+        i4: [i8],
+        i8: [f_],
+        f_: [bf, f2, c_],
+        bf: [f4],
+        f2: [f4],
+        f4: [f8, c4],
+        f8: [c8],
+        c_: [c4],
+        c4: [c8],
+        c8: [],
+    }
+    return out
+
+
+def _make_lattice_upper_bounds():
+    lattice = _type_promotion_lattice()
+    upper_bounds = {node: {node} for node in lattice}
+    for n in lattice:
+        while True:
+            new_upper_bounds = set().union(
+                *(lattice[b] for b in upper_bounds[n])
+            )
+            if n in new_upper_bounds:
+                raise ValueError(
+                    f"cycle detected in type promotion lattice for node {n}"
+                )
+            if new_upper_bounds.issubset(upper_bounds[n]):
+                break
+            upper_bounds[n] |= new_upper_bounds
+    return upper_bounds
+
+
+_lattice_upper_bounds = _make_lattice_upper_bounds()
+
+
+@functools.lru_cache(512)
+def _least_upper_bound(*nodes):
+    """Compute the least upper bound of a set of nodes.
+
+    Args:
+        nodes: sequence of entries from _jax_types + _weak_types
+
+    Returns:
+        The type representing the least upper bound of the input nodes on the
+        promotion lattice.
+    """
+    # This function computes the least upper bound of a set of nodes N within a
+    # partially ordered set defined by the lattice generated above.
+    # Given a partially ordered set S, let the set of upper bounds of n ∈ S be
+    #   UB(n) ≡ {m ∈ S | n ≤ m}
+    # Further, for a set of nodes N ⊆ S, let the set of common upper bounds be
+    # given by
+    #   CUB(N) ≡ {a ∈ S | ∀ b ∈ N: a ∈ UB(b)}
+    # Then the least upper bound of N is defined as
+    #   LUB(N) ≡ {c ∈ CUB(N) | ∀ d ∈ CUB(N), c ≤ d}
+    # The definition of an upper bound implies that
+    #   c ≤ d if and only if d ∈ UB(c),
+    # so the LUB can be expressed:
+    #   LUB(N) = {c ∈ CUB(N) | ∀ d ∈ CUB(N): d ∈ UB(c)}
+    # or, equivalently:
+    #   LUB(N) = {c ∈ CUB(N) | CUB(N) ⊆ UB(c)}
+    # By definition, LUB(N) has a cardinality of 1 for a partially ordered set.
+    # Note a potential algorithmic shortcut: from the definition of CUB(N),
+    # we have
+    #   ∀ c ∈ N: CUB(N) ⊆ UB(c)
+    # So if N ∩ CUB(N) is nonempty, if follows that LUB(N) = N ∩ CUB(N).
+    N = set(nodes)
+    UB = _lattice_upper_bounds
+    try:
+        bounds = [UB[n] for n in N]
+    except KeyError:
+        dtype = next(n for n in N if n not in UB)
+        raise ValueError(
+            f"{dtype=} is not a valid dtype for Keras Core type promotion."
+        )
+    CUB = set.intersection(*bounds)
+    LUB = (CUB & N) or {c for c in CUB if CUB.issubset(UB[c])}
+    if len(LUB) == 1:
+        return LUB.pop()
+    elif len(LUB) == 0:
+        msg = (
+            f"Input dtypes {tuple(str(n) for n in nodes)} have no available "
+            "implicit dtype promotion path. Try explicitly casting inputs to "
+            "the desired output type."
+        )
+        raise ValueError(msg)
+    else:
+        # If we get here, it means the lattice is ill-formed.
+        raise ValueError(
+            f"Internal Type Promotion error: {nodes} do not have a unique "
+            f"least upper bound on the specified lattice; options are {LUB}. "
+            "This is an unexpected error in Keras Core's internal logic; "
+            "please report it to the maintainers."
+        )
+
+
+def _lattice_result_type(*args):
+    dtypes, weak_types = zip(*(_dtype_and_weaktype(arg) for arg in args))
+    if len(dtypes) == 1:
+        out_dtype = dtypes[0]
+        out_weak_type = weak_types[0]
+    elif len(set(dtypes)) == 1 and not all(weak_types):
+        # Trivial promotion case. This allows extended dtypes through.
+        out_dtype = dtypes[0]
+        out_weak_type = False
+    elif all(weak_types):
+        # If all inputs are weakly typed, we compute the bound of the
+        # strongly-typed counterparts and apply the weak type at the end. This
+        # avoids returning the incorrect result with non-canonical weak types
+        # (e.g. weak int16).
+        # TODO: explore removing this special case.
+        result_type = _least_upper_bound(
+            *{_keras_core_type(dtype, False) for dtype in dtypes}
+        )
+        out_dtype = dtype(result_type)
+        out_weak_type = True
+    else:
+        result_type = _least_upper_bound(
+            *{_keras_core_type(d, w) for d, w in zip(dtypes, weak_types)}
+        )
+        out_dtype = dtype(result_type)
+        out_weak_type = any(result_type is t for t in _weak_types)
+    return out_dtype, (out_dtype != "bool") and out_weak_type
+
+
+@keras_core_export("keras_core.backend.result_dtype")
+def result_dtype(*args, return_weak_type_flag=False):
+    """Convenience function to apply Keras Core argument dtype promotion.
+
+    This function attempts to match the result of `jax.numpy.result_dtype`.
+    """
+    # TODO: support weaktype
+    if len(args) == 0:
+        raise ValueError("at least one array or dtype is required")
+    dtype, weak_type = _lattice_result_type(
+        *(backend.floatx() if arg is None else arg for arg in args)
+    )
+    if weak_type:
+        raise ValueError(f"{weak_type}, {dtype}")
+    else:
+        dtype = canonicalize_dtype(backend.floatx(), dtype)
+    return (dtype, weak_type) if return_weak_type_flag else dtype

--- a/keras_core/backend/common/dtypes_test.py
+++ b/keras_core/backend/common/dtypes_test.py
@@ -1,0 +1,40 @@
+from absl.testing import parameterized
+
+from keras_core.backend.common import result_dtype
+from keras_core.testing import test_case
+
+
+class DtypesTest(test_case.TestCase, parameterized.TestCase):
+    @parameterized.product(
+        dtype=[
+            "float16",
+            "float32",
+            "float64",
+            "uint8",
+            "uint16",
+            "uint32",
+            "uint64",
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "bfloat16",
+            "bool",
+            # "string",  # not supported
+        ],
+        python_scalar_type=[
+            bool,
+            int,
+            float,
+            # complex,  # not supported
+        ],
+    )
+    def test_result_dtype_with_python_scalar_types(
+        self, dtype, python_scalar_type
+    ):
+        import jax.numpy as jnp
+
+        # match `jnp.result_dtype` result
+        out = result_dtype(dtype, python_scalar_type)
+        expected = jnp.result_type(dtype, python_scalar_type).name
+        self.assertEqual(out, expected)

--- a/keras_core/backend/jax/numpy.py
+++ b/keras_core/backend/jax/numpy.py
@@ -70,11 +70,13 @@ def max(x, axis=None, keepdims=False, initial=None):
     return jnp.max(x, axis=axis, keepdims=keepdims, initial=initial)
 
 
-def ones(shape, dtype="float32"):
+def ones(shape, dtype=None):
+    dtype = dtype or config.floatx()
     return jnp.ones(shape, dtype=dtype)
 
 
-def zeros(shape, dtype="float32"):
+def zeros(shape, dtype=None):
+    dtype = dtype or config.floatx()
     return jnp.zeros(shape, dtype=dtype)
 
 
@@ -253,7 +255,8 @@ def dot(x, y):
     return jnp.dot(x, y)
 
 
-def empty(shape, dtype="float32"):
+def empty(shape, dtype=None):
+    dtype = dtype or config.floatx()
     return jnp.empty(shape, dtype=dtype)
 
 
@@ -284,6 +287,7 @@ def floor(x):
 
 
 def full(shape, fill_value, dtype=None):
+    dtype = dtype or config.floatx()
     return jnp.full(shape, fill_value, dtype=dtype)
 
 
@@ -307,7 +311,8 @@ def hstack(xs):
     return jnp.hstack(xs)
 
 
-def identity(n, dtype="float32"):
+def identity(n, dtype=None):
+    dtype = dtype or config.floatx()
     return jnp.identity(n, dtype=dtype)
 
 
@@ -348,6 +353,7 @@ def less_equal(x1, x2):
 def linspace(
     start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0
 ):
+    dtype = dtype or config.floatx()
     return jnp.linspace(
         start,
         stop,
@@ -398,6 +404,7 @@ def logical_or(x1, x2):
 
 
 def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
+    dtype = dtype or config.floatx()
     return jnp.logspace(
         start,
         stop,
@@ -573,7 +580,8 @@ def trace(x, offset=0, axis1=0, axis2=1):
     return jnp.trace(x, offset=offset, axis1=axis1, axis2=axis2)
 
 
-def tri(N, M=None, k=0, dtype="float32"):
+def tri(N, M=None, k=0, dtype=None):
+    dtype = dtype or config.floatx()
     return jnp.tri(N, M=M, k=k, dtype=dtype)
 
 
@@ -652,7 +660,8 @@ def sum(x, axis=None, keepdims=False):
     return jnp.sum(x, axis=axis, keepdims=keepdims)
 
 
-def eye(N, M=None, k=0, dtype="float32"):
+def eye(N, M=None, k=0, dtype=None):
+    dtype = dtype or config.floatx()
     return jnp.eye(N, M=M, k=k, dtype=dtype)
 
 

--- a/keras_core/backend/numpy/numpy.py
+++ b/keras_core/backend/numpy/numpy.py
@@ -34,11 +34,13 @@ def max(x, axis=None, keepdims=False, initial=None):
     return np.max(x, axis=axis, keepdims=keepdims, initial=initial)
 
 
-def ones(shape, dtype="float32"):
+def ones(shape, dtype=None):
+    dtype = dtype or config.floatx()
     return np.ones(shape, dtype=dtype)
 
 
-def zeros(shape, dtype="float32"):
+def zeros(shape, dtype=None):
+    dtype = dtype or config.floatx()
     return np.zeros(shape, dtype=dtype)
 
 
@@ -134,7 +136,6 @@ def argsort(x, axis=-1):
 
 
 def array(x, dtype=None):
-    dtype = dtype or config.floatx()
     return np.array(x, dtype=dtype)
 
 
@@ -251,7 +252,8 @@ def dot(x, y):
     return np.dot(x, y)
 
 
-def empty(shape, dtype="float32"):
+def empty(shape, dtype=None):
+    dtype = dtype or config.floatx()
     return np.empty(shape, dtype=dtype)
 
 
@@ -302,7 +304,8 @@ def hstack(xs):
     return np.hstack(xs)
 
 
-def identity(n, dtype="float32"):
+def identity(n, dtype=None):
+    dtype = dtype or config.floatx()
     return np.identity(n, dtype=dtype)
 
 
@@ -338,6 +341,7 @@ def linspace(
     start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0
 ):
     axis = tuple(axis) if isinstance(axis, list) else axis
+    dtype = dtype or config.floatx()
     return np.linspace(
         start,
         stop,
@@ -382,6 +386,7 @@ def logical_or(x1, x2):
 
 
 def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
+    dtype = dtype or config.floatx()
     return np.logspace(
         start,
         stop,
@@ -556,7 +561,8 @@ def trace(x, offset=0, axis1=0, axis2=1):
     return np.trace(x, offset=offset, axis1=axis1, axis2=axis2)
 
 
-def tri(N, M=None, k=0, dtype="float32"):
+def tri(N, M=None, k=0, dtype=None):
+    dtype = dtype or config.floatx()
     return np.tri(N, M=M, k=k, dtype=dtype)
 
 
@@ -631,7 +637,8 @@ def sum(x, axis=None, keepdims=False):
     return np.sum(x, axis=axis, keepdims=keepdims)
 
 
-def eye(N, M=None, k=0, dtype="float32"):
+def eye(N, M=None, k=0, dtype=None):
+    dtype = dtype or config.floatx()
     return np.eye(N, M=M, k=k, dtype=dtype)
 
 

--- a/keras_core/backend/tensorflow/numpy.py
+++ b/keras_core/backend/tensorflow/numpy.py
@@ -134,11 +134,13 @@ def max(x, axis=None, keepdims=False, initial=None):
     return tfnp.max(x, axis=axis, keepdims=keepdims)
 
 
-def ones(shape, dtype="float32"):
+def ones(shape, dtype=None):
+    dtype = dtype or config.floatx()
     return tf.ones(shape, dtype=dtype)
 
 
-def zeros(shape, dtype="float32"):
+def zeros(shape, dtype=None):
+    dtype = dtype or config.floatx()
     return tf.zeros(shape, dtype=dtype)
 
 
@@ -341,7 +343,8 @@ def dot(x, y):
     return tfnp.dot(x, y)
 
 
-def empty(shape, dtype="float32"):
+def empty(shape, dtype=None):
+    dtype = dtype or config.floatx()
     return tfnp.empty(shape, dtype=dtype)
 
 
@@ -370,6 +373,7 @@ def floor(x):
 
 
 def full(shape, fill_value, dtype=None):
+    dtype = dtype or config.floatx()
     return tfnp.full(shape, fill_value, dtype=dtype)
 
 
@@ -389,7 +393,8 @@ def hstack(xs):
     return tfnp.hstack(xs)
 
 
-def identity(n, dtype="float32"):
+def identity(n, dtype=None):
+    dtype = dtype or config.floatx()
     return tfnp.identity(n, dtype=dtype)
 
 
@@ -424,6 +429,7 @@ def less_equal(x1, x2):
 def linspace(
     start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0
 ):
+    dtype = dtype or config.floatx()
     return tfnp.linspace(
         start,
         stop,
@@ -468,6 +474,7 @@ def logical_or(x1, x2):
 
 
 def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
+    dtype = dtype or config.floatx()
     return tfnp.logspace(
         start,
         stop,
@@ -712,7 +719,8 @@ def trace(x, offset=0, axis1=0, axis2=1):
     return tfnp.trace(x, offset=offset, axis1=axis1, axis2=axis2)
 
 
-def tri(N, M=None, k=0, dtype="float32"):
+def tri(N, M=None, k=0, dtype=None):
+    dtype = dtype or config.floatx()
     return tfnp.tri(N, M=M, k=k, dtype=dtype)
 
 
@@ -781,7 +789,8 @@ def sum(x, axis=None, keepdims=False):
     return tfnp.sum(x, axis=axis, keepdims=keepdims)
 
 
-def eye(N, M=None, k=0, dtype="float32"):
+def eye(N, M=None, k=0, dtype=None):
+    dtype = dtype or config.floatx()
     return tfnp.eye(N, M=M, k=k, dtype=dtype)
 
 

--- a/keras_core/backend/torch/numpy.py
+++ b/keras_core/backend/torch/numpy.py
@@ -76,15 +76,15 @@ def max(x, axis=None, keepdims=False, initial=None):
     return result
 
 
-def ones(shape, dtype="float32"):
-    dtype = to_torch_dtype(dtype)
+def ones(shape, dtype=None):
+    dtype = to_torch_dtype(dtype or config.floatx())
     if isinstance(shape, int):
         shape = (shape,)
     return torch.ones(size=shape, dtype=dtype, device=get_device())
 
 
-def zeros(shape, dtype="float32"):
-    dtype = to_torch_dtype(dtype)
+def zeros(shape, dtype=None):
+    dtype = to_torch_dtype(dtype or config.floatx())
     if isinstance(shape, int):
         shape = (shape,)
     return torch.zeros(size=shape, dtype=dtype, device=get_device())
@@ -230,7 +230,8 @@ def argsort(x, axis=-1):
 
 
 def array(x, dtype=None):
-    dtype = to_torch_dtype(dtype)
+    if dtype is not None:
+        dtype = to_torch_dtype(dtype)
     if isinstance(x, torch.Tensor):
         return x
     return torch.tensor(x, dtype=dtype, device=get_device())
@@ -386,8 +387,8 @@ def dot(x, y):
     return torch.matmul(x, y)
 
 
-def empty(shape, dtype="float32"):
-    dtype = to_torch_dtype(dtype)
+def empty(shape, dtype=None):
+    dtype = to_torch_dtype(dtype or config.floatx())
     return torch.empty(size=shape, dtype=dtype, device=get_device())
 
 
@@ -426,7 +427,7 @@ def floor(x):
 
 
 def full(shape, fill_value, dtype=None):
-    dtype = to_torch_dtype(dtype)
+    dtype = to_torch_dtype(dtype or config.floatx())
     fill_value = convert_to_tensor(fill_value, dtype=dtype)
     if len(fill_value.shape) > 0:
         # `torch.full` only supports scala `fill_value`.
@@ -457,8 +458,8 @@ def hstack(xs):
     return torch.hstack(xs)
 
 
-def identity(n, dtype="float32"):
-    dtype = to_torch_dtype(dtype)
+def identity(n, dtype=None):
+    dtype = to_torch_dtype(dtype or config.floatx())
     return torch.eye(n, dtype=dtype)
 
 
@@ -512,7 +513,7 @@ def linspace(
             "torch.linspace does not support an `axis` argument. "
             f"Received axis={axis}"
         )
-    dtype = to_torch_dtype(dtype)
+    dtype = to_torch_dtype(dtype or config.floatx())
     if endpoint is False:
         stop = stop - ((stop - start) / num)
     if hasattr(start, "__len__") and hasattr(stop, "__len__"):
@@ -586,7 +587,7 @@ def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
             "torch.logspace does not support an `axis` argument. "
             f"Received axis={axis}"
         )
-    dtype = to_torch_dtype(dtype)
+    dtype = to_torch_dtype(dtype or config.floatx())
     if endpoint is False:
         stop = stop - ((stop - start) / num)
     if hasattr(start, "__len__") and hasattr(stop, "__len__"):
@@ -738,7 +739,8 @@ def pad(x, pad_width, mode="constant"):
 
 def prod(x, axis=None, keepdims=False, dtype=None):
     x = convert_to_tensor(x)
-    dtype = to_torch_dtype(dtype)
+    if dtype is not None:
+        dtype = to_torch_dtype(dtype)
     if axis is None:
         return torch.prod(x, dtype=dtype)
     if not isinstance(axis, (list, tuple)):
@@ -933,8 +935,8 @@ def trace(x, offset=None, axis1=None, axis2=None):
     return torch.sum(torch.diagonal(x, offset, axis1, axis2), dim=-1)
 
 
-def tri(N, M=None, k=0, dtype="float32"):
-    dtype = to_torch_dtype(dtype)
+def tri(N, M=None, k=0, dtype=None):
+    dtype = to_torch_dtype(dtype or config.floatx())
     M = M or N
     x = torch.ones((N, M), dtype=dtype, device=get_device())
     return torch.tril(x, diagonal=k)
@@ -1037,8 +1039,8 @@ def sum(x, axis=None, keepdims=False):
     return torch.sum(x)
 
 
-def eye(N, M=None, k=None, dtype="float32"):
-    dtype = to_torch_dtype(dtype)
+def eye(N, M=None, k=None, dtype=None):
+    dtype = to_torch_dtype(dtype or config.floatx())
     M = N if M is None else M
     k = 0 if k is None else k
     if k == 0:

--- a/keras_core/layers/rnn/dropout_rnn_cell.py
+++ b/keras_core/layers/rnn/dropout_rnn_cell.py
@@ -23,7 +23,7 @@ class DropoutRNNCell:
         if not hasattr(self, "_dropout_mask"):
             self._dropout_mask = None
         if self._dropout_mask is None and self.dropout > 0:
-            ones = ops.ones_like(step_input)
+            ones = ops.ones_like(step_input, "float32")
             self._dropout_mask = backend.random.dropout(
                 ones, rate=self.dropout, seed=self.seed_generator
             )

--- a/keras_core/layers/rnn/dropout_rnn_cell.py
+++ b/keras_core/layers/rnn/dropout_rnn_cell.py
@@ -23,7 +23,7 @@ class DropoutRNNCell:
         if not hasattr(self, "_dropout_mask"):
             self._dropout_mask = None
         if self._dropout_mask is None and self.dropout > 0:
-            ones = ops.ones_like(step_input, "float32")
+            ones = ops.ones_like(step_input)
             self._dropout_mask = backend.random.dropout(
                 ones, rate=self.dropout, seed=self.seed_generator
             )

--- a/keras_core/layers/rnn/dropout_rnn_cell_test.py
+++ b/keras_core/layers/rnn/dropout_rnn_cell_test.py
@@ -67,19 +67,27 @@ class DropoutRNNCellTest(testing.TestCase):
             run_mixed_precision_check=False,
         )
 
-        # custom mixed_float16 check
-        self.run_layer_test(
-            layers.RNN,
-            init_kwargs={
-                "cell": RNNCellWithDropout(5, seed=1337, dtype="mixed_float16"),
-                "dtype": "mixed_float16",
-            },
-            input_shape=(3, 2, 4),
-            call_kwargs={"training": True},
-            expected_output_shape=(3, 5),
-            expected_num_trainable_weights=2,
-            expected_num_non_trainable_weights=0,
-            expected_num_non_trainable_variables=1,
-            supports_masking=True,
-            run_mixed_precision_check=False,
-        )
+        # Custom mixed_float16 check
+        # Never test mixed precision on torch CPU. Torch lacks support.
+        if backend.backend() == "torch":
+            import torch
+
+            run_mixed_precision_check = torch.cuda.is_available()
+        if run_mixed_precision_check:
+            self.run_layer_test(
+                layers.RNN,
+                init_kwargs={
+                    "cell": RNNCellWithDropout(
+                        5, seed=1337, dtype="mixed_float16"
+                    ),
+                    "dtype": "mixed_float16",
+                },
+                input_shape=(3, 2, 4),
+                call_kwargs={"training": True},
+                expected_output_shape=(3, 5),
+                expected_num_trainable_weights=2,
+                expected_num_non_trainable_weights=0,
+                expected_num_non_trainable_variables=1,
+                supports_masking=True,
+                run_mixed_precision_check=False,
+            )

--- a/keras_core/layers/rnn/dropout_rnn_cell_test.py
+++ b/keras_core/layers/rnn/dropout_rnn_cell_test.py
@@ -69,6 +69,7 @@ class DropoutRNNCellTest(testing.TestCase):
 
         # Custom mixed_float16 check
         # Never test mixed precision on torch CPU. Torch lacks support.
+        run_mixed_precision_check = True
         if backend.backend() == "torch":
             import torch
 

--- a/keras_core/layers/rnn/dropout_rnn_cell_test.py
+++ b/keras_core/layers/rnn/dropout_rnn_cell_test.py
@@ -64,4 +64,22 @@ class DropoutRNNCellTest(testing.TestCase):
             expected_num_non_trainable_weights=0,
             expected_num_non_trainable_variables=1,
             supports_masking=True,
+            run_mixed_precision_check=False,
+        )
+
+        # custom mixed_float16 check
+        self.run_layer_test(
+            layers.RNN,
+            init_kwargs={
+                "cell": RNNCellWithDropout(5, seed=1337, dtype="mixed_float16"),
+                "dtype": "mixed_float16",
+            },
+            input_shape=(3, 2, 4),
+            call_kwargs={"training": True},
+            expected_output_shape=(3, 5),
+            expected_num_trainable_weights=2,
+            expected_num_non_trainable_weights=0,
+            expected_num_non_trainable_variables=1,
+            supports_masking=True,
+            run_mixed_precision_check=False,
         )

--- a/keras_core/ops/numpy.py
+++ b/keras_core/ops/numpy.py
@@ -147,6 +147,7 @@ from keras_core import backend
 from keras_core.api_export import keras_core_export
 from keras_core.backend import KerasTensor
 from keras_core.backend import any_symbolic_tensors
+from keras_core.backend import config
 from keras_core.ops import operation_utils
 from keras_core.ops.operation import Operation
 from keras_core.ops.operation_utils import reduce_shape
@@ -663,6 +664,13 @@ class Arange(Operation):
         if stop is None:
             start, stop = 0, start
         output_shape = [np.ceil((stop - start) / step).astype(int)]
+        if dtype is None:
+            if hasattr(start, "dtype"):
+                dtype = start.dtype
+            elif isinstance(start, int):
+                dtype = "int32"
+            else:
+                dtype = config.floatx()
         return KerasTensor(output_shape, dtype=dtype)
 
 
@@ -2304,20 +2312,22 @@ def einsum(subscripts, *operands):
 
 
 class Empty(Operation):
-    def call(self, shape, dtype="float32"):
+    def call(self, shape, dtype=None):
         return backend.numpy.empty(shape, dtype=dtype)
 
-    def compute_output_spec(self, shape, dtype="float32"):
+    def compute_output_spec(self, shape, dtype=None):
+        dtype = dtype or config.floatx()
         return KerasTensor(shape, dtype=dtype)
 
 
 @keras_core_export(["keras_core.ops.empty", "keras_core.ops.numpy.empty"])
-def empty(shape, dtype="float32"):
+def empty(shape, dtype=None):
     """Return a tensor of given shape and type filled with uninitialized data.
 
     Args:
         shape: Shape of the empty tensor.
-        dtype: Desired data type of the empty tensor.
+        dtype: Desired data type of the empty tensor. If `None`, defaults to
+            `backend.floatx()`.
 
     Returns:
         The empty tensor.
@@ -2506,6 +2516,7 @@ class Full(Operation):
         return backend.numpy.full(shape, fill_value, dtype=dtype)
 
     def compute_output_spec(self, shape, fill_value, dtype=None):
+        dtype or config.floatx()
         return KerasTensor(shape, dtype=dtype)
 
 
@@ -2516,7 +2527,8 @@ def full(shape, fill_value, dtype=None):
     Args:
         shape: Shape of the new tensor.
         fill_value: Fill value.
-        dtype: Desired data type of the tensor.
+        dtype: Desired data type of the tensor. If `None`, defaults to
+            `backend.floatx()`.
 
     Returns:
         Output tensor.
@@ -2732,15 +2744,16 @@ def hstack(xs):
 
 
 class Identity(Operation):
-    def call(self, n, dtype="float32"):
+    def call(self, n, dtype=None):
         return backend.numpy.identity(n, dtype=dtype)
 
-    def compute_output_spec(self, n, dtype="float32"):
+    def compute_output_spec(self, n, dtype=None):
+        dtype = dtype or config.floatx()
         return KerasTensor([n, n], dtype=dtype)
 
 
 @keras_core_export(["keras_core.ops.identity", "keras_core.ops.numpy.identity"])
-def identity(n, dtype="float32"):
+def identity(n, dtype=None):
     """Return the identity tensor.
 
     The identity tensor is a square tensor with ones on the main diagonal and
@@ -2748,7 +2761,8 @@ def identity(n, dtype="float32"):
 
     Args:
         n: Number of rows (and columns) in the `n x n` output tensor.
-        dtype: Data type of the output tensor.
+        dtype: Data type of the output tensor. If `None`, defaults to
+            `backend.floatx()`.
 
     Returns:
         The identity tensor.
@@ -2940,7 +2954,7 @@ def less_equal(x1, x2):
 
 class Linspace(Operation):
     def __init__(
-        self, num=50, endpoint=True, retstep=False, dtype=float, axis=0
+        self, num=50, endpoint=True, retstep=False, dtype=None, axis=0
     ):
         super().__init__()
         self.num = num
@@ -2979,7 +2993,7 @@ class Linspace(Operation):
                 + output_shape[self.axis + 1 :]
             )
 
-        dtype = self.dtype if self.dtype is not None else start.dtype
+        dtype = self.dtype or config.floatx()
         if self.retstep:
             return (KerasTensor(output_shape, dtype=dtype), None)
         return KerasTensor(output_shape, dtype=dtype)
@@ -3008,7 +3022,8 @@ def linspace(
             not included. Defaults to`True`.
         retstep: If `True`, return `(samples, step)`, where `step` is the
             spacing between samples.
-        dtype: The type of the output tensor.
+        dtype: The type of the output tensor. If `None`, defaults to
+            `backend.floatx()`.
         axis: The axis in the result to store the samples. Relevant only if
             start or stop are array-like. Defaults to `0`.
 
@@ -3257,7 +3272,7 @@ def logical_or(x1, x2):
 
 
 class Logspace(Operation):
-    def __init__(self, num=50, endpoint=True, base=10, dtype=float, axis=0):
+    def __init__(self, num=50, endpoint=True, base=10, dtype=None, axis=0):
         super().__init__()
         self.num = num
         self.endpoint = endpoint
@@ -3295,7 +3310,7 @@ class Logspace(Operation):
                 + output_shape[self.axis + 1 :]
             )
 
-        dtype = self.dtype if self.dtype is not None else start.dtype
+        dtype = self.dtype or config.floatx()
         return KerasTensor(output_shape, dtype=dtype)
 
 
@@ -3316,7 +3331,8 @@ def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
         endpoint: If `True`, `stop` is the last sample. Otherwise, it is not
             included. Defaults to`True`.
         base: The base of the log space. Defaults to `10`.
-        dtype: The type of the output tensor.
+        dtype: The type of the output tensor. If `None`, defaults to
+            `backend.floatx()`.
         axis: The axis in the result to store the samples. Relevant only
             if start or stop are array-like.
 
@@ -4888,17 +4904,18 @@ def trace(x, offset=0, axis1=0, axis2=1):
 
 
 class Tri(Operation):
-    def call(self, N, M=None, k=0, dtype="float32"):
+    def call(self, N, M=None, k=0, dtype=None):
         return backend.numpy.tri(N, M=M, k=k, dtype=dtype)
 
-    def compute_output_spec(self, N, M=None, k=0, dtype="float32"):
+    def compute_output_spec(self, N, M=None, k=0, dtype=None):
         if M is None:
             M = N
+        dtype = dtype or config.floatx()
         return KerasTensor((N, M), dtype=dtype)
 
 
 @keras_core_export(["keras_core.ops.tri", "keras_core.ops.numpy.tri"])
-def tri(N, M=None, k=0, dtype="float32"):
+def tri(N, M=None, k=0, dtype=None):
     """Return a tensor with ones at and below a diagonal and zeros elsewhere.
 
     Args:
@@ -4907,7 +4924,8 @@ def tri(N, M=None, k=0, dtype="float32"):
         k: The sub-diagonal at and below which the array is filled.
             `k = 0` is the main diagonal, while `k < 0` is below it, and
             `k > 0` is above. The default is 0.
-        dtype: Data type of the returned tensor. The default is "float32".
+        dtype: Data type of the returned tensor. If `None`, defaults to
+            `backend.floatx()`.
 
     Returns:
         Tensor with its lower triangle filled with ones and zeros elsewhere.
@@ -5492,20 +5510,22 @@ def sum(x, axis=None, keepdims=False):
 
 
 class Zeros(Operation):
-    def call(self, shape, dtype="float32"):
+    def call(self, shape, dtype=None):
         return backend.numpy.zeros(shape, dtype=dtype)
 
-    def compute_output_spec(self, shape, dtype="float32"):
+    def compute_output_spec(self, shape, dtype=None):
+        dtype = dtype or config.floatx()
         return KerasTensor(shape, dtype=dtype)
 
 
 @keras_core_export(["keras_core.ops.zeros", "keras_core.ops.numpy.zeros"])
-def zeros(shape, dtype="float32"):
+def zeros(shape, dtype=None):
     """Return a new tensor of given shape and type, filled with zeros.
 
     Args:
         shape: Shape of the new tensor.
-        dtype: Desired data type of the tensor.
+        dtype: Desired data type of the tensor. If `None`, defaults to
+            `backend.floatx()`.
 
     Returns:
         Tensor of zeros with the given shape and dtype.
@@ -5514,20 +5534,22 @@ def zeros(shape, dtype="float32"):
 
 
 class Ones(Operation):
-    def call(self, shape, dtype="float32"):
+    def call(self, shape, dtype=None):
         return backend.numpy.ones(shape, dtype=dtype)
 
-    def compute_output_spec(self, shape, dtype="float32"):
+    def compute_output_spec(self, shape, dtype=None):
+        dtype = dtype or config.floatx()
         return KerasTensor(shape, dtype=dtype)
 
 
 @keras_core_export(["keras_core.ops.ones", "keras_core.ops.numpy.ones"])
-def ones(shape, dtype="float32"):
+def ones(shape, dtype=None):
     """Return a new tensor of given shape and type, filled with ones.
 
     Args:
         shape: Shape of the new tensor.
-        dtype: Desired data type of the tensor.
+        dtype: Desired data type of the tensor. If `None`, defaults to
+            `backend.floatx()`.
 
     Returns:
         Tensor of ones with the given shape and dtype.
@@ -5536,17 +5558,18 @@ def ones(shape, dtype="float32"):
 
 
 class Eye(Operation):
-    def call(self, N, M=None, k=0, dtype="float32"):
+    def call(self, N, M=None, k=0, dtype=None):
         return backend.numpy.eye(N, M=M, k=k, dtype=dtype)
 
-    def compute_output_spec(self, N, M=None, k=0, dtype="float32"):
+    def compute_output_spec(self, N, M=None, k=0, dtype=None):
         if M is None:
             M = N
+        dtype = dtype or config.floatx()
         return KerasTensor((N, M), dtype=dtype)
 
 
 @keras_core_export(["keras_core.ops.eye", "keras_core.ops.numpy.eye"])
-def eye(N, M=None, k=0, dtype="float32"):
+def eye(N, M=None, k=0, dtype=None):
     """Return a 2-D tensor with ones on the diagonal and zeros elsewhere.
 
     Args:
@@ -5555,7 +5578,8 @@ def eye(N, M=None, k=0, dtype="float32"):
         k: Index of the diagonal: 0 (the default) refers to the main
             diagonal, a positive value refers to an upper diagonal,
             and a negative value to a lower diagonal.
-        dtype: Data type of the returned tensor.
+        dtype: Data type of the returned tensor. If `None`, defaults to
+            `backend.floatx()`.
 
     Returns:
         Tensor with ones on the k-th diagonal and zeros elsewhere.


### PR DESCRIPTION
This PR unifies the default dtype behavior in `ops.numpy.*` and ensures that they respect `backend.floatx()`

A subtle bug has been caught in `dropout_rnn_cell_test.py`:
We should perform a custom mixed precision check because we can't initialize `cell` with `dtype="mixed_float16"` in `self.run_layer_test`.

EDITED:

WIP:
- [x] Add `backend.dtypes` functionality
- [ ] Add unit tests
- [ ] Refactor `ops.numpy`