### PR TITLE
[WIP] Increase-test-coverage for `keras_tensor`  and `variables`+  Fix `__invert__`  + Fix `FloorDivide` 

### DIFF
--- a/keras_core/backend/common/keras_tensor.py
+++ b/keras_core/backend/common/keras_tensor.py
@@ -166,48 +166,24 @@ class KerasTensor:
         return ops.Matmul().symbolic_call(other, self)
 
     def __div__(self, other):
-        print("Inside __div__ method!")
         from keras_core import ops
 
         return ops.Divide().symbolic_call(self, other)
 
     def __rdiv__(self, other):
-        print("Inside __rdiv__ method!")
         from keras_core import ops
 
         return ops.Divide().symbolic_call(other, self)
 
     def __truediv__(self, other):
-        print("Inside __truediv__ method!")
         from keras_core import ops
 
         return ops.TrueDivide().symbolic_call(self, other)
 
     def __rtruediv__(self, other):
-        print("Inside __rtruediv__ method!")
         from keras_core import ops
 
         return ops.TrueDivide().symbolic_call(other, self)
-
-    # def __div__(self, other):
-    #     from keras_core import ops
-
-    #     return ops.Divide().symbolic_call(self, other)
-
-    # def __rdiv__(self, other):
-    #     from keras_core import ops
-
-    #     return ops.Divide().symbolic_call(other, self)
-
-    # def __truediv__(self, other):
-    #     from keras_core import ops
-
-    #     return ops.TrueDivide().symbolic_call(self, other)
-
-    # def __rtruediv__(self, other):
-    #     from keras_core import ops
-
-    #     return ops.TrueDivide().symbolic_call(other, self)
 
     def __neg__(self):
         from keras_core import ops

--- a/keras_core/backend/common/keras_tensor.py
+++ b/keras_core/backend/common/keras_tensor.py
@@ -166,24 +166,48 @@ class KerasTensor:
         return ops.Matmul().symbolic_call(other, self)
 
     def __div__(self, other):
+        print("Inside __div__ method!")
         from keras_core import ops
 
         return ops.Divide().symbolic_call(self, other)
 
     def __rdiv__(self, other):
+        print("Inside __rdiv__ method!")
         from keras_core import ops
 
         return ops.Divide().symbolic_call(other, self)
 
     def __truediv__(self, other):
+        print("Inside __truediv__ method!")
         from keras_core import ops
 
         return ops.TrueDivide().symbolic_call(self, other)
 
     def __rtruediv__(self, other):
+        print("Inside __rtruediv__ method!")
         from keras_core import ops
 
         return ops.TrueDivide().symbolic_call(other, self)
+
+    # def __div__(self, other):
+    #     from keras_core import ops
+
+    #     return ops.Divide().symbolic_call(self, other)
+
+    # def __rdiv__(self, other):
+    #     from keras_core import ops
+
+    #     return ops.Divide().symbolic_call(other, self)
+
+    # def __truediv__(self, other):
+    #     from keras_core import ops
+
+    #     return ops.TrueDivide().symbolic_call(self, other)
+
+    # def __rtruediv__(self, other):
+    #     from keras_core import ops
+
+    #     return ops.TrueDivide().symbolic_call(other, self)
 
     def __neg__(self):
         from keras_core import ops
@@ -208,12 +232,12 @@ class KerasTensor:
     def __floordiv__(self, other):
         from keras_core import ops
 
-        return ops.FloorDiv().symbolic_call(self, other)
+        return ops.FloorDivide().symbolic_call(self, other)
 
     def __rfloordiv__(self, other):
         from keras_core import ops
 
-        return ops.FloorDiv().symbolic_call(other, self)
+        return ops.FloorDivide().symbolic_call(other, self)
 
     def __mod__(self, other):
         from keras_core import ops
@@ -270,10 +294,10 @@ class KerasTensor:
 
         return ops.LogicalOr().symbolic_call(other, self)
 
-    def __invert__(self, other):
+    def __invert__(self):
         from keras_core import ops
 
-        return ops.LogicalNot().symbolic_call(other, self)
+        return ops.LogicalNot().symbolic_call(self)
 
     def __xor__(self, other):
         from keras_core import ops

--- a/keras_core/backend/common/keras_tensor_test.py
+++ b/keras_core/backend/common/keras_tensor_test.py
@@ -369,7 +369,7 @@ class KerasTensorTest(testing.TestCase):
         mock_symbolic_call.return_value = mock_tensor
         x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
         y = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
-        # to ensure compatibility across Python versions
+        # to ensure compatibility across Python versions.
         result = x.__div__(y)
         mock_symbolic_call.assert_called_once_with(x, y)
         self.assertEqual(result, mock_tensor)
@@ -381,7 +381,7 @@ class KerasTensorTest(testing.TestCase):
         mock_symbolic_call.return_value = mock_tensor
         x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
         y = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
-        # to ensure compatibility across Python versions
+        # to ensure compatibility across Python versions.
         result = x.__rdiv__(y)
         mock_symbolic_call.assert_called_once_with(y, x)
         self.assertEqual(result, mock_tensor)

--- a/keras_core/backend/common/keras_tensor_test.py
+++ b/keras_core/backend/common/keras_tensor_test.py
@@ -362,24 +362,26 @@ class KerasTensorTest(testing.TestCase):
         mock_symbolic_call.assert_called_once_with(y, x)
         self.assertEqual(result, mock_tensor)
 
-    # TODO: FAILED Expected 'symbolic_call' to be called once but wasn't
-    # @patch("keras_core.ops.Divide.symbolic_call")
-    # def test_div_method(self, mock_symbolic_call):
-    #     mock_tensor = Mock()
-    #     mock_symbolic_call.return_value = mock_tensor
-    #     x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
-    #     y = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
-    #     result = x / y
-    #     mock_symbolic_call.assert_called_once_with(x, y)
-    #     self.assertEqual(result, mock_tensor)
+    @patch("keras_core.ops.Divide.symbolic_call")
+    def test_div_method(self, mock_symbolic_call):
+        """Test __div__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        # to ensure compatibility across Python versions
+        result = x.__div__(y)
+        mock_symbolic_call.assert_called_once_with(x, y)
+        self.assertEqual(result, mock_tensor)
 
-    # TODO: FAILED Expected 'symbolic_call' to be called once but wasn't
-    # @patch("keras_core.ops.Divide.symbolic_call")
-    # def test_rdiv_method(self, mock_symbolic_call):
-    #     mock_tensor = Mock()
-    #     mock_symbolic_call.return_value = mock_tensor
-    #     x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
-    #     y = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
-    #     result = y / x
-    #     mock_symbolic_call.assert_called_once_with(y, x)
-    #     self.assertEqual(result, mock_tensor)
+    @patch("keras_core.ops.Divide.symbolic_call")
+    def test_rdiv_method(self, mock_symbolic_call):
+        """Test __rdiv__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        # to ensure compatibility across Python versions
+        result = x.__rdiv__(y)
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)

--- a/keras_core/backend/common/keras_tensor_test.py
+++ b/keras_core/backend/common/keras_tensor_test.py
@@ -362,24 +362,24 @@ class KerasTensorTest(testing.TestCase):
         mock_symbolic_call.assert_called_once_with(y, x)
         self.assertEqual(result, mock_tensor)
 
-    # #TODO: FAILED Expected 'symbolic_call' to be called once but wasn't.
+    # TODO: FAILED Expected 'symbolic_call' to be called once but wasn't.
     # @patch("keras_core.ops.Divide.symbolic_call")
     # def test_div_method(self, mock_symbolic_call):
     #     mock_tensor = Mock()
     #     mock_symbolic_call.return_value = mock_tensor
-    #     x = keras_tensor.KerasTensor(shape=(1,), dtype="float32")
-    #     y = keras_tensor.KerasTensor(shape=(1,), dtype="float32")
+    #     x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+    #     y = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
     #     result = x / y
     #     mock_symbolic_call.assert_called_once_with(x, y)
     #     self.assertEqual(result, mock_tensor)
 
-    # #TODO: FAILED Expected 'symbolic_call' to be called once but wasn't.
+    # TODO: FAILED Expected 'symbolic_call' to be called once but wasn't.
     # @patch("keras_core.ops.Divide.symbolic_call")
     # def test_rdiv_method(self, mock_symbolic_call):
     #     mock_tensor = Mock()
     #     mock_symbolic_call.return_value = mock_tensor
-    #     x = keras_tensor.KerasTensor(shape=(1,), dtype="float32")
-    #     y = keras_tensor.KerasTensor(shape=(1,), dtype="float32")
+    #     x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+    #     y = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
     #     result = y / x
     #     mock_symbolic_call.assert_called_once_with(y, x)
     #     self.assertEqual(result, mock_tensor)

--- a/keras_core/backend/common/keras_tensor_test.py
+++ b/keras_core/backend/common/keras_tensor_test.py
@@ -153,3 +153,233 @@ class KerasTensorTest(testing.TestCase):
         result = operator(x, other)
         mock_method.assert_called_once_with(x, other)
         self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.Add.symbolic_call")
+    def test_radd_method(self, mock_symbolic_call):
+        """Test __radd__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = y + x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.Subtract.symbolic_call")
+    def test_rsub_method(self, mock_symbolic_call):
+        """Test __rsub__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = y - x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.Multiply.symbolic_call")
+    def test_rmul_method(self, mock_symbolic_call):
+        """Test __rmul__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = y * x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.Matmul.symbolic_call")
+    def test_rmatmul_method(self, mock_symbolic_call):
+        """Test __rmatmul__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = y @ x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.Power.symbolic_call")
+    def test_rpow_method(self, mock_symbolic_call):
+        """Test __rpow__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = y**x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.FloorDivide.symbolic_call")
+    def test_floordiv_method(self, mock_symbolic_call):
+        """Test __floordiv__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = x // y
+        mock_symbolic_call.assert_called_once_with(x, y)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.FloorDivide.symbolic_call")
+    def test_rfloordiv_method(self, mock_symbolic_call):
+        """Test __rfloordiv__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = y // x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.Mod.symbolic_call")
+    def test_rmod_method(self, mock_symbolic_call):
+        """Test __rmod__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = y % x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.LessEqual.symbolic_call")
+    def test_le_method(self, mock_symbolic_call):
+        """Test __le__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = x <= y
+        mock_symbolic_call.assert_called_once_with(x, y)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.Greater.symbolic_call")
+    def test_gt_method(self, mock_symbolic_call):
+        """Test __gt__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = x > y
+        mock_symbolic_call.assert_called_once_with(x, y)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.GreaterEqual.symbolic_call")
+    def test_ge_method(self, mock_symbolic_call):
+        """Test __ge__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = x >= y
+        mock_symbolic_call.assert_called_once_with(x, y)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.NotEqual.symbolic_call")
+    def test_ne_method(self, mock_symbolic_call):
+        """Test __ne__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = x != y
+        mock_symbolic_call.assert_called_once_with(x, y)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.LogicalAnd.symbolic_call")
+    def test_rand_method(self, mock_symbolic_call):
+        """Test __rand__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="bool")
+        y = Mock()
+        result = y & x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.LogicalOr.symbolic_call")
+    def test_ror_method(self, mock_symbolic_call):
+        """Test __ror__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="bool")
+        y = Mock()
+        result = y | x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.LogicalNot.symbolic_call")
+    def test_invert_method(self, mock_symbolic_call):
+        """Test __invert__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="bool")
+        result = ~x
+        mock_symbolic_call.assert_called_once_with(x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.LogicalXor.symbolic_call")
+    def test_xor_method(self, mock_symbolic_call):
+        """Test __xor__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="bool")
+        y = Mock()
+        result = x ^ y
+        mock_symbolic_call.assert_called_once_with(x, y)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.LogicalXor.symbolic_call")
+    def test_rxor_method(self, mock_symbolic_call):
+        """Test __rxor__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="bool")
+        y = Mock()
+        result = y ^ x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.TrueDivide.symbolic_call")
+    def test_truediv_method(self, mock_symbolic_call):
+        """Test __truediv__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = x / y
+        mock_symbolic_call.assert_called_once_with(x, y)
+        self.assertEqual(result, mock_tensor)
+
+    @patch("keras_core.ops.TrueDivide.symbolic_call")
+    def test_rtruediv_method(self, mock_symbolic_call):
+        """Test __rtruediv__ method"""
+        mock_tensor = Mock()
+        mock_symbolic_call.return_value = mock_tensor
+        x = keras_tensor.KerasTensor(shape=(3, 4), dtype="float32")
+        y = Mock()
+        result = y / x
+        mock_symbolic_call.assert_called_once_with(y, x)
+        self.assertEqual(result, mock_tensor)
+
+    # #TODO: FAILED Expected 'symbolic_call' to be called once but wasn't.
+    # @patch("keras_core.ops.Divide.symbolic_call")
+    # def test_div_method(self, mock_symbolic_call):
+    #     mock_tensor = Mock()
+    #     mock_symbolic_call.return_value = mock_tensor
+    #     x = keras_tensor.KerasTensor(shape=(1,), dtype="float32")
+    #     y = keras_tensor.KerasTensor(shape=(1,), dtype="float32")
+    #     result = x / y
+    #     mock_symbolic_call.assert_called_once_with(x, y)
+    #     self.assertEqual(result, mock_tensor)
+
+    # #TODO: FAILED Expected 'symbolic_call' to be called once but wasn't.
+    # @patch("keras_core.ops.Divide.symbolic_call")
+    # def test_rdiv_method(self, mock_symbolic_call):
+    #     mock_tensor = Mock()
+    #     mock_symbolic_call.return_value = mock_tensor
+    #     x = keras_tensor.KerasTensor(shape=(1,), dtype="float32")
+    #     y = keras_tensor.KerasTensor(shape=(1,), dtype="float32")
+    #     result = y / x
+    #     mock_symbolic_call.assert_called_once_with(y, x)
+    #     self.assertEqual(result, mock_tensor)

--- a/keras_core/backend/common/keras_tensor_test.py
+++ b/keras_core/backend/common/keras_tensor_test.py
@@ -362,7 +362,7 @@ class KerasTensorTest(testing.TestCase):
         mock_symbolic_call.assert_called_once_with(y, x)
         self.assertEqual(result, mock_tensor)
 
-    # TODO: FAILED Expected 'symbolic_call' to be called once but wasn't.
+    # TODO: FAILED Expected 'symbolic_call' to be called once but wasn't
     # @patch("keras_core.ops.Divide.symbolic_call")
     # def test_div_method(self, mock_symbolic_call):
     #     mock_tensor = Mock()
@@ -373,7 +373,7 @@ class KerasTensorTest(testing.TestCase):
     #     mock_symbolic_call.assert_called_once_with(x, y)
     #     self.assertEqual(result, mock_tensor)
 
-    # TODO: FAILED Expected 'symbolic_call' to be called once but wasn't.
+    # TODO: FAILED Expected 'symbolic_call' to be called once but wasn't
     # @patch("keras_core.ops.Divide.symbolic_call")
     # def test_rdiv_method(self, mock_symbolic_call):
     #     mock_tensor = Mock()

--- a/keras_core/backend/common/variables_test.py
+++ b/keras_core/backend/common/variables_test.py
@@ -6,6 +6,7 @@ from keras_core.backend.common.variables import AutocastScope
 from keras_core.backend.common.variables import KerasVariable
 from keras_core.backend.common.variables import standardize_shape
 from keras_core.testing import test_case
+from keras_core.ops.core import convert_to_tensor
 
 
 class VariablesTest(test_case.TestCase):
@@ -125,3 +126,224 @@ class VariablesTest(test_case.TestCase):
             "`AutocastScope` can only be used with a floating-point",
         ):
             _ = AutocastScope("int32")
+
+    def test_variable_initialization_with_non_callable(self):
+        v = backend.Variable(initializer=np.ones((2, 2)))
+        self.assertAllClose(v.value, np.ones((2, 2)))
+
+    def test_variable_path_creation(self):
+        v = backend.Variable(initializer=np.ones((2, 2)), name="test_var")
+        self.assertEqual(v.path, "test_var")
+
+    def test_variable_initialization_with_non_trainable(self):
+        v = backend.Variable(initializer=np.ones((2, 2)), trainable=False)
+        self.assertFalse(v.trainable)
+
+    def test_variable_initialization_with_dtype(self):
+        v = backend.Variable(initializer=np.ones((2, 2)), dtype="int32")
+        self.assertEqual(v.dtype, "int32")
+        self.assertEqual(backend.standardize_dtype(v.value.dtype), "int32")
+
+    def test_variable_initialization_without_shape(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "When creating a Variable from an initializer, the `shape` ",
+        ):
+            backend.Variable(initializer=initializers.RandomNormal())
+
+    def test_deferred_initialize_already_initialized(self):
+        v = backend.Variable(initializer=np.ones((2, 2)))
+        with self.assertRaisesRegex(
+            ValueError, f"Variable {v.path} is already initialized."
+        ):
+            v._deferred_initialize()
+
+    def test_deferred_initialize_within_stateless_scope(self):
+        with backend.StatelessScope():
+            v = backend.Variable(
+                initializer=initializers.RandomNormal(), shape=(2, 2)
+            )
+            with self.assertRaisesRegex(
+                ValueError,
+                "You are attempting to initialize a variable "
+                "while in a stateless scope. This is disallowed.",
+            ):
+                v._deferred_initialize()
+
+    def test_variable_as_boolean(self):
+        v = backend.Variable(initializer=np.ones((2, 2)))
+        with self.assertRaises(TypeError):
+            bool(v)
+
+    def test_variable_negation(self):
+        v = backend.Variable(initializer=np.array([-1, 2]))
+        neg_v = -v
+        self.assertAllClose(neg_v, np.array([1, -2]))
+
+    def test_variable_pos(self):
+        v = backend.Variable(initializer=np.array([-1, 2]))
+        pos_v = v
+        self.assertAllClose(pos_v, np.array([-1, 2]))
+
+    def test_variable_abs(self):
+        v = backend.Variable(initializer=np.array([-1, 2]))
+        abs_v = abs(v)
+        self.assertAllClose(abs_v, np.array([1, 2]))
+
+    def test_variable_invert(self):
+        v = backend.Variable(initializer=np.array([0, -1]), dtype="int32")
+        inv_v = ~v
+        self.assertAllClose(inv_v, np.array([-1, 0]))
+
+    def test_variable_lt_tensor(self):
+        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
+        v2 = backend.Variable(initializer=np.array([1, 3, 2]))
+
+        lt_result = v1 < v2
+        self.assertAllClose(lt_result.numpy(), np.array([False, True, False]))
+
+    def test_variable_lt_scalar(self):
+        v = backend.Variable(initializer=np.array([1, 2, 3]))
+
+        lt_result = v < 3
+        self.assertAllClose(lt_result.numpy(), np.array([True, True, False]))
+
+    def test_variable_lt_numpy_array(self):
+        v = backend.Variable(initializer=np.array([1, 2, 3]))
+        arr = np.array([2, 2, 2])
+
+        lt_result = v < arr
+        self.assertAllClose(lt_result.numpy(), np.array([True, False, False]))
+
+    def test_variable_ge_tensor(self):
+        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
+        v2 = backend.Variable(initializer=np.array([1, 3, 2]))
+
+        ge_result = v1 >= v2
+        self.assertAllClose(ge_result.numpy(), np.array([True, False, True]))
+
+    def test_variable_ge_scalar(self):
+        v = backend.Variable(initializer=np.array([1, 2, 3]))
+
+        ge_result = v >= 2
+        self.assertAllClose(ge_result.numpy(), np.array([False, True, True]))
+
+    def test_variable_ge_numpy_array(self):
+        v = backend.Variable(initializer=np.array([1, 2, 3]))
+        arr = np.array([2, 2, 2])
+
+        ge_result = v >= arr
+        self.assertAllClose(ge_result.numpy(), np.array([False, True, True]))
+
+    def test_variable_rsub_scalar(self):
+        v = backend.Variable(initializer=np.array([1, 2, 3]))
+
+        rsub_result = 2 - v
+        self.assertAllClose(rsub_result.numpy(), np.array([1, 0, -1]))
+
+    def test_variable_div_scalar(self):
+        v = backend.Variable(initializer=np.array([2, 4, 8]))
+
+        div_result = v / 2
+        self.assertAllClose(div_result.numpy(), np.array([1, 2, 4]))
+
+    def test_variable_rdiv_scalar(self):
+        v = backend.Variable(initializer=np.array([2, 4, 8]))
+
+        rdiv_result = 16 / v
+        self.assertAllClose(rdiv_result.numpy(), np.array([8, 4, 2]))
+
+    def test_variable_div_numpy_array(self):
+        v = backend.Variable(initializer=np.array([2, 4, 8]))
+        arr = np.array([2, 8, 16])
+
+        div_result = arr / v
+        self.assertAllClose(div_result, np.array([1, 2, 2]))
+
+    def test_variable_rdiv_numpy_array(self):
+        v = backend.Variable(initializer=np.array([2, 4, 8]))
+        arr = np.array([16, 32, 64])
+
+        rdiv_result = arr / v
+        self.assertAllClose(rdiv_result, np.array([8, 8, 8]))
+
+    def test_variable_rsub_numpy_array(self):
+        v = backend.Variable(initializer=np.array([1, 2, 3]))
+        arr = np.array([2, 2, 2])
+
+        rsub_result = arr - v
+        self.assertAllClose(rsub_result, np.array([1, 0, -1]))
+
+    def test_variable_rtruediv(self):
+        v = backend.Variable(initializer=np.array([2, 4, 8]))
+        result = 16 / v
+        self.assertAllClose(result.numpy(), np.array([8, 4, 2]))
+
+    def test_variable_floordiv(self):
+        v = backend.Variable(initializer=np.array([3, 4, 6]))
+        result = v // np.array([2, 3, 6])
+        self.assertAllClose(result.numpy(), np.array([1, 1, 1]))
+
+    def test_variable_rfloordiv(self):
+        v = backend.Variable(initializer=np.array([3, 4, 6]))
+        result = np.array([9, 12, 18]) // v
+        self.assertAllClose(result.numpy(), np.array([3, 3, 3]))
+
+    def test_variable_rfloordiv(self):
+        v = backend.Variable(initializer=np.array([3, 4, 6]))
+        result = np.array([9, 12, 18]) // v
+        self.assertAllClose(result, np.array([3, 3, 3]))
+
+    def test_variable_mod_scalar(self):
+        v = backend.Variable(initializer=np.array([2, 4, 8]))
+        mod_result = v % 3
+        self.assertAllClose(mod_result.numpy(), np.array([2, 1, 2]))
+
+    def test_variable_rmod_scalar(self):
+        v = backend.Variable(initializer=np.array([3, 5, 7]))
+        rmod_result = 10 % v
+        self.assertAllClose(rmod_result.numpy(), np.array([1, 0, 3]))
+
+    def test_variable_pow_scalar(self):
+        v = backend.Variable(initializer=np.array([2, 3, 4]))
+        pow_result = v**2
+        self.assertAllClose(pow_result.numpy(), np.array([4, 9, 16]))
+
+    def test_variable_rpow_scalar(self):
+        v = backend.Variable(initializer=np.array([2, 3, 4]))
+        rpow_result = 3**v
+        self.assertAllClose(rpow_result.numpy(), np.array([9, 27, 81]))
+
+    def test_variable_matmul(self):
+        v = backend.Variable(initializer=np.array([[2, 3], [4, 5]]))
+        other = np.array([[1, 2], [3, 4]])
+        matmul_result = v @ other
+        self.assertAllClose(
+            matmul_result.numpy(), np.array([[11, 16], [19, 28]])
+        )
+
+    def test_variable_rmatmul(self):
+        v = backend.Variable(initializer=np.array([[2, 3], [4, 5]]))
+        other = np.array([[1, 2], [3, 4]])
+        rmatmul_result = other @ v
+        self.assertAllClose(rmatmul_result, np.array([[10, 13], [22, 29]]))
+
+    def test_variable_and(self):
+        v = backend.Variable(
+            initializer=np.array([1, 0, 1, 0], dtype=np.int32), dtype="int32"
+        )
+        other_tensor = convert_to_tensor(
+            np.array([1, 1, 0, 1], dtype=np.int32), dtype="int32"
+        )
+        and_result = v & other_tensor
+        self.assertAllClose(and_result.numpy(), np.array([1, 0, 0, 0]))
+
+    def test_variable_rand(self):
+        v = backend.Variable(
+            initializer=np.array([1, 0, 1, 0], dtype=np.int32), dtype="int32"
+        )
+        other_tensor = convert_to_tensor(
+            np.array([1, 1, 0, 1], dtype=np.int32), dtype="int32"
+        )
+        rand_result = other_tensor & v
+        self.assertAllClose(rand_result.numpy(), np.array([1, 0, 0, 0]))

--- a/keras_core/backend/common/variables_test.py
+++ b/keras_core/backend/common/variables_test.py
@@ -195,63 +195,12 @@ class VariablesTest(test_case.TestCase):
         inv_v = ~v
         self.assertAllClose(inv_v, np.array([-1, 0]))
 
-    def test_variable_lt_tensor(self):
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([1, 3, 2]))
-
-        lt_result = v1 < v2
-        self.assertAllClose(lt_result.numpy(), np.array([False, True, False]))
-
-    def test_variable_lt_scalar(self):
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-
-        lt_result = v < 3
-        self.assertAllClose(lt_result.numpy(), np.array([True, True, False]))
-
     def test_variable_lt_numpy_array(self):
         v = backend.Variable(initializer=np.array([1, 2, 3]))
         arr = np.array([2, 2, 2])
 
         lt_result = v < arr
         self.assertAllClose(lt_result.numpy(), np.array([True, False, False]))
-
-    def test_variable_ge_tensor(self):
-        v1 = backend.Variable(initializer=np.array([1, 2, 3]))
-        v2 = backend.Variable(initializer=np.array([1, 3, 2]))
-
-        ge_result = v1 >= v2
-        self.assertAllClose(ge_result.numpy(), np.array([True, False, True]))
-
-    def test_variable_ge_scalar(self):
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-
-        ge_result = v >= 2
-        self.assertAllClose(ge_result.numpy(), np.array([False, True, True]))
-
-    def test_variable_ge_numpy_array(self):
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-        arr = np.array([2, 2, 2])
-
-        ge_result = v >= arr
-        self.assertAllClose(ge_result.numpy(), np.array([False, True, True]))
-
-    def test_variable_rsub_scalar(self):
-        v = backend.Variable(initializer=np.array([1, 2, 3]))
-
-        rsub_result = 2 - v
-        self.assertAllClose(rsub_result.numpy(), np.array([1, 0, -1]))
-
-    def test_variable_div_scalar(self):
-        v = backend.Variable(initializer=np.array([2, 4, 8]))
-
-        div_result = v / 2
-        self.assertAllClose(div_result.numpy(), np.array([1, 2, 4]))
-
-    def test_variable_rdiv_scalar(self):
-        v = backend.Variable(initializer=np.array([2, 4, 8]))
-
-        rdiv_result = 16 / v
-        self.assertAllClose(rdiv_result.numpy(), np.array([8, 4, 2]))
 
     def test_variable_div_numpy_array(self):
         v = backend.Variable(initializer=np.array([2, 4, 8]))
@@ -274,16 +223,6 @@ class VariablesTest(test_case.TestCase):
         rsub_result = arr - v
         self.assertAllClose(rsub_result, np.array([1, 0, -1]))
 
-    def test_variable_rtruediv(self):
-        v = backend.Variable(initializer=np.array([2, 4, 8]))
-        result = 16 / v
-        self.assertAllClose(result.numpy(), np.array([8, 4, 2]))
-
-    def test_variable_floordiv(self):
-        v = backend.Variable(initializer=np.array([3, 4, 6]))
-        result = v // np.array([2, 3, 6])
-        self.assertAllClose(result.numpy(), np.array([1, 1, 1]))
-
     def test_variable_rfloordiv(self):
         v = backend.Variable(initializer=np.array([3, 4, 6]))
         result = np.array([9, 12, 18]) // v
@@ -294,56 +233,8 @@ class VariablesTest(test_case.TestCase):
         result = np.array([9, 12, 18]) // v
         self.assertAllClose(result, np.array([3, 3, 3]))
 
-    def test_variable_mod_scalar(self):
-        v = backend.Variable(initializer=np.array([2, 4, 8]))
-        mod_result = v % 3
-        self.assertAllClose(mod_result.numpy(), np.array([2, 1, 2]))
-
-    def test_variable_rmod_scalar(self):
-        v = backend.Variable(initializer=np.array([3, 5, 7]))
-        rmod_result = 10 % v
-        self.assertAllClose(rmod_result.numpy(), np.array([1, 0, 3]))
-
-    def test_variable_pow_scalar(self):
-        v = backend.Variable(initializer=np.array([2, 3, 4]))
-        pow_result = v**2
-        self.assertAllClose(pow_result.numpy(), np.array([4, 9, 16]))
-
-    def test_variable_rpow_scalar(self):
-        v = backend.Variable(initializer=np.array([2, 3, 4]))
-        rpow_result = 3**v
-        self.assertAllClose(rpow_result.numpy(), np.array([9, 27, 81]))
-
-    def test_variable_matmul(self):
-        v = backend.Variable(initializer=np.array([[2, 3], [4, 5]]))
-        other = np.array([[1, 2], [3, 4]])
-        matmul_result = v @ other
-        self.assertAllClose(
-            matmul_result.numpy(), np.array([[11, 16], [19, 28]])
-        )
-
     def test_variable_rmatmul(self):
         v = backend.Variable(initializer=np.array([[2, 3], [4, 5]]))
         other = np.array([[1, 2], [3, 4]])
         rmatmul_result = other @ v
         self.assertAllClose(rmatmul_result, np.array([[10, 13], [22, 29]]))
-
-    def test_variable_and(self):
-        v = backend.Variable(
-            initializer=np.array([1, 0, 1, 0], dtype=np.int32), dtype="int32"
-        )
-        other_tensor = convert_to_tensor(
-            np.array([1, 1, 0, 1], dtype=np.int32), dtype="int32"
-        )
-        and_result = v & other_tensor
-        self.assertAllClose(and_result.numpy(), np.array([1, 0, 0, 0]))
-
-    def test_variable_rand(self):
-        v = backend.Variable(
-            initializer=np.array([1, 0, 1, 0], dtype=np.int32), dtype="int32"
-        )
-        other_tensor = convert_to_tensor(
-            np.array([1, 1, 0, 1], dtype=np.int32), dtype="int32"
-        )
-        rand_result = other_tensor & v
-        self.assertAllClose(rand_result.numpy(), np.array([1, 0, 0, 0]))


### PR DESCRIPTION
Increase-test-coverage for keras_tensor + Fix `__invert__` method and update `FloorDiv` references in `keras_tensor.py`


1. Fixes a `TypeError` encountered when using the unary bitwise inversion (`~`) on a `KerasTensor` object. The `__invert__` method had an incorrect signature, accepting an unnecessary `other` parameter.
2. Updates references from `FloorDiv` to `FloorDivide` to align with the correct operation name.

**Changes:**
1. Modified the `__invert__` method in `keras_tensor.py` to remove the `other` parameter and correctly call the `LogicalNot` operation:

2. Updated all occurrences of `FloorDiv` to `FloorDivide` in `keras_tensor.py` to ensure correct behavior.
